### PR TITLE
chore: cleanup misc baby-yoda references

### DIFF
--- a/src/theme/login/register.ftl
+++ b/src/theme/login/register.ftl
@@ -2,7 +2,7 @@
     <@layout.registrationLayout displayMessage=!messagesPerField.existsError('firstName','lastName','email','username','password','password-confirm'); section>
         <#if section="form">
             <form action="/chuck-norris-calendar-goes-straight-from-march-31st-to-april-2nd-because-no-one-fools-chuck-norris"
-                id="baby-yoda-form" method="post">
+                id="unicorn-registration-form" method="post">
                 <#if cacIdentity??>
                     <div class="alert alert-info cac-info">
                         <h2>DoD PKI User Registration</h2>
@@ -267,7 +267,7 @@
             confidence.innerText = Math.round((count / threshold) * 100);
             if (count > threshold) {
                 complete = true;
-                const form = document.getElementById('baby-yoda-form');
+                const form = document.getElementById('kc-form');
                 const register = document.getElementById('do-register');
                 const location = document.getElementById('user.attributes.location');
                 location.value = '42';

--- a/src/theme/login/resources/css/new-ui.css
+++ b/src/theme/login/resources/css/new-ui.css
@@ -1,21 +1,3 @@
-#custom-header {
-  align-items: center;
-  background: url(../img/p1-logo.png) no-repeat;
-  background-position-x: 20px;
-  background-size: contain;
-  font-size: 32px;
-  height: 200px;
-  justify-content: center;
-  letter-spacing: 3px;
-  line-height: 1.45em;
-  margin: 50px auto;
-  max-width: 500px;
-  padding-left: 229px;
-  text-align: left;
-  text-shadow: 2px 4px 3px rgba(0, 0, 0, 0.8);
-  white-space: normal;
-}
-
 .alert.alert-error {
   background: rgba(227, 79, 79, 0.1);
   border-radius: 7px;
@@ -40,16 +22,6 @@
   box-shadow:
     0 14px 28px rgba(0, 0, 0, 0.95),
     0 10px 10px rgba(0, 0, 0, 0.92);
-}
-
-.navbar .navbar-title {
-  background-image: url(../img/p1-logo-alt.png);
-  background-repeat: no-repeat;
-  background-size: contain;
-  font-size: 0;
-  height: 100px;
-  margin: 0;
-  width: 100%;
 }
 
 .navbar .nav-item > a {
@@ -191,25 +163,6 @@ ul#kc-totp-supported-apps {
   font-weight: 500;
   letter-spacing: 0.1rem;
   text-shadow: 2px 4px 3px rgba(0, 0, 0, 0.1);
-}
-
-#baby-yoda-logo {
-  align-items: center;
-  background: url(../img/p1-logo.png) no-repeat;
-  background-position-x: 20px;
-  background-size: contain;
-  display: flex;
-  font-size: 32px;
-  height: 200px;
-  justify-content: center;
-  letter-spacing: 3px;
-  line-height: 1.45em;
-  margin: 50px auto;
-  max-width: 500px;
-  padding-left: 229px;
-  text-align: left;
-  text-shadow: 2px 4px 3px rgba(0, 0, 0, 0.8);
-  white-space: normal;
 }
 
 .app-logo {

--- a/src/theme/login/template.ftl
+++ b/src/theme/login/template.ftl
@@ -91,9 +91,7 @@ ${message.type}
             </div>
             </div>
             <footer class="fixed-footer">
-                <#-- <img src="${url.resourcesPath}/img/yoda-mission-obsessed.png" /> -->
                 <img src="${url.resourcesPath}/img/full-du-logo.png" />
-                <#-- Powered by DoD Platform One -->
             </footer>
             </body>
 


### PR DESCRIPTION
## Description
While digging through some of the theme stuff, noticed there was still some extraneous references to p1 images and baby-yoda usecases. Removed those where necessary.

All changes i believe were copy and pasted from the existing idam-keycloak repo which was still still uilizing the baby-yoda realm and p1 theme by default. Cleanup to remove any confusion.

Tested locally by deploying uds-core and changing theme. Then registering a new user and logging in with user. In my testing the removal of css seemed to have no effect and searching through compiled css, there was no results for those css rules.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed