### PR TITLE
ci: add dev task for testing build + cacert

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize]
+
+jobs:
+  title_check:
+    runs-on: ubuntu-latest
+    name: Test Docker Build
+    permissions:
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install commitlint
+        run: uds run dev-build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,12 @@ name: Test
 on:
   pull_request:
     branches: [main]
-    types: [opened, edited, synchronize]
+    types: [milestoned, opened, reopened, synchronize]
+
+# Abort prior jobs in the same workflow / PR
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   title_check:
@@ -16,6 +21,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Environment setup
+        uses: defenseunicorns/uds-common/.github/actions/setup@417b9c2bc088f664c616c9929a2b3ce448d251f7
 
       - name: Test building the docker image
         run: uds run dev-build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,5 +17,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Install commitlint
+      - name: Test building the docker image
         run: uds run dev-build

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ build/
 *.tar.zst
 zarf-sbom
 tmp/
-
+cacert.b64

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## UDS Identity Config
+# UDS Identity Config
 
-This repo builds the UDS Identity (keycloak) 0.1.0s used by UDS Identity. In this repo you'll find the following 0.1.0s:
+This repo builds the UDS Identity (keycloak) Config image used by UDS Identity. In this repo you'll find the following:
 
 - `src/extra-jars` - Place any extra jars here to be added to the Keycloak server
 - `src/Dockerfile` - The Dockerfile used to build the image, `CA_ZIP_URL` and `CA_REGEX_EXCLUSION_FILTER` builds args control the Trust Store
@@ -8,3 +8,5 @@ This repo builds the UDS Identity (keycloak) 0.1.0s used by UDS Identity. In thi
 - `src/theme` - A custom Keycloak theme for the login, registration, and account management pages
 - `src/truststore` - A script to pull CA certs into a truststore, using the docker build ARGs for `CA_ZIP_URL` (remote URL to a zip file with CA certs) and `CA_REGEX_EXCLUSION_FILTER` (regex for certs to exclude)
 - `src/realm.json` - The UDS Identity realm configuration used by Keycloak on startup (if the realm doesn't exist)
+
+Also included are a number of UDS tasks under `tasks.yaml`. Each task can be viewed with its name and description using `uds run --list`.

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -10,6 +10,7 @@ variables:
 
 tasks:
   - name: build-and-publish
+    description: "Build and publish the multi-arch image"
     actions:
       - cmd: docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ${IMAGE_NAME}:${VERSION} src
 
@@ -19,6 +20,7 @@ tasks:
       - cmd: docker build src -t uds-core-config:keycloak
 
   - name: dev-update-image
+    description: "Build the image and import locally into k3d"
     actions:
       - task: dev-build
       - cmd: |
@@ -26,27 +28,29 @@ tasks:
           kubectl rollout restart statefulset -n keycloak keycloak
 
   - name: dev-theme
+    description: "Copy theme to Keycloak in dev cluster"
     actions:
-      - description: "Copy theme to Keycloak (must be run from src/keycloak dir)"
-        cmd: |
+      - cmd: |
           PV=$(kubectl get pvc keycloak-themes -n keycloak -o jsonpath='{.spec.volumeName}')
           THEME_PATH=$(kubectl get pv $PV -o jsonpath="{.spec.hostPath.path}")
           docker cp src/theme k3d-uds-server-0:/$THEME_PATH
 
   - name: cacert
+    description: "Get the CA cert value for the Istio Gateway"
     actions:
       # This is written to a file rather than printed because it is a massive value to copy out of the terminal
-      - description: "Get the CA cert value for the Istio Gateway"
-        cmd: |
+      - cmd: |
           docker run --rm --entrypoint sh ${IMAGE_NAME}:${VERSION} -c "cat /home/nonroot/authorized_certs.pem | base64 -w 0" > cacert.b64
           echo "Base64 encoded CA Cert value is in cacert.b64, this can be passed to your Istio tenant gateway for Keycloak OPTIONAL_MUTUAL"
 
   - name: debug-istio-traffic
+    description: "Debug Istio traffic on keycloak"
     actions:
       - cmd: istioctl proxy-config log keycloak-0.keycloak --level debug
       - cmd: kubectl -n keycloak logs keycloak-0 -c istio-proxy -f
 
   - name: regenerate-test-pki
+    description: "Generate a PKI cert for testing"
     actions:
       - cmd: |
           openssl genrsa -out test.pem 2048

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -4,17 +4,24 @@ variables:
     # x-release-please-start-version
     default: "0.3.0"
     # x-release-please-end
+  - name: IMAGE_NAME
+    description: "The repository + name for the published image"
+    default: "ghcr.io/defenseunicorns/uds/identity-config"
 
 tasks:
   - name: build-and-publish
     actions:
-      - cmd: |
-          docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/defenseunicorns/uds/identity-config:${VERSION} src
+      - cmd: docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ${IMAGE_NAME}:${VERSION} src
+
+  - name: dev-build
+    description: "Build the image locally for dev"
+    actions:
+      - cmd: docker build src -t uds-core-config:keycloak
 
   - name: dev-update-image
     actions:
+      - task: dev-build
       - cmd: |
-          docker build src -t uds-core-config:keycloak
           k3d image import -c uds uds-core-config:keycloak
           kubectl rollout restart statefulset -n keycloak keycloak
 
@@ -25,6 +32,14 @@ tasks:
           PV=$(kubectl get pvc keycloak-themes -n keycloak -o jsonpath='{.spec.volumeName}')
           THEME_PATH=$(kubectl get pv $PV -o jsonpath="{.spec.hostPath.path}")
           docker cp src/theme k3d-uds-server-0:/$THEME_PATH
+
+  - name: cacert
+    actions:
+      # This is written to a file rather than printed because it is a massive value to copy out of the terminal
+      - description: "Get the CA cert value for the Istio Gateway"
+        cmd: |
+          docker run --rm --entrypoint sh ${IMAGE_NAME}:${VERSION} -c "cat /home/nonroot/authorized_certs.pem | base64 -w 0" > cacert.b64
+          echo "Base64 encoded CA Cert value is in cacert.b64, this can be passed to your Istio tenant gateway for Keycloak OPTIONAL_MUTUAL"
 
   - name: debug-istio-traffic
     actions:


### PR DESCRIPTION
## Description

Adds a docker build task for basic local dev/CI validation.

Also adds a `cacert` task that runs the image and gets the cacert in base64 encoded format for use in the istio gateway.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed