### PR TITLE
fix: expose environment variables

### DIFF
--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -76,7 +76,7 @@ See the [Testing custom image in UDS Core](./CUSTOMIZE.md#testing-custom-image-i
 > Keycloak supports using environment variables within the realm configuration, see [docs](https://www.keycloak.org/server/importExport).
 >
 > These environment variables have default values set in the realm.json that uses the following syntax:
-> ```json
+> ```
 >  ${REALM_GOOGLE_IDP_ENABLED:false}
 > ```
 > 

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -94,6 +94,9 @@ See the [Testing custom image in UDS Core](./CUSTOMIZE.md#testing-custom-image-i
 >                  GOOGLE_IDP_CORE_ENTITY_ID: <fill in value here>
 >                  GOOGLE_IDP_ADMIN_GROUP: <fill in value here>
 >                  GOOGLE_IDP_AUDITOR_GROUP: <fill in value here>
+>                  EMAIL_VERIFICATION_ENABLED: <fill in value here>
+>                  OTP_ENABLED: <fill in value here>
+>                  TERMS_AND_CONDITIONS_ENABLED: <fill in value here>
 >
 >   These environment variables can be found in the [realm.json](../src/realm.json) `identityProviders` section.
 

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -79,7 +79,7 @@ See the [Testing custom image in UDS Core](./CUSTOMIZE.md#testing-custom-image-i
 > 
 > These environment variables will be created with a prefix `REALM_` to avoid collisions with keycloak environment variables. If necessary to add additional template variables within the realm.json must be prefixed with `REALM_`. 
 > 
-> For example, this bundle override would set the necessary configuration for a google idp to be enabled:
+> For example, this bundle override contains all the available overrides:
 >
 >     overrides:
 >      keycloak:
@@ -97,6 +97,7 @@ See the [Testing custom image in UDS Core](./CUSTOMIZE.md#testing-custom-image-i
 >                  EMAIL_VERIFICATION_ENABLED: <fill in value here>
 >                  OTP_ENABLED: <fill in value here>
 >                  TERMS_AND_CONDITIONS_ENABLED: <fill in value here>
+>                  PASSWORD_POLICY: <fill in value here>
 >
 >   These environment variables can be found in the [realm.json](../src/realm.json) `identityProviders` section.
 

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -98,6 +98,7 @@ See the [Testing custom image in UDS Core](./CUSTOMIZE.md#testing-custom-image-i
 >                  OTP_ENABLED: <fill in value here>
 >                  TERMS_AND_CONDITIONS_ENABLED: <fill in value here>
 >                  PASSWORD_POLICY: <fill in value here>
+>                  X509_OCSP_FAIL_OPEN: <fill in value here>
 >
 >   These environment variables can be found in the [realm.json](../src/realm.json) `identityProviders` section.
 

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -74,8 +74,13 @@ See the [Testing custom image in UDS Core](./CUSTOMIZE.md#testing-custom-image-i
 
 ### Templated Realm Values
 > Keycloak supports using environment variables within the realm configuration, see [docs](https://www.keycloak.org/server/importExport).
+>
+> These environment variables have default values set in the realm.json that uses the following syntax:
+> ```json
+>  ${REALM_GOOGLE_IDP_ENABLED:false}
+> ```
 > 
-> In the uds-core keycloak [values.yaml](https://github.com/defenseunicorns/uds-core/blob/main/src/keycloak/chart/values.yaml), the `realmInitEnv` defines set of environment variables that can be used to configure the realm.
+> In the uds-core keycloak [values.yaml](https://github.com/defenseunicorns/uds-core/blob/main/src/keycloak/chart/values.yaml), the `realmInitEnv` defines set of environment variables that can be used to configure the realm different from default values.
 > 
 > These environment variables will be created with a prefix `REALM_` to avoid collisions with keycloak environment variables. If necessary to add additional template variables within the realm.json must be prefixed with `REALM_`. 
 > 
@@ -94,11 +99,11 @@ See the [Testing custom image in UDS Core](./CUSTOMIZE.md#testing-custom-image-i
 >                  GOOGLE_IDP_CORE_ENTITY_ID: <fill in value here>
 >                  GOOGLE_IDP_ADMIN_GROUP: <fill in value here>
 >                  GOOGLE_IDP_AUDITOR_GROUP: <fill in value here>
->                  EMAIL_VERIFICATION_ENABLED: <fill in value here>
->                  OTP_ENABLED: <fill in value here>
->                  TERMS_AND_CONDITIONS_ENABLED: <fill in value here>
+>                  EMAIL_VERIFICATION_ENABLED: true
+>                  OTP_ENABLED: true
+>                  TERMS_AND_CONDITIONS_ENABLED: true
 >                  PASSWORD_POLICY: <fill in value here>
->                  X509_OCSP_FAIL_OPEN: <fill in value here>
+>                  X509_OCSP_FAIL_OPEN: true
 >
 >   These environment variables can be found in the [realm.json](../src/realm.json) `identityProviders` section.
 

--- a/src/realm.json
+++ b/src/realm.json
@@ -438,7 +438,7 @@
     "requiredCredentials": [
         "password"
     ],
-    "passwordPolicy": "${REALM_PASSWORD_POLICY}:hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)",
+    "passwordPolicy": "${REALM_PASSWORD_POLICY:hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)}",
     "otpPolicyType": "totp",
     "otpPolicyAlgorithm": "HmacSHA1",
     "otpPolicyInitialCounter": 0,

--- a/src/realm.json
+++ b/src/realm.json
@@ -438,7 +438,7 @@
     "requiredCredentials": [
         "password"
     ],
-    "passwordPolicy": "${REALM_PASSWORD_POLICY}",
+    "passwordPolicy": "${REALM_PASSWORD_POLICY}:hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)",
     "otpPolicyType": "totp",
     "otpPolicyAlgorithm": "HmacSHA1",
     "otpPolicyInitialCounter": 0,
@@ -1716,7 +1716,7 @@
           "displayName": "Google SSO",
           "internalId": "1538a301-8427-46d2-b59f-203f2f76e573",
           "providerId": "saml",
-          "enabled": "${REALM_GOOGLE_IDP_ENABLED}",
+          "enabled": "${REALM_GOOGLE_IDP_ENABLED:false}",
           "updateProfileFirstLoginMode": "on",
           "trustEmail": true,
           "storeToken": false,
@@ -2775,7 +2775,7 @@
                 "x509-cert-auth.canonical-dn-enabled": "false",
                 "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
                 "x509-cert-auth.serialnumber-hex-enabled": "false",
-                "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
+                "x509-cert-auth.ocsp-fail-open": "${REALM_X509_OCSP_FAIL_OPEN:false}",
                 "x509-cert-auth.regular-expression": "(.*?)(?:$)",
                 "x509-cert-auth.certificate-policy-mode": "All",
                 "x509-cert-auth.timestamp-validation-enabled": "true",
@@ -2804,7 +2804,7 @@
             "alias": "TERMS_AND_CONDITIONS",
             "name": "Terms and Conditions",
             "providerId": "TERMS_AND_CONDITIONS",
-            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
+            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED:false}",
             "defaultAction": true,
             "priority": 10,
             "config": {}
@@ -2813,7 +2813,7 @@
             "alias": "CONFIGURE_TOTP",
             "name": "Configure OTP",
             "providerId": "CONFIGURE_TOTP",
-            "enabled": "${REALM_OTP_ENABLED}",
+            "enabled": "${REALM_OTP_ENABLED:false}",
             "defaultAction": false,
             "priority": 20,
             "config": {}
@@ -2840,7 +2840,7 @@
             "alias": "VERIFY_EMAIL",
             "name": "Verify Email",
             "providerId": "VERIFY_EMAIL",
-            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
+            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED:false}",
             "defaultAction": true,
             "priority": 50,
             "config": {}

--- a/src/realm.json
+++ b/src/realm.json
@@ -39,6 +39,7 @@
     "editUsernameAllowed": false,
     "bruteForceProtected": true,
     "permanentLockout": true,
+    "maxTemporaryLockouts": 0,
     "maxFailureWaitSeconds": 900,
     "minimumQuickLoginWaitSeconds": 60,
     "waitIncrementSeconds": 60,
@@ -1911,6 +1912,20 @@
                     "priority": [
                         "100"
                     ]
+                }
+            },
+            {
+                "id": "df923c3c-a0ef-457c-b66c-f2c623c87586",
+                "name": "fallback-HS512",
+                "providerId": "hmac-generated",
+                "subComponents": {},
+                "config": {
+                  "priority": [
+                    "-100"
+                  ],
+                  "algorithm": [
+                    "HS512"
+                  ]
                 }
             },
             {

--- a/src/realm.json
+++ b/src/realm.json
@@ -437,7 +437,7 @@
     "requiredCredentials": [
         "password"
     ],
-    "passwordPolicy": "hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)",
+    "passwordPolicy": "${REALM_PASSWORD_POLICY}",
     "otpPolicyType": "totp",
     "otpPolicyAlgorithm": "HmacSHA1",
     "otpPolicyInitialCounter": 0,

--- a/src/realm.json
+++ b/src/realm.json
@@ -2814,7 +2814,7 @@
             "alias": "CONFIGURE_TOTP",
             "name": "Configure OTP",
             "providerId": "CONFIGURE_TOTP",
-            "enabled": "${REALM_OTP_ENABLED:false}",
+            "enabled": "${REALM_OTP_ENABLED:true}",
             "defaultAction": false,
             "priority": 20,
             "config": {}

--- a/src/realm.json
+++ b/src/realm.json
@@ -2760,7 +2760,7 @@
                 "x509-cert-auth.canonical-dn-enabled": "false",
                 "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
                 "x509-cert-auth.serialnumber-hex-enabled": "false",
-                "x509-cert-auth.ocsp-fail-open": "false",
+                "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
                 "x509-cert-auth.regular-expression": "(.*?)(?:$)",
                 "x509-cert-auth.certificate-policy-mode": "All",
                 "x509-cert-auth.timestamp-validation-enabled": "true",
@@ -2789,7 +2789,7 @@
             "alias": "TERMS_AND_CONDITIONS",
             "name": "Terms and Conditions",
             "providerId": "TERMS_AND_CONDITIONS",
-            "enabled": false,
+            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
             "defaultAction": true,
             "priority": 10,
             "config": {}
@@ -2798,7 +2798,7 @@
             "alias": "CONFIGURE_TOTP",
             "name": "Configure OTP",
             "providerId": "CONFIGURE_TOTP",
-            "enabled": true,
+            "enabled": "${REALM_OTP_ENABLED}",
             "defaultAction": false,
             "priority": 20,
             "config": {}
@@ -2825,7 +2825,7 @@
             "alias": "VERIFY_EMAIL",
             "name": "Verify Email",
             "providerId": "VERIFY_EMAIL",
-            "enabled": true,
+            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
             "defaultAction": true,
             "priority": 50,
             "config": {}

--- a/src/test/cypress/e2e/login.cy.ts
+++ b/src/test/cypress/e2e/login.cy.ts
@@ -7,7 +7,7 @@ describe("Login Flow", () => {
       firstName: "Testing",
       lastName: "User",
       username: "testing_user",
-      password: "testingpassword!!",
+      password: "testingpassword1!!",
     };
 
     cy.loginUser(formData.username, formData.password);
@@ -24,7 +24,7 @@ describe("Login Flow", () => {
   it("Invalid User Creds", () => {
     const formData: RegistrationFormData = {
       username: "testing_user",
-      password: "PrettyUnicorns!!",
+      password: "PrettyUnicorns1!!",
     };
 
     cy.loginUser(formData.username, formData.password);

--- a/src/test/cypress/e2e/registration.cy.ts
+++ b/src/test/cypress/e2e/registration.cy.ts
@@ -74,7 +74,7 @@ describe("Registration Tests", () => {
       organization: "Defense Unicorns",
       username: "testing_user",
       email: "testinguser@gmail.com",
-      password: "PrettyUnicorns!!",
+      password: "PrettyUnicorns1!!",
       affiliation: "Contractor",
       payGrade: "N/A",
     };
@@ -93,7 +93,7 @@ describe("Registration Tests", () => {
       organization: "Defense Unicorns",
       username: "new_user",
       email: "newuser@gmail.com",
-      password: "Pretty!!",
+      password: "Pretty1!!",
       affiliation: "Contractor",
       payGrade: "N/A",
     };
@@ -113,7 +113,7 @@ describe("Registration Tests", () => {
       organization: "Defense Unicorns",
       username: "new_user",
       email: "newuser@gmail.com",
-      password: "PrettyUnicorns",
+      password: "PrettyUnicorns1",
       affiliation: "Contractor",
       payGrade: "N/A",
     };

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -1,2662 +1,2662 @@
 {
-  "id": "uds",
-  "realm": "uds",
-  "displayName": "Unicorn Delivery Service",
-  "displayNameHtml": "Identity Service",
-  "notBefore": 0,
-  "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": false,
-  "refreshTokenMaxReuse": 0,
-  "accessTokenLifespan": 300,
-  "accessTokenLifespanForImplicitFlow": 900,
-  "ssoSessionIdleTimeout": 1800,
-  "ssoSessionMaxLifespan": 36000,
-  "ssoSessionIdleTimeoutRememberMe": 0,
-  "ssoSessionMaxLifespanRememberMe": 0,
-  "offlineSessionIdleTimeout": 2592000,
-  "offlineSessionMaxLifespanEnabled": false,
-  "offlineSessionMaxLifespan": 5184000,
-  "clientSessionIdleTimeout": 0,
-  "clientSessionMaxLifespan": 0,
-  "clientOfflineSessionIdleTimeout": 0,
-  "clientOfflineSessionMaxLifespan": 0,
-  "accessCodeLifespan": 60,
-  "accessCodeLifespanUserAction": 300,
-  "accessCodeLifespanLogin": 1800,
-  "actionTokenGeneratedByAdminLifespan": 43200,
-  "actionTokenGeneratedByUserLifespan": 300,
-  "oauth2DeviceCodeLifespan": 600,
-  "oauth2DevicePollingInterval": 5,
-  "enabled": true,
-  "sslRequired": "external",
-  "registrationAllowed": true,
-  "registrationEmailAsUsername": false,
-  "rememberMe": false,
-  "verifyEmail": true,
-  "loginWithEmailAllowed": true,
-  "duplicateEmailsAllowed": false,
-  "resetPasswordAllowed": true,
-  "editUsernameAllowed": false,
-  "bruteForceProtected": true,
-  "permanentLockout": true,
-  "maxTemporaryLockouts": 0,
-  "maxFailureWaitSeconds": 900,
-  "minimumQuickLoginWaitSeconds": 60,
-  "waitIncrementSeconds": 60,
-  "quickLoginCheckMilliSeconds": 1000,
-  "maxDeltaTimeSeconds": 43200,
-  "failureFactor": 5,
-  "users": [
-      {
-          "id": "123",
-          "username": "testing_user",
-          "enabled": "true",
-          "credentials": [
-              {
-                  "type": "password",
-                  "value": "testingpassword1!!"
-              }
-          ],
-          "firstName": "Testing",
-          "lastName": "User",
-          "email": "testinguser@gmail.com",
-          "emailVerified": true,
-          "realmRoles": ["default-roles-uds"]
-      }
-  ],
-  "roles": {
-      "realm": [
-          {
-              "id": "9630aa66-af3d-4704-9063-a80c25fb24ae",
-              "name": "uma_authorization",
-              "description": "${role_uma_authorization}",
-              "composite": false,
-              "clientRole": false,
-              "containerId": "uds",
-              "attributes": {}
-          },
-          {
-              "id": "ee67a20a-d607-4ed8-8a77-f11f92e7157f",
-              "name": "offline_access",
-              "description": "${role_offline-access}",
-              "composite": false,
-              "clientRole": false,
-              "containerId": "uds",
-              "attributes": {}
-          },
-          {
-              "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
-              "name": "default-roles-uds",
-              "description": "${role_default-roles}",
-              "composite": true,
-              "composites": {
-                  "realm": [
-                      "offline_access",
-                      "uma_authorization"
-                  ],
-                  "client": {
-                      "account": [
-                          "manage-account",
-                          "view-profile",
-                          "view-groups"
-                      ]
-                  }
-              },
-              "clientRole": false,
-              "containerId": "uds",
-              "attributes": {}
-          }
-      ],
-      "client": {
-          "realm-management": [
-              {
-                  "id": "b97936e6-d425-4dd2-a828-1444065d7b69",
-                  "name": "query-users",
-                  "description": "${role_query-users}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "89f798f8-f316-4588-8eef-51bfb0afb50a",
-                  "name": "view-authorization",
-                  "description": "${role_view-authorization}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "5d2ee7fb-0c5c-4abe-9424-5a6df6a2a9e3",
-                  "name": "query-realms",
-                  "description": "${role_query-realms}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "8dfc18ae-276f-4b8c-921c-3fad62390679",
-                  "name": "create-client",
-                  "description": "${role_create-client}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "145a11f5-38ba-46ff-aa7d-050780ff43d8",
-                  "name": "impersonation",
-                  "description": "${role_impersonation}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "8b6f75e9-fb44-40de-a998-c68f816a44fc",
-                  "name": "view-events",
-                  "description": "${role_view-events}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "1c07b7e2-3d16-428c-b68b-e3064f230ced",
-                  "name": "manage-authorization",
-                  "description": "${role_manage-authorization}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "ed54aef5-cac0-47b5-ab8b-fd2852835569",
-                  "name": "query-clients",
-                  "description": "${role_query-clients}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "997c82fa-0963-4161-80ba-6a93240c7328",
-                  "name": "view-identity-providers",
-                  "description": "${role_view-identity-providers}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "db96dcd7-7322-4e63-a45d-f3cb79d2735f",
-                  "name": "realm-admin",
-                  "description": "${role_realm-admin}",
-                  "composite": true,
-                  "composites": {
-                      "client": {
-                          "realm-management": [
-                              "view-authorization",
-                              "query-users",
-                              "query-realms",
-                              "impersonation",
-                              "view-events",
-                              "create-client",
-                              "manage-authorization",
-                              "view-identity-providers",
-                              "query-clients",
-                              "view-clients",
-                              "query-groups",
-                              "manage-realm",
-                              "manage-identity-providers",
-                              "view-users",
-                              "manage-events",
-                              "manage-clients",
-                              "manage-users",
-                              "view-realm"
-                          ]
-                      }
-                  },
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "f5a79a5f-2081-49c4-b5f2-a4de65872324",
-                  "name": "view-clients",
-                  "description": "${role_view-clients}",
-                  "composite": true,
-                  "composites": {
-                      "client": {
-                          "realm-management": [
-                              "query-clients"
-                          ]
-                      }
-                  },
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "b06aa3b9-2158-4368-a1c0-923ec601b612",
-                  "name": "query-groups",
-                  "description": "${role_query-groups}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "ea696cf6-a201-4959-8eb6-21ae767f55e2",
-                  "name": "manage-realm",
-                  "description": "${role_manage-realm}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "df80d4c8-5414-4fef-863f-2567e9ed3c06",
-                  "name": "manage-identity-providers",
-                  "description": "${role_manage-identity-providers}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "a59628c5-c193-4cee-9714-ec6936104f31",
-                  "name": "view-users",
-                  "description": "${role_view-users}",
-                  "composite": true,
-                  "composites": {
-                      "client": {
-                          "realm-management": [
-                              "query-groups",
-                              "query-users"
-                          ]
-                      }
-                  },
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "76358e4d-eb1c-4d20-9fc6-4a1fe66ce547",
-                  "name": "manage-events",
-                  "description": "${role_manage-events}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "0d86a9c9-d218-48ca-b362-b9cfb9f1cec7",
-                  "name": "manage-clients",
-                  "description": "${role_manage-clients}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "8daa5681-8c5e-4842-9454-f3ee52542b62",
-                  "name": "manage-users",
-                  "description": "${role_manage-users}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              },
-              {
-                  "id": "4b1f822c-9ad8-4f64-abac-d6d67d8b5c27",
-                  "name": "view-realm",
-                  "description": "${role_view-realm}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                  "attributes": {}
-              }
-          ],
-          "security-admin-console": [],
-          "admin-cli": [],
-          "account-console": [],
-          "broker": [
-              {
-                  "id": "7781303d-b0d3-4c73-bfb8-4aafb4c6fe20",
-                  "name": "read-token",
-                  "description": "${role_read-token}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
-                  "attributes": {}
-              }
-          ],
-          "account": [
-              {
-                  "id": "66091206-7730-446e-9a55-7c68c990d60a",
-                  "name": "manage-consent",
-                  "description": "${role_manage-consent}",
-                  "composite": true,
-                  "composites": {
-                      "client": {
-                          "account": [
-                              "view-consent"
-                          ]
-                      }
-                  },
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              },
-              {
-                  "id": "b945fcb1-4882-4d55-bfac-dfdc8923ba80",
-                  "name": "view-applications",
-                  "description": "${role_view-applications}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              },
-              {
-                  "id": "1b79071c-e0c6-4b14-980d-a673410308f5",
-                  "name": "manage-account",
-                  "description": "${role_manage-account}",
-                  "composite": true,
-                  "composites": {
-                      "client": {
-                          "account": [
-                              "manage-account-links"
-                          ]
-                      }
-                  },
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              },
-              {
-                  "id": "76fb4026-c5e6-4a7c-948d-ef46cc837852",
-                  "name": "view-profile",
-                  "description": "${role_view-profile}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              },
-              {
-                  "id": "7a3e2678-e64d-43b7-a749-fd91c5f8e415",
-                  "name": "view-groups",
-                  "description": "${role_view-groups}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              },
-              {
-                  "id": "93feab65-1196-499a-ad78-c3d38b26a653",
-                  "name": "manage-account-links",
-                  "description": "${role_manage-account-links}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              },
-              {
-                  "id": "a985566b-6df2-48e5-a81d-f23f1509a074",
-                  "name": "delete-account",
-                  "description": "${role_delete-account}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              },
-              {
-                  "id": "8c9f1ab5-a69e-40e2-bf2f-294f6d483ce1",
-                  "name": "view-consent",
-                  "description": "${role_view-consent}",
-                  "composite": false,
-                  "clientRole": true,
-                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                  "attributes": {}
-              }
-          ]
-      }
-  },
-  "groups": [
-      {
-          "id": "53521ed0-aa44-4007-9727-0015d5281c3e",
-          "name": "UDS Core",
-          "path": "/UDS Core",
-          "subGroups": [
-              {
-                  "id": "1ce48bde-e0e9-4bac-8b77-8b4cc96d2135",
-                  "name": "Admin",
-                  "path": "/UDS Core/Admin",
-                  "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
-              },
-              {
-                  "id": "03a34e8e-be2d-44cd-8ad2-75e90e28f6d9",
-                  "name": "Auditor",
-                  "path": "/UDS Core/Auditor",
-                  "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
-              }
-          ]
-      }
-  ],
-  "defaultRole": {
-      "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
-      "name": "default-roles-uds",
-      "description": "${role_default-roles}",
-      "composite": true,
-      "clientRole": false,
-      "containerId": "uds"
-  },
-  "requiredCredentials": [
-      "password"
-  ],
-  "passwordPolicy": "${REALM_PASSWORD_POLICY}",
-  "otpPolicyType": "totp",
-  "otpPolicyAlgorithm": "HmacSHA1",
-  "otpPolicyInitialCounter": 0,
-  "otpPolicyDigits": 6,
-  "otpPolicyLookAheadWindow": 3,
-  "otpPolicyPeriod": 30,
-  "otpPolicyCodeReusable": false,
-  "otpSupportedApplications": [
-      "totpAppFreeOTPName",
-      "totpAppGoogleName",
-      "totpAppMicrosoftAuthenticatorName"
-  ],
-  "localizationTexts": {},
-  "webAuthnPolicyRpEntityName": "keycloak",
-  "webAuthnPolicySignatureAlgorithms": [
-      "ES256"
-  ],
-  "webAuthnPolicyRpId": "",
-  "webAuthnPolicyAttestationConveyancePreference": "not specified",
-  "webAuthnPolicyAuthenticatorAttachment": "not specified",
-  "webAuthnPolicyRequireResidentKey": "not specified",
-  "webAuthnPolicyUserVerificationRequirement": "not specified",
-  "webAuthnPolicyCreateTimeout": 0,
-  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
-  "webAuthnPolicyAcceptableAaguids": [],
-  "webAuthnPolicyExtraOrigins": [],
-  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
-  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
-      "ES256"
-  ],
-  "webAuthnPolicyPasswordlessRpId": "",
-  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
-  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
-  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
-  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
-  "webAuthnPolicyPasswordlessCreateTimeout": 0,
-  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
-  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
-  "webAuthnPolicyPasswordlessExtraOrigins": [],
-  "scopeMappings": [
-      {
-          "clientScope": "offline_access",
-          "roles": [
-              "offline_access"
-          ]
-      }
-  ],
-  "clientScopeMappings": {
-      "account": [
-          {
-              "client": "account-console",
-              "roles": [
-                  "manage-account",
-                  "view-groups"
-              ]
-          }
-      ]
-  },
-  "clients": [
-      {
-          "id": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-          "clientId": "account",
-          "name": "Account",
-          "description": "",
-          "rootUrl": "${authBaseUrl}",
-          "adminUrl": "",
-          "baseUrl": "/realms/uds/account/",
-          "surrogateAuthRequired": false,
-          "enabled": true,
-          "alwaysDisplayInConsole": false,
-          "clientAuthenticatorType": "client-secret",
-          "redirectUris": [
-              "/realms/uds/account/*"
-          ],
-          "webOrigins": [],
-          "notBefore": 0,
-          "bearerOnly": false,
-          "consentRequired": false,
-          "standardFlowEnabled": true,
-          "implicitFlowEnabled": false,
-          "directAccessGrantsEnabled": false,
-          "serviceAccountsEnabled": false,
-          "publicClient": true,
-          "frontchannelLogout": false,
-          "protocol": "openid-connect",
-          "attributes": {
-              "oidc.ciba.grant.enabled": "false",
-              "backchannel.logout.session.required": "true",
-              "post.logout.redirect.uris": "+",
-              "oauth2.device.authorization.grant.enabled": "false",
-              "display.on.consent.screen": "false",
-              "backchannel.logout.revoke.offline.tokens": "false"
-          },
-          "authenticationFlowBindingOverrides": {},
-          "fullScopeAllowed": false,
-          "nodeReRegistrationTimeout": 0,
-          "defaultClientScopes": [
-              "web-origins",
-              "acr",
-              "profile",
-              "roles",
-              "email"
-          ],
-          "optionalClientScopes": [
-              "address",
-              "phone",
-              "offline_access",
-              "microprofile-jwt"
-          ]
-      },
-      {
-          "id": "f5c075d3-33ea-4bd6-8629-a3ecbeda72d9",
-          "clientId": "account-console",
-          "name": "My Account",
-          "description": "",
-          "rootUrl": "${authBaseUrl}",
-          "adminUrl": "",
-          "baseUrl": "/realms/uds/account/",
-          "surrogateAuthRequired": false,
-          "enabled": true,
-          "alwaysDisplayInConsole": false,
-          "clientAuthenticatorType": "client-secret",
-          "redirectUris": [
-              "/realms/uds/account/*"
-          ],
-          "webOrigins": [],
-          "notBefore": 0,
-          "bearerOnly": false,
-          "consentRequired": false,
-          "standardFlowEnabled": true,
-          "implicitFlowEnabled": false,
-          "directAccessGrantsEnabled": false,
-          "serviceAccountsEnabled": false,
-          "publicClient": true,
-          "frontchannelLogout": false,
-          "protocol": "openid-connect",
-          "attributes": {
-              "oidc.ciba.grant.enabled": "false",
-              "backchannel.logout.session.required": "true",
-              "post.logout.redirect.uris": "+",
-              "oauth2.device.authorization.grant.enabled": "false",
-              "display.on.consent.screen": "false",
-              "pkce.code.challenge.method": "S256",
-              "backchannel.logout.revoke.offline.tokens": "false"
-          },
-          "authenticationFlowBindingOverrides": {},
-          "fullScopeAllowed": false,
-          "nodeReRegistrationTimeout": 0,
-          "protocolMappers": [
-              {
-                  "id": "254c52b4-d381-4612-a26f-ba7586d1d9a3",
-                  "name": "audience resolve",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-audience-resolve-mapper",
-                  "consentRequired": false,
-                  "config": {}
-              }
-          ],
-          "defaultClientScopes": [
-              "web-origins",
-              "acr",
-              "profile",
-              "roles",
-              "email"
-          ],
-          "optionalClientScopes": [
-              "address",
-              "phone",
-              "offline_access",
-              "microprofile-jwt"
-          ]
-      },
-      {
-          "id": "deca352c-0907-40ca-aea7-ea92792d6246",
-          "clientId": "admin-cli",
-          "name": "${client_admin-cli}",
-          "surrogateAuthRequired": false,
-          "enabled": true,
-          "alwaysDisplayInConsole": false,
-          "clientAuthenticatorType": "client-secret",
-          "redirectUris": [],
-          "webOrigins": [],
-          "notBefore": 0,
-          "bearerOnly": false,
-          "consentRequired": false,
-          "standardFlowEnabled": false,
-          "implicitFlowEnabled": false,
-          "directAccessGrantsEnabled": true,
-          "serviceAccountsEnabled": false,
-          "publicClient": true,
-          "frontchannelLogout": false,
-          "protocol": "openid-connect",
-          "attributes": {
-              "post.logout.redirect.uris": "+"
-          },
-          "authenticationFlowBindingOverrides": {},
-          "fullScopeAllowed": false,
-          "nodeReRegistrationTimeout": 0,
-          "defaultClientScopes": [
-              "web-origins",
-              "acr",
-              "profile",
-              "roles",
-              "email"
-          ],
-          "optionalClientScopes": [
-              "address",
-              "phone",
-              "offline_access",
-              "microprofile-jwt"
-          ]
-      },
-      {
-          "id": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
-          "clientId": "broker",
-          "name": "Broker",
-          "surrogateAuthRequired": false,
-          "enabled": true,
-          "alwaysDisplayInConsole": false,
-          "clientAuthenticatorType": "client-secret",
-          "redirectUris": [],
-          "webOrigins": [],
-          "notBefore": 0,
-          "bearerOnly": true,
-          "consentRequired": false,
-          "standardFlowEnabled": true,
-          "implicitFlowEnabled": false,
-          "directAccessGrantsEnabled": false,
-          "serviceAccountsEnabled": false,
-          "publicClient": false,
-          "frontchannelLogout": false,
-          "protocol": "openid-connect",
-          "attributes": {
-              "post.logout.redirect.uris": "+"
-          },
-          "authenticationFlowBindingOverrides": {},
-          "fullScopeAllowed": false,
-          "nodeReRegistrationTimeout": 0,
-          "defaultClientScopes": [
-              "web-origins",
-              "acr",
-              "profile",
-              "roles",
-              "email"
-          ],
-          "optionalClientScopes": [
-              "address",
-              "phone",
-              "offline_access",
-              "microprofile-jwt"
-          ]
-      },
-      {
-          "id": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-          "clientId": "realm-management",
-          "name": "Realm Management",
-          "surrogateAuthRequired": false,
-          "enabled": true,
-          "alwaysDisplayInConsole": false,
-          "clientAuthenticatorType": "client-secret",
-          "redirectUris": [],
-          "webOrigins": [],
-          "notBefore": 0,
-          "bearerOnly": true,
-          "consentRequired": false,
-          "standardFlowEnabled": true,
-          "implicitFlowEnabled": false,
-          "directAccessGrantsEnabled": false,
-          "serviceAccountsEnabled": false,
-          "publicClient": false,
-          "frontchannelLogout": false,
-          "protocol": "openid-connect",
-          "attributes": {
-              "post.logout.redirect.uris": "+"
-          },
-          "authenticationFlowBindingOverrides": {},
-          "fullScopeAllowed": false,
-          "nodeReRegistrationTimeout": 0,
-          "defaultClientScopes": [
-              "web-origins",
-              "acr",
-              "profile",
-              "roles",
-              "email"
-          ],
-          "optionalClientScopes": [
-              "address",
-              "phone",
-              "offline_access",
-              "microprofile-jwt"
-          ]
-      },
-      {
-          "id": "51bb67ac-a911-4594-96fa-0c9af22daead",
-          "clientId": "security-admin-console",
-          "name": "Security Admin Console",
-          "description": "",
-          "rootUrl": "${authAdminUrl}",
-          "adminUrl": "",
-          "baseUrl": "/admin/uds/console/",
-          "surrogateAuthRequired": false,
-          "enabled": true,
-          "alwaysDisplayInConsole": false,
-          "clientAuthenticatorType": "client-secret",
-          "redirectUris": [
-              "/admin/uds/console/*"
-          ],
-          "webOrigins": [
-              "+"
-          ],
-          "notBefore": 0,
-          "bearerOnly": false,
-          "consentRequired": false,
-          "standardFlowEnabled": true,
-          "implicitFlowEnabled": false,
-          "directAccessGrantsEnabled": false,
-          "serviceAccountsEnabled": false,
-          "publicClient": true,
-          "frontchannelLogout": false,
-          "protocol": "openid-connect",
-          "attributes": {
-              "oidc.ciba.grant.enabled": "false",
-              "backchannel.logout.session.required": "true",
-              "post.logout.redirect.uris": "+",
-              "oauth2.device.authorization.grant.enabled": "false",
-              "display.on.consent.screen": "false",
-              "pkce.code.challenge.method": "S256",
-              "backchannel.logout.revoke.offline.tokens": "false"
-          },
-          "authenticationFlowBindingOverrides": {},
-          "fullScopeAllowed": false,
-          "nodeReRegistrationTimeout": 0,
-          "protocolMappers": [
-              {
-                  "id": "461284ab-c557-4d08-9ade-0328d2d6d0c0",
-                  "name": "locale",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "locale",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "locale",
-                      "jsonType.label": "String"
-                  }
-              }
-          ],
-          "defaultClientScopes": [
-              "web-origins",
-              "acr",
-              "profile",
-              "roles",
-              "email"
-          ],
-          "optionalClientScopes": [
-              "address",
-              "phone",
-              "offline_access",
-              "microprofile-jwt"
-          ]
-      }
-  ],
-  "clientScopes": [
-      {
-          "id": "ad5955d0-5a02-4d77-9729-c9c50e3c614f",
-          "name": "role_list",
-          "description": "SAML role list",
-          "protocol": "saml",
-          "attributes": {
-              "consent.screen.text": "${samlRoleListScopeConsentText}",
-              "display.on.consent.screen": "true"
-          },
-          "protocolMappers": [
-              {
-                  "id": "8dbe7da2-9fae-4e24-b258-adffce4af581",
-                  "name": "role list",
-                  "protocol": "saml",
-                  "protocolMapper": "saml-role-list-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "single": "false",
-                      "attribute.nameformat": "Basic",
-                      "attribute.name": "Role"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "a56e312f-85f1-4c48-9822-b2c73ec29fef",
-          "name": "phone",
-          "description": "OpenID Connect built-in scope: phone",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "true",
-              "display.on.consent.screen": "true",
-              "consent.screen.text": "${phoneScopeConsentText}"
-          },
-          "protocolMappers": [
-              {
-                  "id": "5cb0a293-9545-4125-9a93-be8ff09805e8",
-                  "name": "phone number",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "phoneNumber",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "phone_number",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "f70f8a3d-2ef3-4b05-a33d-0b825406c703",
-                  "name": "phone number verified",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "phoneNumberVerified",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "phone_number_verified",
-                      "jsonType.label": "boolean"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "6970f878-3093-40f0-b48e-a749087760dc",
-          "name": "microprofile-jwt",
-          "description": "Microprofile - JWT built-in scope",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "true",
-              "display.on.consent.screen": "false"
-          },
-          "protocolMappers": [
-              {
-                  "id": "b1994403-6493-4e5c-92bf-b41db1342f74",
-                  "name": "upn",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "username",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "upn",
-                      "jsonType.label": "String"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "15fd77dc-7f74-4c66-83bb-0b9350c6b554",
-          "name": "email",
-          "description": "OpenID Connect built-in scope: email",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "true",
-              "display.on.consent.screen": "true",
-              "consent.screen.text": "${emailScopeConsentText}"
-          },
-          "protocolMappers": [
-              {
-                  "id": "381b388d-b090-47b5-be92-713204f48163",
-                  "name": "email",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "email",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "email",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "eb386cd0-5efc-4087-ac56-8b3d0530a950",
-                  "name": "email verified",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-property-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "emailVerified",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "email_verified",
-                      "jsonType.label": "boolean"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "752a2fd8-ace8-407c-a1bf-d74f7f14b79c",
-          "name": "profile",
-          "description": "OpenID Connect built-in scope: profile",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "true",
-              "display.on.consent.screen": "true",
-              "consent.screen.text": "${profileScopeConsentText}"
-          },
-          "protocolMappers": [
-              {
-                  "id": "ca69a4e5-c386-477f-9f92-d4cc90e3e9c6",
-                  "name": "picture",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "picture",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "picture",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "7d126b72-cc83-45b7-8213-e5a2e52df40d",
-                  "name": "website",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "website",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "website",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "57a93d89-f1e0-4fb6-9abb-c709f5b265a5",
-                  "name": "zoneinfo",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "zoneinfo",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "zoneinfo",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "958c9a5d-87a8-4c93-989e-3e41283bab1f",
-                  "name": "birthdate",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "birthdate",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "birthdate",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "2f254814-1025-4290-8008-7a9ed422e53c",
-                  "name": "username",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "username",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "preferred_username",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "1b28f611-9197-43cf-a1af-ac6a404553d6",
-                  "name": "locale",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "locale",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "locale",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "fa02cb75-2f6c-44ee-b9b7-103efd0ae92b",
-                  "name": "middle name",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "middleName",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "middle_name",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "92b04117-abb1-4afe-ab2d-4863671d4b11",
-                  "name": "updated at",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "updatedAt",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "updated_at",
-                      "jsonType.label": "long"
-                  }
-              },
-              {
-                  "id": "f5965fdb-2351-4681-b0d6-8576f4b2186d",
-                  "name": "nickname",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "nickname",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "nickname",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "574469f2-13ec-4240-ad18-f8ac02374cab",
-                  "name": "given name",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "firstName",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "given_name",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "39ed2777-22c8-428d-893e-3df346eea7e4",
-                  "name": "groups",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-group-membership-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "full.path": "true",
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "multivalued": "true",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "groups"
-                  }
-              },
-              {
-                  "id": "6d52407c-f35d-4f1f-8fee-46a3c1d25afe",
-                  "name": "full name",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-full-name-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "id.token.claim": "true",
-                      "introspection.token.claim": "true",
-                      "access.token.claim": "true",
-                      "userinfo.token.claim": "true"
-                  }
-              },
-              {
-                  "id": "e7dedcf0-2b37-45bd-a31c-f7a2b7f3c5ac",
-                  "name": "family name",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "lastName",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "family_name",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "bd488196-dcbf-434f-90ba-0a8b5f9a9e27",
-                  "name": "gender",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "gender",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "gender",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "f16482ec-79c4-491b-b1a7-67a14c882be5",
-                  "name": "profile",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-attribute-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "userinfo.token.claim": "true",
-                      "user.attribute": "profile",
-                      "id.token.claim": "true",
-                      "access.token.claim": "true",
-                      "claim.name": "profile",
-                      "jsonType.label": "String"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "1a66d616-6eb0-45d7-89f7-df975f26a88e",
-          "name": "roles",
-          "description": "OpenID Connect scope for add user roles to the access token",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "false",
-              "display.on.consent.screen": "true",
-              "consent.screen.text": "${rolesScopeConsentText}"
-          },
-          "protocolMappers": [
-              {
-                  "id": "17a0e011-6792-4112-b787-e3748e2fe255",
-                  "name": "realm roles",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-realm-role-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "multivalued": "true",
-                      "user.attribute": "foo",
-                      "access.token.claim": "true",
-                      "claim.name": "realm_access.roles",
-                      "jsonType.label": "String"
-                  }
-              },
-              {
-                  "id": "e91b9e2a-b20e-47c5-bb72-e4e999c0f9a7",
-                  "name": "audience resolve",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-audience-resolve-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "access.token.claim": "true"
-                  }
-              },
-              {
-                  "id": "021aabc9-aca3-4a31-9fa4-3b4d4fc5d129",
-                  "name": "client roles",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-usermodel-client-role-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "multivalued": "true",
-                      "user.attribute": "foo",
-                      "access.token.claim": "true",
-                      "claim.name": "resource_access.${client_id}.roles",
-                      "jsonType.label": "String"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "80bca4fb-c991-4f47-b941-90033d417619",
-          "name": "web-origins",
-          "description": "OpenID Connect scope for add allowed web origins to the access token",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "false",
-              "display.on.consent.screen": "false",
-              "consent.screen.text": ""
-          },
-          "protocolMappers": [
-              {
-                  "id": "65298359-14d0-4291-899e-3ca27dbf283b",
-                  "name": "allowed web origins",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-allowed-origins-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "introspection.token.claim": "true",
-                      "access.token.claim": "true"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "770edec1-8367-40cc-834c-ee2ef116cb0a",
-          "name": "offline_access",
-          "description": "OpenID Connect built-in scope: offline_access",
-          "protocol": "openid-connect",
-          "attributes": {
-              "consent.screen.text": "${offlineAccessScopeConsentText}",
-              "display.on.consent.screen": "true"
-          }
-      },
-      {
-          "id": "0c4e8857-3a4c-4ef6-bac7-952b24a7591e",
-          "name": "acr",
-          "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "false",
-              "display.on.consent.screen": "false"
-          },
-          "protocolMappers": [
-              {
-                  "id": "3db9f004-36c9-4154-a076-6f027699aad4",
-                  "name": "acr loa level",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-acr-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "id.token.claim": "true",
-                      "introspection.token.claim": "true",
-                      "access.token.claim": "true",
-                      "userinfo.token.claim": "true"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "76a50ab0-c3e2-4224-b89f-6cec16ab87c4",
-          "name": "address",
-          "description": "OpenID Connect built-in scope: address",
-          "protocol": "openid-connect",
-          "attributes": {
-              "include.in.token.scope": "true",
-              "display.on.consent.screen": "true",
-              "consent.screen.text": "${addressScopeConsentText}"
-          },
-          "protocolMappers": [
-              {
-                  "id": "ab3891ab-f49e-4f23-b6fd-d456c0084d9b",
-                  "name": "address",
-                  "protocol": "openid-connect",
-                  "protocolMapper": "oidc-address-mapper",
-                  "consentRequired": false,
-                  "config": {
-                      "user.attribute.formatted": "formatted",
-                      "user.attribute.country": "country",
-                      "introspection.token.claim": "true",
-                      "user.attribute.postal_code": "postal_code",
-                      "userinfo.token.claim": "true",
-                      "user.attribute.street": "street",
-                      "id.token.claim": "true",
-                      "user.attribute.region": "region",
-                      "access.token.claim": "true",
-                      "user.attribute.locality": "locality"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "52fa0872-8912-4096-a124-da2c077b5539",
-          "name": "openid",
-          "description": "OpenID Connect built-in scope: openid",
-          "protocol": "openid-connect",
-          "attributes": {
-            "include.in.token.scope": "true",
-            "display.on.consent.screen": "true"
-          }
-      }
-  ],
-  "defaultDefaultClientScopes": [
-      "role_list",
-      "profile",
-      "email",
-      "roles",
-      "web-origins",
-      "acr"
-  ],
-  "defaultOptionalClientScopes": [
-      "offline_access",
-      "address",
-      "phone",
-      "microprofile-jwt"
-  ],
-  "browserSecurityHeaders": {
-      "contentSecurityPolicyReportOnly": "",
-      "xContentTypeOptions": "nosniff",
-      "referrerPolicy": "no-referrer",
-      "xRobotsTag": "none",
-      "xFrameOptions": "SAMEORIGIN",
-      "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-      "xXSSProtection": "1; mode=block",
-      "strictTransportSecurity": "max-age=31536000; includeSubDomains"
-  },
-  "smtpServer": {},
-  "loginTheme": "theme",
-  "accountTheme": "theme",
-  "eventsEnabled": true,
-  "eventsExpiration": 1800,
-  "eventsListeners": [
-      "jboss-logging",
-      "custom-registration-listener"
-  ],
-  "enabledEventTypes": [
-      "SEND_RESET_PASSWORD",
-      "UPDATE_CONSENT_ERROR",
-      "GRANT_CONSENT",
-      "REMOVE_TOTP",
-      "REVOKE_GRANT",
-      "UPDATE_TOTP",
-      "LOGIN_ERROR",
-      "CLIENT_LOGIN",
-      "RESET_PASSWORD_ERROR",
-      "IMPERSONATE_ERROR",
-      "CODE_TO_TOKEN_ERROR",
-      "CUSTOM_REQUIRED_ACTION",
-      "RESTART_AUTHENTICATION",
-      "IMPERSONATE",
-      "UPDATE_PROFILE_ERROR",
-      "LOGIN",
-      "UPDATE_PASSWORD_ERROR",
-      "CLIENT_INITIATED_ACCOUNT_LINKING",
-      "TOKEN_EXCHANGE",
-      "LOGOUT",
-      "REGISTER",
-      "CLIENT_REGISTER",
-      "IDENTITY_PROVIDER_LINK_ACCOUNT",
-      "UPDATE_PASSWORD",
-      "CLIENT_DELETE",
-      "FEDERATED_IDENTITY_LINK_ERROR",
-      "IDENTITY_PROVIDER_FIRST_LOGIN",
-      "CLIENT_DELETE_ERROR",
-      "VERIFY_EMAIL",
-      "CLIENT_LOGIN_ERROR",
-      "RESTART_AUTHENTICATION_ERROR",
-      "EXECUTE_ACTIONS",
-      "REMOVE_FEDERATED_IDENTITY_ERROR",
-      "TOKEN_EXCHANGE_ERROR",
-      "PERMISSION_TOKEN",
-      "SEND_IDENTITY_PROVIDER_LINK_ERROR",
-      "EXECUTE_ACTION_TOKEN_ERROR",
-      "SEND_VERIFY_EMAIL",
-      "EXECUTE_ACTIONS_ERROR",
-      "REMOVE_FEDERATED_IDENTITY",
-      "IDENTITY_PROVIDER_POST_LOGIN",
-      "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
-      "UPDATE_EMAIL",
-      "REGISTER_ERROR",
-      "REVOKE_GRANT_ERROR",
-      "EXECUTE_ACTION_TOKEN",
-      "LOGOUT_ERROR",
-      "UPDATE_EMAIL_ERROR",
-      "CLIENT_UPDATE_ERROR",
-      "UPDATE_PROFILE",
-      "CLIENT_REGISTER_ERROR",
-      "FEDERATED_IDENTITY_LINK",
-      "SEND_IDENTITY_PROVIDER_LINK",
-      "SEND_VERIFY_EMAIL_ERROR",
-      "RESET_PASSWORD",
-      "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
-      "UPDATE_CONSENT",
-      "REMOVE_TOTP_ERROR",
-      "VERIFY_EMAIL_ERROR",
-      "SEND_RESET_PASSWORD_ERROR",
-      "CLIENT_UPDATE",
-      "CUSTOM_REQUIRED_ACTION_ERROR",
-      "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
-      "UPDATE_TOTP_ERROR",
-      "CODE_TO_TOKEN",
-      "GRANT_CONSENT_ERROR",
-      "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
-  ],
-  "adminEventsEnabled": true,
-  "adminEventsDetailsEnabled": true,
-  "identityProviders": [
-      {
-        "alias": "saml",
-        "displayName": "Google SSO",
-        "internalId": "1538a301-8427-46d2-b59f-203f2f76e573",
-        "providerId": "saml",
-        "enabled": "${REALM_GOOGLE_IDP_ENABLED}",
-        "updateProfileFirstLoginMode": "on",
-        "trustEmail": true,
-        "storeToken": false,
-        "addReadTokenRoleOnCreate": false,
-        "authenticateByDefault": false,
-        "linkOnly": false,
-        "config": {
-          "postBindingLogout": "false",
-          "postBindingResponse": "true",
-          "backchannelSupported": "false",
-          "idpEntityId": "https://accounts.google.com/o/saml2?idpid=${REALM_GOOGLE_IDP_ID}",
-          "loginHint": "false",
-          "allowCreate": "true",
-          "enabledFromMetadata": "true",
-          "singleSignOnServiceUrl": "https://accounts.google.com/o/saml2/idp?idpid=${REALM_GOOGLE_IDP_ID}",
-          "wantAuthnRequestsSigned": "false",
-          "allowedClockSkew": "0",
-          "validateSignature": "false",
-          "signingCertificate": "${REALM_GOOGLE_IDP_SIGNING_CERT}",
-          "nameIDPolicyFormat": "${REALM_GOOGLE_IDP_NAME_ID_FORMAT}",
-          "entityId": "${REALM_GOOGLE_IDP_CORE_ENTITY_ID}",
-          "signSpMetadata": "false",
-          "wantAssertionsEncrypted": "false",
-          "sendClientIdOnLogout": "false",
-          "wantAssertionsSigned": "false",
-          "sendIdTokenOnLogout": "true",
-          "postBindingAuthnRequest": "true",
-          "forceAuthn": "false",
-          "attributeConsumingServiceIndex": "0",
-          "addExtensionsElementWithKeyInfo": "false",
-          "principalType": "Subject NameID"
+    "id": "uds",
+    "realm": "uds",
+    "displayName": "Unicorn Delivery Service",
+    "displayNameHtml": "Identity Service",
+    "notBefore": 0,
+    "defaultSignatureAlgorithm": "RS256",
+    "revokeRefreshToken": false,
+    "refreshTokenMaxReuse": 0,
+    "accessTokenLifespan": 300,
+    "accessTokenLifespanForImplicitFlow": 900,
+    "ssoSessionIdleTimeout": 1800,
+    "ssoSessionMaxLifespan": 36000,
+    "ssoSessionIdleTimeoutRememberMe": 0,
+    "ssoSessionMaxLifespanRememberMe": 0,
+    "offlineSessionIdleTimeout": 2592000,
+    "offlineSessionMaxLifespanEnabled": false,
+    "offlineSessionMaxLifespan": 5184000,
+    "clientSessionIdleTimeout": 0,
+    "clientSessionMaxLifespan": 0,
+    "clientOfflineSessionIdleTimeout": 0,
+    "clientOfflineSessionMaxLifespan": 0,
+    "accessCodeLifespan": 60,
+    "accessCodeLifespanUserAction": 300,
+    "accessCodeLifespanLogin": 1800,
+    "actionTokenGeneratedByAdminLifespan": 43200,
+    "actionTokenGeneratedByUserLifespan": 300,
+    "oauth2DeviceCodeLifespan": 600,
+    "oauth2DevicePollingInterval": 5,
+    "enabled": true,
+    "sslRequired": "external",
+    "registrationAllowed": true,
+    "registrationEmailAsUsername": false,
+    "rememberMe": false,
+    "verifyEmail": true,
+    "loginWithEmailAllowed": true,
+    "duplicateEmailsAllowed": false,
+    "resetPasswordAllowed": true,
+    "editUsernameAllowed": false,
+    "bruteForceProtected": true,
+    "permanentLockout": true,
+    "maxTemporaryLockouts": 0,
+    "maxFailureWaitSeconds": 900,
+    "minimumQuickLoginWaitSeconds": 60,
+    "waitIncrementSeconds": 60,
+    "quickLoginCheckMilliSeconds": 1000,
+    "maxDeltaTimeSeconds": 43200,
+    "failureFactor": 5,
+    "users": [
+        {
+            "id": "123",
+            "username": "testing_user",
+            "enabled": "true",
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "testingpassword1!!"
+                }
+            ],
+            "firstName": "Testing",
+            "lastName": "User",
+            "email": "testinguser@gmail.com",
+            "emailVerified": true,
+            "realmRoles": ["default-roles-uds"]
         }
-      }
     ],
-    "identityProviderMappers": [
-      {
-        "id": "24c62f1a-9da4-4758-bc97-3310e04ea73b",
-        "name": "Email Mapper",
-        "identityProviderAlias": "saml",
-        "identityProviderMapper": "saml-user-attribute-idp-mapper",
-        "config": {
-          "syncMode": "INHERIT",
-          "user.attribute": "email",
-          "attribute.friendly.name": "email",
-          "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
-          "attribute.name": "email"
+    "roles": {
+        "realm": [
+            {
+                "id": "9630aa66-af3d-4704-9063-a80c25fb24ae",
+                "name": "uma_authorization",
+                "description": "${role_uma_authorization}",
+                "composite": false,
+                "clientRole": false,
+                "containerId": "uds",
+                "attributes": {}
+            },
+            {
+                "id": "ee67a20a-d607-4ed8-8a77-f11f92e7157f",
+                "name": "offline_access",
+                "description": "${role_offline-access}",
+                "composite": false,
+                "clientRole": false,
+                "containerId": "uds",
+                "attributes": {}
+            },
+            {
+                "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
+                "name": "default-roles-uds",
+                "description": "${role_default-roles}",
+                "composite": true,
+                "composites": {
+                    "realm": [
+                        "offline_access",
+                        "uma_authorization"
+                    ],
+                    "client": {
+                        "account": [
+                            "manage-account",
+                            "view-profile",
+                            "view-groups"
+                        ]
+                    }
+                },
+                "clientRole": false,
+                "containerId": "uds",
+                "attributes": {}
+            }
+        ],
+        "client": {
+            "realm-management": [
+                {
+                    "id": "b97936e6-d425-4dd2-a828-1444065d7b69",
+                    "name": "query-users",
+                    "description": "${role_query-users}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "89f798f8-f316-4588-8eef-51bfb0afb50a",
+                    "name": "view-authorization",
+                    "description": "${role_view-authorization}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "5d2ee7fb-0c5c-4abe-9424-5a6df6a2a9e3",
+                    "name": "query-realms",
+                    "description": "${role_query-realms}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "8dfc18ae-276f-4b8c-921c-3fad62390679",
+                    "name": "create-client",
+                    "description": "${role_create-client}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "145a11f5-38ba-46ff-aa7d-050780ff43d8",
+                    "name": "impersonation",
+                    "description": "${role_impersonation}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "8b6f75e9-fb44-40de-a998-c68f816a44fc",
+                    "name": "view-events",
+                    "description": "${role_view-events}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "1c07b7e2-3d16-428c-b68b-e3064f230ced",
+                    "name": "manage-authorization",
+                    "description": "${role_manage-authorization}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "ed54aef5-cac0-47b5-ab8b-fd2852835569",
+                    "name": "query-clients",
+                    "description": "${role_query-clients}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "997c82fa-0963-4161-80ba-6a93240c7328",
+                    "name": "view-identity-providers",
+                    "description": "${role_view-identity-providers}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "db96dcd7-7322-4e63-a45d-f3cb79d2735f",
+                    "name": "realm-admin",
+                    "description": "${role_realm-admin}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "realm-management": [
+                                "view-authorization",
+                                "query-users",
+                                "query-realms",
+                                "impersonation",
+                                "view-events",
+                                "create-client",
+                                "manage-authorization",
+                                "view-identity-providers",
+                                "query-clients",
+                                "view-clients",
+                                "query-groups",
+                                "manage-realm",
+                                "manage-identity-providers",
+                                "view-users",
+                                "manage-events",
+                                "manage-clients",
+                                "manage-users",
+                                "view-realm"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "f5a79a5f-2081-49c4-b5f2-a4de65872324",
+                    "name": "view-clients",
+                    "description": "${role_view-clients}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "realm-management": [
+                                "query-clients"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "b06aa3b9-2158-4368-a1c0-923ec601b612",
+                    "name": "query-groups",
+                    "description": "${role_query-groups}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "ea696cf6-a201-4959-8eb6-21ae767f55e2",
+                    "name": "manage-realm",
+                    "description": "${role_manage-realm}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "df80d4c8-5414-4fef-863f-2567e9ed3c06",
+                    "name": "manage-identity-providers",
+                    "description": "${role_manage-identity-providers}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "a59628c5-c193-4cee-9714-ec6936104f31",
+                    "name": "view-users",
+                    "description": "${role_view-users}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "realm-management": [
+                                "query-groups",
+                                "query-users"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "76358e4d-eb1c-4d20-9fc6-4a1fe66ce547",
+                    "name": "manage-events",
+                    "description": "${role_manage-events}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "0d86a9c9-d218-48ca-b362-b9cfb9f1cec7",
+                    "name": "manage-clients",
+                    "description": "${role_manage-clients}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "8daa5681-8c5e-4842-9454-f3ee52542b62",
+                    "name": "manage-users",
+                    "description": "${role_manage-users}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                },
+                {
+                    "id": "4b1f822c-9ad8-4f64-abac-d6d67d8b5c27",
+                    "name": "view-realm",
+                    "description": "${role_view-realm}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                    "attributes": {}
+                }
+            ],
+            "security-admin-console": [],
+            "admin-cli": [],
+            "account-console": [],
+            "broker": [
+                {
+                    "id": "7781303d-b0d3-4c73-bfb8-4aafb4c6fe20",
+                    "name": "read-token",
+                    "description": "${role_read-token}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
+                    "attributes": {}
+                }
+            ],
+            "account": [
+                {
+                    "id": "66091206-7730-446e-9a55-7c68c990d60a",
+                    "name": "manage-consent",
+                    "description": "${role_manage-consent}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "account": [
+                                "view-consent"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                },
+                {
+                    "id": "b945fcb1-4882-4d55-bfac-dfdc8923ba80",
+                    "name": "view-applications",
+                    "description": "${role_view-applications}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                },
+                {
+                    "id": "1b79071c-e0c6-4b14-980d-a673410308f5",
+                    "name": "manage-account",
+                    "description": "${role_manage-account}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "account": [
+                                "manage-account-links"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                },
+                {
+                    "id": "76fb4026-c5e6-4a7c-948d-ef46cc837852",
+                    "name": "view-profile",
+                    "description": "${role_view-profile}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                },
+                {
+                    "id": "7a3e2678-e64d-43b7-a749-fd91c5f8e415",
+                    "name": "view-groups",
+                    "description": "${role_view-groups}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                },
+                {
+                    "id": "93feab65-1196-499a-ad78-c3d38b26a653",
+                    "name": "manage-account-links",
+                    "description": "${role_manage-account-links}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                },
+                {
+                    "id": "a985566b-6df2-48e5-a81d-f23f1509a074",
+                    "name": "delete-account",
+                    "description": "${role_delete-account}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                },
+                {
+                    "id": "8c9f1ab5-a69e-40e2-bf2f-294f6d483ce1",
+                    "name": "view-consent",
+                    "description": "${role_view-consent}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                    "attributes": {}
+                }
+            ]
         }
-      },
-      {
-        "id": "ae4f9a94-5e70-4eb2-be9f-752b7401f98e",
-        "name": "Admin Group Mapper",
-        "identityProviderAlias": "saml",
-        "identityProviderMapper": "saml-advanced-group-idp-mapper",
-        "config": {
-          "syncMode": "INHERIT",
-          "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_ADMIN_GROUP}\"}]",
-          "group": "/UDS Core/Admin"
+    },
+    "groups": [
+        {
+            "id": "53521ed0-aa44-4007-9727-0015d5281c3e",
+            "name": "UDS Core",
+            "path": "/UDS Core",
+            "subGroups": [
+                {
+                    "id": "1ce48bde-e0e9-4bac-8b77-8b4cc96d2135",
+                    "name": "Admin",
+                    "path": "/UDS Core/Admin",
+                    "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
+                },
+                {
+                    "id": "03a34e8e-be2d-44cd-8ad2-75e90e28f6d9",
+                    "name": "Auditor",
+                    "path": "/UDS Core/Auditor",
+                    "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
+                }
+            ]
         }
-      },
-      {
-        "id": "ea435551-17dc-4096-8a26-e4585b48dbfa",
-        "name": "Auditor Group Mapper",
-        "identityProviderAlias": "saml",
-        "identityProviderMapper": "saml-advanced-group-idp-mapper",
-        "config": {
-          "syncMode": "INHERIT",
-          "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_AUDITOR_GROUP}\"}]",
-          "group": "/UDS Core/Auditor"
-        }
-      },
-      {
-        "id": "9492c99f-6d42-4127-9b29-4230b69f17b0",
-        "name": "firstName Mapper",
-        "identityProviderAlias": "saml",
-        "identityProviderMapper": "saml-user-attribute-idp-mapper",
-        "config": {
-          "syncMode": "INHERIT",
-          "user.attribute": "firstName",
-          "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
-          "attribute.name": "firstName"
-        }
-      },
-      {
-        "id": "affcb9cd-e27d-459f-8d69-c2b16ba5e5f7",
-        "name": "lastName Mapper",
-        "identityProviderAlias": "saml",
-        "identityProviderMapper": "saml-user-attribute-idp-mapper",
-        "config": {
-          "syncMode": "INHERIT",
-          "user.attribute": "lastName",
-          "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
-          "attribute.name": "lastName"
-        }
-      }
     ],
-  "components": {
-      "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
-          {
-              "id": "ccd57f68-3f54-4f9b-b2a7-47cbbedefe84",
-              "name": "Allowed Client Scopes",
-              "providerId": "allowed-client-templates",
-              "subType": "anonymous",
-              "subComponents": {},
-              "config": {
-                  "allow-default-scopes": [
-                      "true"
-                  ],
-                  "allowed-client-scopes": [
-                      "openid"
-                  ]
-              }
-          },
-          {
-              "id": "7717935d-a03c-46e0-82fd-78be66dab63b",
-              "name": "Allowed Client Scopes",
-              "providerId": "allowed-client-templates",
-              "subType": "authenticated",
-              "subComponents": {},
-              "config": {
-                  "allow-default-scopes": [
-                      "true"
-                  ]
-              }
-          },
-          {
-              "id": "e3d72400-e970-4fd1-85c6-130d1f0e9b4c",
-              "name": "Full Scope Disabled",
-              "providerId": "scope",
-              "subType": "anonymous",
-              "subComponents": {},
-              "config": {}
-          },
-          {
-              "id": "0bc6c803-7a6d-46dd-b4d9-4118d7fd465b",
-              "name": "Trusted Hosts",
-              "providerId": "trusted-hosts",
-              "subType": "anonymous",
-              "subComponents": {},
-              "config": {
-                  "host-sending-registration-request-must-match": [
-                      "true"
-                  ],
-                  "trusted-hosts": [
-                      "127.0.0.6",
-                      "*.${UDS_DOMAIN}",
-                      "*.admin.${UDS_DOMAIN}"
-                  ],
-                  "client-uris-must-match": [
-                      "true"
-                  ]
-              }
-          }
-      ],
-      "org.keycloak.userprofile.UserProfileProvider": [
-          {
-            "id": "3c5c068c-c9a5-4d68-8373-b30ae5e54c9c",
-            "providerId": "declarative-user-profile",
-            "subComponents": {},
-            "config": {
-              "kc.user.profile.config": [
-                "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
-              ]
+    "defaultRole": {
+        "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
+        "name": "default-roles-uds",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "clientRole": false,
+        "containerId": "uds"
+    },
+    "requiredCredentials": [
+        "password"
+    ],
+    "passwordPolicy": "${REALM_PASSWORD_POLICY}",
+    "otpPolicyType": "totp",
+    "otpPolicyAlgorithm": "HmacSHA1",
+    "otpPolicyInitialCounter": 0,
+    "otpPolicyDigits": 6,
+    "otpPolicyLookAheadWindow": 3,
+    "otpPolicyPeriod": 30,
+    "otpPolicyCodeReusable": false,
+    "otpSupportedApplications": [
+        "totpAppFreeOTPName",
+        "totpAppGoogleName",
+        "totpAppMicrosoftAuthenticatorName"
+    ],
+    "localizationTexts": {},
+    "webAuthnPolicyRpEntityName": "keycloak",
+    "webAuthnPolicySignatureAlgorithms": [
+        "ES256"
+    ],
+    "webAuthnPolicyRpId": "",
+    "webAuthnPolicyAttestationConveyancePreference": "not specified",
+    "webAuthnPolicyAuthenticatorAttachment": "not specified",
+    "webAuthnPolicyRequireResidentKey": "not specified",
+    "webAuthnPolicyUserVerificationRequirement": "not specified",
+    "webAuthnPolicyCreateTimeout": 0,
+    "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+    "webAuthnPolicyAcceptableAaguids": [],
+    "webAuthnPolicyExtraOrigins": [],
+    "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+    "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+        "ES256"
+    ],
+    "webAuthnPolicyPasswordlessRpId": "",
+    "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+    "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+    "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+    "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+    "webAuthnPolicyPasswordlessCreateTimeout": 0,
+    "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+    "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+    "webAuthnPolicyPasswordlessExtraOrigins": [],
+    "scopeMappings": [
+        {
+            "clientScope": "offline_access",
+            "roles": [
+                "offline_access"
+            ]
+        }
+    ],
+    "clientScopeMappings": {
+        "account": [
+            {
+                "client": "account-console",
+                "roles": [
+                    "manage-account",
+                    "view-groups"
+                ]
             }
-          }
-      ],
-      "org.keycloak.keys.KeyProvider": [
-          {
-              "id": "649a4094-5312-4249-811d-82dcb8d1c5f8",
-              "name": "aes-generated",
-              "providerId": "aes-generated",
-              "subComponents": {},
-              "config": {
-                  "priority": [
-                      "100"
-                  ]
-              }
-          },
-          {
-              "id": "d4be2127-76f9-4539-b5cf-061ef408c1df",
-              "name": "rsa-generated",
-              "providerId": "rsa-generated",
-              "subComponents": {},
-              "config": {
-                  "priority": [
-                      "100"
-                  ]
-              }
-          },
-          {
-            "id": "df923c3c-a0ef-457c-b66c-f2c623c87586",
-            "name": "fallback-HS512",
-            "providerId": "hmac-generated",
-            "subComponents": {},
-            "config": {
-              "priority": [
-                "-100"
-              ],
-              "algorithm": [
-                "HS512"
-              ]
+        ]
+    },
+    "clients": [
+        {
+            "id": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "clientId": "account",
+            "name": "Account",
+            "description": "",
+            "rootUrl": "${authBaseUrl}",
+            "adminUrl": "",
+            "baseUrl": "/realms/uds/account/",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [
+                "/realms/uds/account/*"
+            ],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "oidc.ciba.grant.enabled": "false",
+                "backchannel.logout.session.required": "true",
+                "post.logout.redirect.uris": "+",
+                "oauth2.device.authorization.grant.enabled": "false",
+                "display.on.consent.screen": "false",
+                "backchannel.logout.revoke.offline.tokens": "false"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "f5c075d3-33ea-4bd6-8629-a3ecbeda72d9",
+            "clientId": "account-console",
+            "name": "My Account",
+            "description": "",
+            "rootUrl": "${authBaseUrl}",
+            "adminUrl": "",
+            "baseUrl": "/realms/uds/account/",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [
+                "/realms/uds/account/*"
+            ],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "oidc.ciba.grant.enabled": "false",
+                "backchannel.logout.session.required": "true",
+                "post.logout.redirect.uris": "+",
+                "oauth2.device.authorization.grant.enabled": "false",
+                "display.on.consent.screen": "false",
+                "pkce.code.challenge.method": "S256",
+                "backchannel.logout.revoke.offline.tokens": "false"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "protocolMappers": [
+                {
+                    "id": "254c52b4-d381-4612-a26f-ba7586d1d9a3",
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                }
+            ],
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "deca352c-0907-40ca-aea7-ea92792d6246",
+            "clientId": "admin-cli",
+            "name": "${client_admin-cli}",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": false,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": true,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "post.logout.redirect.uris": "+"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
+            "clientId": "broker",
+            "name": "Broker",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": true,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": false,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "post.logout.redirect.uris": "+"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "clientId": "realm-management",
+            "name": "Realm Management",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": true,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": false,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "post.logout.redirect.uris": "+"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "51bb67ac-a911-4594-96fa-0c9af22daead",
+            "clientId": "security-admin-console",
+            "name": "Security Admin Console",
+            "description": "",
+            "rootUrl": "${authAdminUrl}",
+            "adminUrl": "",
+            "baseUrl": "/admin/uds/console/",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [
+                "/admin/uds/console/*"
+            ],
+            "webOrigins": [
+                "+"
+            ],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "oidc.ciba.grant.enabled": "false",
+                "backchannel.logout.session.required": "true",
+                "post.logout.redirect.uris": "+",
+                "oauth2.device.authorization.grant.enabled": "false",
+                "display.on.consent.screen": "false",
+                "pkce.code.challenge.method": "S256",
+                "backchannel.logout.revoke.offline.tokens": "false"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "protocolMappers": [
+                {
+                    "id": "461284ab-c557-4d08-9ade-0328d2d6d0c0",
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "locale",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "locale",
+                        "jsonType.label": "String"
+                    }
+                }
+            ],
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        }
+    ],
+    "clientScopes": [
+        {
+            "id": "ad5955d0-5a02-4d77-9729-c9c50e3c614f",
+            "name": "role_list",
+            "description": "SAML role list",
+            "protocol": "saml",
+            "attributes": {
+                "consent.screen.text": "${samlRoleListScopeConsentText}",
+                "display.on.consent.screen": "true"
+            },
+            "protocolMappers": [
+                {
+                    "id": "8dbe7da2-9fae-4e24-b258-adffce4af581",
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "single": "false",
+                        "attribute.nameformat": "Basic",
+                        "attribute.name": "Role"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "a56e312f-85f1-4c48-9822-b2c73ec29fef",
+            "name": "phone",
+            "description": "OpenID Connect built-in scope: phone",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${phoneScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "5cb0a293-9545-4125-9a93-be8ff09805e8",
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "phoneNumber",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "phone_number",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "f70f8a3d-2ef3-4b05-a33d-0b825406c703",
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "phoneNumberVerified",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "phone_number_verified",
+                        "jsonType.label": "boolean"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "6970f878-3093-40f0-b48e-a749087760dc",
+            "name": "microprofile-jwt",
+            "description": "Microprofile - JWT built-in scope",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "false"
+            },
+            "protocolMappers": [
+                {
+                    "id": "b1994403-6493-4e5c-92bf-b41db1342f74",
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "username",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "upn",
+                        "jsonType.label": "String"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "15fd77dc-7f74-4c66-83bb-0b9350c6b554",
+            "name": "email",
+            "description": "OpenID Connect built-in scope: email",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${emailScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "381b388d-b090-47b5-be92-713204f48163",
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "email",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "email",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "eb386cd0-5efc-4087-ac56-8b3d0530a950",
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "emailVerified",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "email_verified",
+                        "jsonType.label": "boolean"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "752a2fd8-ace8-407c-a1bf-d74f7f14b79c",
+            "name": "profile",
+            "description": "OpenID Connect built-in scope: profile",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${profileScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "ca69a4e5-c386-477f-9f92-d4cc90e3e9c6",
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "picture",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "picture",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "7d126b72-cc83-45b7-8213-e5a2e52df40d",
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "website",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "website",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "57a93d89-f1e0-4fb6-9abb-c709f5b265a5",
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "zoneinfo",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "zoneinfo",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "958c9a5d-87a8-4c93-989e-3e41283bab1f",
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "birthdate",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "birthdate",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "2f254814-1025-4290-8008-7a9ed422e53c",
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "username",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "preferred_username",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "1b28f611-9197-43cf-a1af-ac6a404553d6",
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "locale",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "locale",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "fa02cb75-2f6c-44ee-b9b7-103efd0ae92b",
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "middleName",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "middle_name",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "92b04117-abb1-4afe-ab2d-4863671d4b11",
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "updatedAt",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "updated_at",
+                        "jsonType.label": "long"
+                    }
+                },
+                {
+                    "id": "f5965fdb-2351-4681-b0d6-8576f4b2186d",
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "nickname",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "nickname",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "574469f2-13ec-4240-ad18-f8ac02374cab",
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "firstName",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "given_name",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "39ed2777-22c8-428d-893e-3df346eea7e4",
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-group-membership-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "full.path": "true",
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "multivalued": "true",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "groups"
+                    }
+                },
+                {
+                    "id": "6d52407c-f35d-4f1f-8fee-46a3c1d25afe",
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "id.token.claim": "true",
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true",
+                        "userinfo.token.claim": "true"
+                    }
+                },
+                {
+                    "id": "e7dedcf0-2b37-45bd-a31c-f7a2b7f3c5ac",
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "lastName",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "family_name",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "bd488196-dcbf-434f-90ba-0a8b5f9a9e27",
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "gender",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "gender",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "f16482ec-79c4-491b-b1a7-67a14c882be5",
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "profile",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "profile",
+                        "jsonType.label": "String"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "1a66d616-6eb0-45d7-89f7-df975f26a88e",
+            "name": "roles",
+            "description": "OpenID Connect scope for add user roles to the access token",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "false",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${rolesScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "17a0e011-6792-4112-b787-e3748e2fe255",
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "multivalued": "true",
+                        "user.attribute": "foo",
+                        "access.token.claim": "true",
+                        "claim.name": "realm_access.roles",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "e91b9e2a-b20e-47c5-bb72-e4e999c0f9a7",
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true"
+                    }
+                },
+                {
+                    "id": "021aabc9-aca3-4a31-9fa4-3b4d4fc5d129",
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "multivalued": "true",
+                        "user.attribute": "foo",
+                        "access.token.claim": "true",
+                        "claim.name": "resource_access.${client_id}.roles",
+                        "jsonType.label": "String"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "80bca4fb-c991-4f47-b941-90033d417619",
+            "name": "web-origins",
+            "description": "OpenID Connect scope for add allowed web origins to the access token",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "false",
+                "display.on.consent.screen": "false",
+                "consent.screen.text": ""
+            },
+            "protocolMappers": [
+                {
+                    "id": "65298359-14d0-4291-899e-3ca27dbf283b",
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "770edec1-8367-40cc-834c-ee2ef116cb0a",
+            "name": "offline_access",
+            "description": "OpenID Connect built-in scope: offline_access",
+            "protocol": "openid-connect",
+            "attributes": {
+                "consent.screen.text": "${offlineAccessScopeConsentText}",
+                "display.on.consent.screen": "true"
             }
-          },
-          {
-              "id": "40f57a34-8abf-4464-9f74-40566c215dc6",
-              "name": "hmac-generated",
-              "providerId": "hmac-generated",
+        },
+        {
+            "id": "0c4e8857-3a4c-4ef6-bac7-952b24a7591e",
+            "name": "acr",
+            "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "false",
+                "display.on.consent.screen": "false"
+            },
+            "protocolMappers": [
+                {
+                    "id": "3db9f004-36c9-4154-a076-6f027699aad4",
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "id.token.claim": "true",
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true",
+                        "userinfo.token.claim": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "76a50ab0-c3e2-4224-b89f-6cec16ab87c4",
+            "name": "address",
+            "description": "OpenID Connect built-in scope: address",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${addressScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "ab3891ab-f49e-4f23-b6fd-d456c0084d9b",
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "user.attribute.formatted": "formatted",
+                        "user.attribute.country": "country",
+                        "introspection.token.claim": "true",
+                        "user.attribute.postal_code": "postal_code",
+                        "userinfo.token.claim": "true",
+                        "user.attribute.street": "street",
+                        "id.token.claim": "true",
+                        "user.attribute.region": "region",
+                        "access.token.claim": "true",
+                        "user.attribute.locality": "locality"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "52fa0872-8912-4096-a124-da2c077b5539",
+            "name": "openid",
+            "description": "OpenID Connect built-in scope: openid",
+            "protocol": "openid-connect",
+            "attributes": {
+              "include.in.token.scope": "true",
+              "display.on.consent.screen": "true"
+            }
+        }
+    ],
+    "defaultDefaultClientScopes": [
+        "role_list",
+        "profile",
+        "email",
+        "roles",
+        "web-origins",
+        "acr"
+    ],
+    "defaultOptionalClientScopes": [
+        "offline_access",
+        "address",
+        "phone",
+        "microprofile-jwt"
+    ],
+    "browserSecurityHeaders": {
+        "contentSecurityPolicyReportOnly": "",
+        "xContentTypeOptions": "nosniff",
+        "referrerPolicy": "no-referrer",
+        "xRobotsTag": "none",
+        "xFrameOptions": "SAMEORIGIN",
+        "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+        "xXSSProtection": "1; mode=block",
+        "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+    },
+    "smtpServer": {},
+    "loginTheme": "theme",
+    "accountTheme": "theme",
+    "eventsEnabled": true,
+    "eventsExpiration": 1800,
+    "eventsListeners": [
+        "jboss-logging",
+        "custom-registration-listener"
+    ],
+    "enabledEventTypes": [
+        "SEND_RESET_PASSWORD",
+        "UPDATE_CONSENT_ERROR",
+        "GRANT_CONSENT",
+        "REMOVE_TOTP",
+        "REVOKE_GRANT",
+        "UPDATE_TOTP",
+        "LOGIN_ERROR",
+        "CLIENT_LOGIN",
+        "RESET_PASSWORD_ERROR",
+        "IMPERSONATE_ERROR",
+        "CODE_TO_TOKEN_ERROR",
+        "CUSTOM_REQUIRED_ACTION",
+        "RESTART_AUTHENTICATION",
+        "IMPERSONATE",
+        "UPDATE_PROFILE_ERROR",
+        "LOGIN",
+        "UPDATE_PASSWORD_ERROR",
+        "CLIENT_INITIATED_ACCOUNT_LINKING",
+        "TOKEN_EXCHANGE",
+        "LOGOUT",
+        "REGISTER",
+        "CLIENT_REGISTER",
+        "IDENTITY_PROVIDER_LINK_ACCOUNT",
+        "UPDATE_PASSWORD",
+        "CLIENT_DELETE",
+        "FEDERATED_IDENTITY_LINK_ERROR",
+        "IDENTITY_PROVIDER_FIRST_LOGIN",
+        "CLIENT_DELETE_ERROR",
+        "VERIFY_EMAIL",
+        "CLIENT_LOGIN_ERROR",
+        "RESTART_AUTHENTICATION_ERROR",
+        "EXECUTE_ACTIONS",
+        "REMOVE_FEDERATED_IDENTITY_ERROR",
+        "TOKEN_EXCHANGE_ERROR",
+        "PERMISSION_TOKEN",
+        "SEND_IDENTITY_PROVIDER_LINK_ERROR",
+        "EXECUTE_ACTION_TOKEN_ERROR",
+        "SEND_VERIFY_EMAIL",
+        "EXECUTE_ACTIONS_ERROR",
+        "REMOVE_FEDERATED_IDENTITY",
+        "IDENTITY_PROVIDER_POST_LOGIN",
+        "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
+        "UPDATE_EMAIL",
+        "REGISTER_ERROR",
+        "REVOKE_GRANT_ERROR",
+        "EXECUTE_ACTION_TOKEN",
+        "LOGOUT_ERROR",
+        "UPDATE_EMAIL_ERROR",
+        "CLIENT_UPDATE_ERROR",
+        "UPDATE_PROFILE",
+        "CLIENT_REGISTER_ERROR",
+        "FEDERATED_IDENTITY_LINK",
+        "SEND_IDENTITY_PROVIDER_LINK",
+        "SEND_VERIFY_EMAIL_ERROR",
+        "RESET_PASSWORD",
+        "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
+        "UPDATE_CONSENT",
+        "REMOVE_TOTP_ERROR",
+        "VERIFY_EMAIL_ERROR",
+        "SEND_RESET_PASSWORD_ERROR",
+        "CLIENT_UPDATE",
+        "CUSTOM_REQUIRED_ACTION_ERROR",
+        "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
+        "UPDATE_TOTP_ERROR",
+        "CODE_TO_TOKEN",
+        "GRANT_CONSENT_ERROR",
+        "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
+    ],
+    "adminEventsEnabled": true,
+    "adminEventsDetailsEnabled": true,
+    "identityProviders": [
+        {
+          "alias": "saml",
+          "displayName": "Google SSO",
+          "internalId": "1538a301-8427-46d2-b59f-203f2f76e573",
+          "providerId": "saml",
+          "enabled": "${REALM_GOOGLE_IDP_ENABLED}",
+          "updateProfileFirstLoginMode": "on",
+          "trustEmail": true,
+          "storeToken": false,
+          "addReadTokenRoleOnCreate": false,
+          "authenticateByDefault": false,
+          "linkOnly": false,
+          "config": {
+            "postBindingLogout": "false",
+            "postBindingResponse": "true",
+            "backchannelSupported": "false",
+            "idpEntityId": "https://accounts.google.com/o/saml2?idpid=${REALM_GOOGLE_IDP_ID}",
+            "loginHint": "false",
+            "allowCreate": "true",
+            "enabledFromMetadata": "true",
+            "singleSignOnServiceUrl": "https://accounts.google.com/o/saml2/idp?idpid=${REALM_GOOGLE_IDP_ID}",
+            "wantAuthnRequestsSigned": "false",
+            "allowedClockSkew": "0",
+            "validateSignature": "false",
+            "signingCertificate": "${REALM_GOOGLE_IDP_SIGNING_CERT}",
+            "nameIDPolicyFormat": "${REALM_GOOGLE_IDP_NAME_ID_FORMAT}",
+            "entityId": "${REALM_GOOGLE_IDP_CORE_ENTITY_ID}",
+            "signSpMetadata": "false",
+            "wantAssertionsEncrypted": "false",
+            "sendClientIdOnLogout": "false",
+            "wantAssertionsSigned": "false",
+            "sendIdTokenOnLogout": "true",
+            "postBindingAuthnRequest": "true",
+            "forceAuthn": "false",
+            "attributeConsumingServiceIndex": "0",
+            "addExtensionsElementWithKeyInfo": "false",
+            "principalType": "Subject NameID"
+          }
+        }
+      ],
+      "identityProviderMappers": [
+        {
+          "id": "24c62f1a-9da4-4758-bc97-3310e04ea73b",
+          "name": "Email Mapper",
+          "identityProviderAlias": "saml",
+          "identityProviderMapper": "saml-user-attribute-idp-mapper",
+          "config": {
+            "syncMode": "INHERIT",
+            "user.attribute": "email",
+            "attribute.friendly.name": "email",
+            "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+            "attribute.name": "email"
+          }
+        },
+        {
+          "id": "ae4f9a94-5e70-4eb2-be9f-752b7401f98e",
+          "name": "Admin Group Mapper",
+          "identityProviderAlias": "saml",
+          "identityProviderMapper": "saml-advanced-group-idp-mapper",
+          "config": {
+            "syncMode": "INHERIT",
+            "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_ADMIN_GROUP}\"}]",
+            "group": "/UDS Core/Admin"
+          }
+        },
+        {
+          "id": "ea435551-17dc-4096-8a26-e4585b48dbfa",
+          "name": "Auditor Group Mapper",
+          "identityProviderAlias": "saml",
+          "identityProviderMapper": "saml-advanced-group-idp-mapper",
+          "config": {
+            "syncMode": "INHERIT",
+            "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_AUDITOR_GROUP}\"}]",
+            "group": "/UDS Core/Auditor"
+          }
+        },
+        {
+          "id": "9492c99f-6d42-4127-9b29-4230b69f17b0",
+          "name": "firstName Mapper",
+          "identityProviderAlias": "saml",
+          "identityProviderMapper": "saml-user-attribute-idp-mapper",
+          "config": {
+            "syncMode": "INHERIT",
+            "user.attribute": "firstName",
+            "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+            "attribute.name": "firstName"
+          }
+        },
+        {
+          "id": "affcb9cd-e27d-459f-8d69-c2b16ba5e5f7",
+          "name": "lastName Mapper",
+          "identityProviderAlias": "saml",
+          "identityProviderMapper": "saml-user-attribute-idp-mapper",
+          "config": {
+            "syncMode": "INHERIT",
+            "user.attribute": "lastName",
+            "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+            "attribute.name": "lastName"
+          }
+        }
+      ],
+    "components": {
+        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+            {
+                "id": "ccd57f68-3f54-4f9b-b2a7-47cbbedefe84",
+                "name": "Allowed Client Scopes",
+                "providerId": "allowed-client-templates",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {
+                    "allow-default-scopes": [
+                        "true"
+                    ],
+                    "allowed-client-scopes": [
+                        "openid"
+                    ]
+                }
+            },
+            {
+                "id": "7717935d-a03c-46e0-82fd-78be66dab63b",
+                "name": "Allowed Client Scopes",
+                "providerId": "allowed-client-templates",
+                "subType": "authenticated",
+                "subComponents": {},
+                "config": {
+                    "allow-default-scopes": [
+                        "true"
+                    ]
+                }
+            },
+            {
+                "id": "e3d72400-e970-4fd1-85c6-130d1f0e9b4c",
+                "name": "Full Scope Disabled",
+                "providerId": "scope",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {}
+            },
+            {
+                "id": "0bc6c803-7a6d-46dd-b4d9-4118d7fd465b",
+                "name": "Trusted Hosts",
+                "providerId": "trusted-hosts",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {
+                    "host-sending-registration-request-must-match": [
+                        "true"
+                    ],
+                    "trusted-hosts": [
+                        "127.0.0.6",
+                        "*.${UDS_DOMAIN}",
+                        "*.admin.${UDS_DOMAIN}"
+                    ],
+                    "client-uris-must-match": [
+                        "true"
+                    ]
+                }
+            }
+        ],
+        "org.keycloak.userprofile.UserProfileProvider": [
+            {
+              "id": "3c5c068c-c9a5-4d68-8373-b30ae5e54c9c",
+              "providerId": "declarative-user-profile",
               "subComponents": {},
               "config": {
-                  "priority": [
-                      "100"
-                  ],
-                  "algorithm": [
-                      "HS256"
-                  ]
+                "kc.user.profile.config": [
+                  "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
+                ]
               }
-          },
-          {
-              "id": "8b3e77f4-0e3c-4bbd-b539-6df8d6dfa00e",
-              "name": "rsa-enc-generated",
-              "providerId": "rsa-enc-generated",
-              "subComponents": {},
-              "config": {
-                  "priority": [
-                      "100"
-                  ],
-                  "algorithm": [
-                      "RSA-OAEP"
-                  ]
-              }
-          }
-      ]
-  },
-  "internationalizationEnabled": false,
-  "supportedLocales": [],
-  "authenticationFlows": [
-      {
-          "id": "5fca3666-0018-4ca1-8ec9-4b00deb3d8f1",
-          "alias": "Account verification options",
-          "description": "Method with which to verity the existing account",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "idp-email-verification",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 20,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Verify Existing Account by Re-authentication",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "0c528a3a-e0d7-45f5-a458-f8c23842ab75",
-          "alias": "Authentication",
-          "description": "",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "auth-cookie",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 0,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorConfig": "dod-cac",
-                  "authenticator": "auth-x509-client-username-form",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 0,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "auth-username-password-form",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 1,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "a09f8f86-3df3-4397-91e2-d9dad1678ded",
-          "alias": "Authentication Options",
-          "description": "Authentication options.",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "basic-auth",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "basic-auth-otp",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "auth-spnego",
-                  "authenticatorFlow": false,
-                  "requirement": "DISABLED",
-                  "priority": 30,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "d61e1deb-921e-412f-baed-dc51c0fdc532",
-          "alias": "Browser - Conditional OTP",
-          "description": "Flow to determine if the OTP is required for the authentication",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "conditional-user-configured",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "auth-otp-form",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
-          "alias": "Conditional OTP",
-          "description": "",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "conditional-user-configured",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 0,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "auth-otp-form",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 1,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "2a37f1ea-9a71-46bf-8c76-34c480e90521",
-          "alias": "Direct Grant - Conditional OTP",
-          "description": "Flow to determine if the OTP is required for the authentication",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "conditional-user-configured",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "direct-grant-validate-otp",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "a8c9a858-6236-4e3d-8b07-716527264327",
-          "alias": "First broker login - Conditional OTP",
-          "description": "Flow to determine if the OTP is required for the authentication",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "conditional-user-configured",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "auth-otp-form",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "b44188c2-ddf7-4268-a860-b20e32c7fbcf",
-          "alias": "Handle Existing Account",
-          "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "idp-confirm-link",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Account verification options",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
-          "alias": "MFA Login",
-          "description": "",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "auth-username-password-form",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 0,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "REQUIRED",
-                  "priority": 1,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Conditional OTP",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "459c187e-eb0f-4f2e-8e15-0c0b245a406e",
-          "alias": "Reset - Conditional OTP",
-          "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "conditional-user-configured",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "reset-otp",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "f95bc9ff-dca8-4622-87d4-e89877091cc1",
-          "alias": "UDS Authentication",
-          "description": "browser based authentication",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "REQUIRED",
-                  "priority": 31,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Authentication",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
-          "alias": "UDS Authentication Browser - Conditional OTP",
-          "description": "Flow to determine if the OTP is required for the authentication",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "conditional-user-configured",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "auth-otp-form",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "2122677b-1a02-40a4-817b-66da58b1621a",
-          "alias": "UDS Registration",
-          "description": "registration flow",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "registration-page-form",
-                  "authenticatorFlow": true,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": true,
-                  "flowAlias": "UDS registration form",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "7f506bd3-70f7-4f99-b339-a57e5e4cb456",
-          "alias": "UDS Reset Credentials",
-          "description": "Reset credentials for a user if they forgot their password",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "reset-credentials-choose-user",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "reset-credential-email",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "reset-password",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 30,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "25a3d7b4-3d46-4d66-9a14-0fd4be935dff",
-          "alias": "UDS registration form",
-          "description": "registration form",
-          "providerId": "form-flow",
-          "topLevel": false,
-          "builtIn": false,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "registration-user-creation",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorConfig": "main",
-                  "authenticator": "registration-validation-action",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 50,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "registration-x509-password-action",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 51,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "51f952e6-d3ac-49bd-8e76-fd50128a2bea",
-          "alias": "User creation or linking",
-          "description": "Flow for the existing/non-existing user alternatives",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticatorConfig": "create unique user config",
-                  "authenticator": "idp-create-user-if-unique",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 20,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Handle Existing Account",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "1f94f667-ec06-4e24-9ce5-9fac2cb87892",
-          "alias": "Verify Existing Account by Re-authentication",
-          "description": "Reauthentication of existing account",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "idp-username-password-form",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "CONDITIONAL",
-                  "priority": 20,
-                  "autheticatorFlow": true,
-                  "flowAlias": "First broker login - Conditional OTP",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "128fa0e2-a2e5-4d99-87e8-e60aa672d516",
-          "alias": "browser",
-          "description": "browser based authentication",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "auth-cookie",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "auth-spnego",
-                  "authenticatorFlow": false,
-                  "requirement": "DISABLED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "identity-provider-redirector",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 25,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 30,
-                  "autheticatorFlow": true,
-                  "flowAlias": "forms",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "3053f59e-b554-4573-9a96-092b12cf9cfb",
-          "alias": "clients",
-          "description": "Base authentication for clients",
-          "providerId": "client-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "client-secret",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "client-jwt",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "client-secret-jwt",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 30,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "client-x509",
-                  "authenticatorFlow": false,
-                  "requirement": "ALTERNATIVE",
-                  "priority": 40,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "3b482c5b-59c5-4786-88f8-09123324d74d",
-          "alias": "direct grant",
-          "description": "OpenID Connect Resource Owner Grant",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "direct-grant-validate-username",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "direct-grant-validate-password",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "CONDITIONAL",
-                  "priority": 30,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Direct Grant - Conditional OTP",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "a2e76a41-9a2a-43ce-8a32-e82782f00d98",
-          "alias": "docker auth",
-          "description": "Used by Docker clients to authenticate against the IDP",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "docker-http-basic-authenticator",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "5785e630-7e91-4899-877d-569e3ac79871",
-          "alias": "first broker login",
-          "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticatorConfig": "review profile config",
-                  "authenticator": "idp-review-profile",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": true,
-                  "flowAlias": "User creation or linking",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "4950a920-1925-4deb-a45e-9035be7e7c2b",
-          "alias": "forms",
-          "description": "Username, password, otp and other auth forms.",
-          "providerId": "basic-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "auth-username-password-form",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "CONDITIONAL",
-                  "priority": 20,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Browser - Conditional OTP",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "458de539-a7ff-4038-968c-86066c36b825",
-          "alias": "http challenge",
-          "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "no-cookie-redirect",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Authentication Options",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "5a93f084-9395-4620-a918-47f17828cccd",
-          "alias": "registration",
-          "description": "registration flow",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "registration-page-form",
-                  "authenticatorFlow": true,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": true,
-                  "flowAlias": "registration form",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "6f96df4f-5955-4531-8af3-727a40a62e75",
-          "alias": "registration form",
-          "description": "registration form",
-          "providerId": "form-flow",
-          "topLevel": false,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "registration-user-creation",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "registration-profile-action",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 40,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "registration-password-action",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 50,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "registration-recaptcha-action",
-                  "authenticatorFlow": false,
-                  "requirement": "DISABLED",
-                  "priority": 60,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "ac02e171-c1ef-40da-be31-7b8bda5fc5ff",
-          "alias": "reset credentials",
-          "description": "Reset credentials for a user if they forgot their password or something",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "reset-credentials-choose-user",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "reset-credential-email",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 20,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticator": "reset-password",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 30,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              },
-              {
-                  "authenticatorFlow": true,
-                  "requirement": "CONDITIONAL",
-                  "priority": 40,
-                  "autheticatorFlow": true,
-                  "flowAlias": "Reset - Conditional OTP",
-                  "userSetupAllowed": false
-              }
-          ]
-      },
-      {
-          "id": "fd5f9d3b-7a95-4f93-9f5f-c839f3362e9a",
-          "alias": "saml ecp",
-          "description": "SAML ECP Profile Authentication Flow",
-          "providerId": "basic-flow",
-          "topLevel": true,
-          "builtIn": true,
-          "authenticationExecutions": [
-              {
-                  "authenticator": "http-basic-authenticator",
-                  "authenticatorFlow": false,
-                  "requirement": "REQUIRED",
-                  "priority": 10,
-                  "autheticatorFlow": false,
-                  "userSetupAllowed": false
-              }
-          ]
-      }
-  ],
-  "authenticatorConfig": [
-      {
-          "id": "bd49f97e-6ce0-42c7-b045-a16dc7a37649",
-          "alias": "create unique user config",
-          "config": {
-              "require.password.update.after.registration": "false"
-          }
-      },
-      {
-          "id": "86fd892b-86e0-4b42-944c-5b518706271c",
-          "alias": "dod-cac",
-          "config": {
-              "x509-cert-auth.canonical-dn-enabled": "false",
-              "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
-              "x509-cert-auth.serialnumber-hex-enabled": "false",
-              "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
-              "x509-cert-auth.regular-expression": "(.*?)(?:$)",
-              "x509-cert-auth.certificate-policy-mode": "All",
-              "x509-cert-auth.timestamp-validation-enabled": "true",
-              "x509-cert-auth.mapper-selection": "Custom Attribute Mapper",
-              "x509-cert-auth.crl-relative-path": "crl.pem",
-              "x509-cert-auth.crldp-checking-enabled": "false",
-              "x509-cert-auth.mapping-source-selection": "Subject's Alternative Name otherName (UPN)",
-              "x509-cert-auth.ocsp-checking-enabled": "false"
-          }
-      },
-      {
-          "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
-          "alias": "main",
-          "config": {}
-      },
-      {
-          "id": "d20d218e-9109-455d-9b03-bb453e209e81",
-          "alias": "review profile config",
-          "config": {
-              "update.profile.on.first.login": "missing"
-          }
-      }
-  ],
-  "requiredActions": [
-      {
-          "alias": "TERMS_AND_CONDITIONS",
-          "name": "Terms and Conditions",
-          "providerId": "TERMS_AND_CONDITIONS",
-          "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
-          "defaultAction": true,
-          "priority": 10,
-          "config": {}
-      },
-      {
-          "alias": "CONFIGURE_TOTP",
-          "name": "Configure OTP",
-          "providerId": "CONFIGURE_TOTP",
-          "enabled": "${REALM_OTP_ENABLED}",
-          "defaultAction": false,
-          "priority": 20,
-          "config": {}
-      },
-      {
-          "alias": "UPDATE_PASSWORD",
-          "name": "Update Password",
-          "providerId": "UPDATE_PASSWORD",
-          "enabled": true,
-          "defaultAction": false,
-          "priority": 30,
-          "config": {}
-      },
-      {
-          "alias": "UPDATE_PROFILE",
-          "name": "Update Profile",
-          "providerId": "UPDATE_PROFILE",
-          "enabled": true,
-          "defaultAction": false,
-          "priority": 40,
-          "config": {}
-      },
-      {
-          "alias": "VERIFY_EMAIL",
-          "name": "Verify Email",
-          "providerId": "VERIFY_EMAIL",
-          "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
-          "defaultAction": true,
-          "priority": 50,
-          "config": {}
-      },
-      {
-          "alias": "delete_account",
-          "name": "Delete Account",
-          "providerId": "delete_account",
-          "enabled": false,
-          "defaultAction": false,
-          "priority": 60,
-          "config": {}
-      },
-      {
-          "alias": "update_user_locale",
-          "name": "Update User Locale",
-          "providerId": "update_user_locale",
-          "enabled": false,
-          "defaultAction": false,
-          "priority": 1000,
-          "config": {}
-      },
-      {
-          "alias": "UPDATE_X509",
-          "name": "Update X509",
-          "providerId": "UPDATE_X509",
-          "enabled": true,
-          "defaultAction": false,
-          "priority": 1001,
-          "config": {}
-      }
-  ],
-  "browserFlow": "UDS Authentication",
-  "registrationFlow": "UDS Registration",
-  "directGrantFlow": "direct grant",
-  "resetCredentialsFlow": "UDS Reset Credentials",
-  "clientAuthenticationFlow": "clients",
-  "dockerAuthenticationFlow": "docker auth",
-  "attributes": {
-      "cibaBackchannelTokenDeliveryMode": "poll",
-      "cibaAuthRequestedUserHint": "login_hint",
-      "clientOfflineSessionMaxLifespan": "0",
-      "oauth2DevicePollingInterval": "5",
-      "clientSessionIdleTimeout": "0",
-      "userProfileEnabled": "false",
-      "clientOfflineSessionIdleTimeout": "0",
-      "cibaInterval": "5",
-      "realmReusableOtpCode": "false",
-      "cibaExpiresIn": "120",
-      "oauth2DeviceCodeLifespan": "600",
-      "parRequestUriLifespan": "60",
-      "clientSessionMaxLifespan": "0",
-      "frontendUrl": "",
-      "acr.loa.map": "{}"
-  },
-  "userManagedAccessAllowed": false,
-  "clientProfiles": {
-      "profiles": []
-  },
-  "clientPolicies": {
-      "policies": []
-  }
+            }
+        ],
+        "org.keycloak.keys.KeyProvider": [
+            {
+                "id": "649a4094-5312-4249-811d-82dcb8d1c5f8",
+                "name": "aes-generated",
+                "providerId": "aes-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ]
+                }
+            },
+            {
+                "id": "d4be2127-76f9-4539-b5cf-061ef408c1df",
+                "name": "rsa-generated",
+                "providerId": "rsa-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ]
+                }
+            },
+            {
+                "id": "df923c3c-a0ef-457c-b66c-f2c623c87586",
+                "name": "fallback-HS512",
+                "providerId": "hmac-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "-100"
+                    ],
+                    "algorithm": [
+                        "HS512"
+                    ]
+                }
+            },
+            {
+                "id": "40f57a34-8abf-4464-9f74-40566c215dc6",
+                "name": "hmac-generated",
+                "providerId": "hmac-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ],
+                    "algorithm": [
+                        "HS256"
+                    ]
+                }
+            },
+            {
+                "id": "8b3e77f4-0e3c-4bbd-b539-6df8d6dfa00e",
+                "name": "rsa-enc-generated",
+                "providerId": "rsa-enc-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ],
+                    "algorithm": [
+                        "RSA-OAEP"
+                    ]
+                }
+            }
+        ]
+    },
+    "internationalizationEnabled": false,
+    "supportedLocales": [],
+    "authenticationFlows": [
+        {
+            "id": "5fca3666-0018-4ca1-8ec9-4b00deb3d8f1",
+            "alias": "Account verification options",
+            "description": "Method with which to verity the existing account",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "0c528a3a-e0d7-45f5-a458-f8c23842ab75",
+            "alias": "Authentication",
+            "description": "",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 0,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorConfig": "dod-cac",
+                    "authenticator": "auth-x509-client-username-form",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 0,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 1,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "a09f8f86-3df3-4397-91e2-d9dad1678ded",
+            "alias": "Authentication Options",
+            "description": "Authentication options.",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "basic-auth",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "basic-auth-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "d61e1deb-921e-412f-baed-dc51c0fdc532",
+            "alias": "Browser - Conditional OTP",
+            "description": "Flow to determine if the OTP is required for the authentication",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
+            "alias": "Conditional OTP",
+            "description": "",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 0,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 1,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "2a37f1ea-9a71-46bf-8c76-34c480e90521",
+            "alias": "Direct Grant - Conditional OTP",
+            "description": "Flow to determine if the OTP is required for the authentication",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "a8c9a858-6236-4e3d-8b07-716527264327",
+            "alias": "First broker login - Conditional OTP",
+            "description": "Flow to determine if the OTP is required for the authentication",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "b44188c2-ddf7-4268-a860-b20e32c7fbcf",
+            "alias": "Handle Existing Account",
+            "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
+            "alias": "MFA Login",
+            "description": "",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 0,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 1,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "459c187e-eb0f-4f2e-8e15-0c0b245a406e",
+            "alias": "Reset - Conditional OTP",
+            "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "f95bc9ff-dca8-4622-87d4-e89877091cc1",
+            "alias": "UDS Authentication",
+            "description": "browser based authentication",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 31,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Authentication",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
+            "alias": "UDS Authentication Browser - Conditional OTP",
+            "description": "Flow to determine if the OTP is required for the authentication",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "2122677b-1a02-40a4-817b-66da58b1621a",
+            "alias": "UDS Registration",
+            "description": "registration flow",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "UDS registration form",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "7f506bd3-70f7-4f99-b339-a57e5e4cb456",
+            "alias": "UDS Reset Credentials",
+            "description": "Reset credentials for a user if they forgot their password",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "25a3d7b4-3d46-4d66-9a14-0fd4be935dff",
+            "alias": "UDS registration form",
+            "description": "registration form",
+            "providerId": "form-flow",
+            "topLevel": false,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorConfig": "main",
+                    "authenticator": "registration-validation-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "registration-x509-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 51,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "51f952e6-d3ac-49bd-8e76-fd50128a2bea",
+            "alias": "User creation or linking",
+            "description": "Flow for the existing/non-existing user alternatives",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "1f94f667-ec06-4e24-9ce5-9fac2cb87892",
+            "alias": "Verify Existing Account by Re-authentication",
+            "description": "Reauthentication of existing account",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "128fa0e2-a2e5-4d99-87e8-e60aa672d516",
+            "alias": "browser",
+            "description": "browser based authentication",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "3053f59e-b554-4573-9a96-092b12cf9cfb",
+            "alias": "clients",
+            "description": "Base authentication for clients",
+            "providerId": "client-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "3b482c5b-59c5-4786-88f8-09123324d74d",
+            "alias": "direct grant",
+            "description": "OpenID Connect Resource Owner Grant",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "a2e76a41-9a2a-43ce-8a32-e82782f00d98",
+            "alias": "docker auth",
+            "description": "Used by Docker clients to authenticate against the IDP",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "5785e630-7e91-4899-877d-569e3ac79871",
+            "alias": "first broker login",
+            "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "4950a920-1925-4deb-a45e-9035be7e7c2b",
+            "alias": "forms",
+            "description": "Username, password, otp and other auth forms.",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "458de539-a7ff-4038-968c-86066c36b825",
+            "alias": "http challenge",
+            "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "no-cookie-redirect",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Authentication Options",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "5a93f084-9395-4620-a918-47f17828cccd",
+            "alias": "registration",
+            "description": "registration flow",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "6f96df4f-5955-4531-8af3-727a40a62e75",
+            "alias": "registration form",
+            "description": "registration form",
+            "providerId": "form-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "registration-profile-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "ac02e171-c1ef-40da-be31-7b8bda5fc5ff",
+            "alias": "reset credentials",
+            "description": "Reset credentials for a user if they forgot their password or something",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "fd5f9d3b-7a95-4f93-9f5f-c839f3362e9a",
+            "alias": "saml ecp",
+            "description": "SAML ECP Profile Authentication Flow",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        }
+    ],
+    "authenticatorConfig": [
+        {
+            "id": "bd49f97e-6ce0-42c7-b045-a16dc7a37649",
+            "alias": "create unique user config",
+            "config": {
+                "require.password.update.after.registration": "false"
+            }
+        },
+        {
+            "id": "86fd892b-86e0-4b42-944c-5b518706271c",
+            "alias": "dod-cac",
+            "config": {
+                "x509-cert-auth.canonical-dn-enabled": "false",
+                "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
+                "x509-cert-auth.serialnumber-hex-enabled": "false",
+                "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
+                "x509-cert-auth.regular-expression": "(.*?)(?:$)",
+                "x509-cert-auth.certificate-policy-mode": "All",
+                "x509-cert-auth.timestamp-validation-enabled": "true",
+                "x509-cert-auth.mapper-selection": "Custom Attribute Mapper",
+                "x509-cert-auth.crl-relative-path": "crl.pem",
+                "x509-cert-auth.crldp-checking-enabled": "false",
+                "x509-cert-auth.mapping-source-selection": "Subject's Alternative Name otherName (UPN)",
+                "x509-cert-auth.ocsp-checking-enabled": "false"
+            }
+        },
+        {
+            "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
+            "alias": "main",
+            "config": {}
+        },
+        {
+            "id": "d20d218e-9109-455d-9b03-bb453e209e81",
+            "alias": "review profile config",
+            "config": {
+                "update.profile.on.first.login": "missing"
+            }
+        }
+    ],
+    "requiredActions": [
+        {
+            "alias": "TERMS_AND_CONDITIONS",
+            "name": "Terms and Conditions",
+            "providerId": "TERMS_AND_CONDITIONS",
+            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
+            "defaultAction": true,
+            "priority": 10,
+            "config": {}
+        },
+        {
+            "alias": "CONFIGURE_TOTP",
+            "name": "Configure OTP",
+            "providerId": "CONFIGURE_TOTP",
+            "enabled": "${REALM_OTP_ENABLED}",
+            "defaultAction": false,
+            "priority": 20,
+            "config": {}
+        },
+        {
+            "alias": "UPDATE_PASSWORD",
+            "name": "Update Password",
+            "providerId": "UPDATE_PASSWORD",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 30,
+            "config": {}
+        },
+        {
+            "alias": "UPDATE_PROFILE",
+            "name": "Update Profile",
+            "providerId": "UPDATE_PROFILE",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 40,
+            "config": {}
+        },
+        {
+            "alias": "VERIFY_EMAIL",
+            "name": "Verify Email",
+            "providerId": "VERIFY_EMAIL",
+            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
+            "defaultAction": true,
+            "priority": 50,
+            "config": {}
+        },
+        {
+            "alias": "delete_account",
+            "name": "Delete Account",
+            "providerId": "delete_account",
+            "enabled": false,
+            "defaultAction": false,
+            "priority": 60,
+            "config": {}
+        },
+        {
+            "alias": "update_user_locale",
+            "name": "Update User Locale",
+            "providerId": "update_user_locale",
+            "enabled": false,
+            "defaultAction": false,
+            "priority": 1000,
+            "config": {}
+        },
+        {
+            "alias": "UPDATE_X509",
+            "name": "Update X509",
+            "providerId": "UPDATE_X509",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 1001,
+            "config": {}
+        }
+    ],
+    "browserFlow": "UDS Authentication",
+    "registrationFlow": "UDS Registration",
+    "directGrantFlow": "direct grant",
+    "resetCredentialsFlow": "UDS Reset Credentials",
+    "clientAuthenticationFlow": "clients",
+    "dockerAuthenticationFlow": "docker auth",
+    "attributes": {
+        "cibaBackchannelTokenDeliveryMode": "poll",
+        "cibaAuthRequestedUserHint": "login_hint",
+        "clientOfflineSessionMaxLifespan": "0",
+        "oauth2DevicePollingInterval": "5",
+        "clientSessionIdleTimeout": "0",
+        "userProfileEnabled": "false",
+        "clientOfflineSessionIdleTimeout": "0",
+        "cibaInterval": "5",
+        "realmReusableOtpCode": "false",
+        "cibaExpiresIn": "120",
+        "oauth2DeviceCodeLifespan": "600",
+        "parRequestUriLifespan": "60",
+        "clientSessionMaxLifespan": "0",
+        "frontendUrl": "",
+        "acr.loa.map": "{}"
+    },
+    "userManagedAccessAllowed": false,
+    "clientProfiles": {
+        "profiles": []
+    },
+    "clientPolicies": {
+        "policies": []
+    }
 }

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -456,7 +456,7 @@
     "requiredCredentials": [
         "password"
     ],
-    "passwordPolicy": "${REALM_PASSWORD_POLICY}",
+    "passwordPolicy": "${REALM_PASSWORD_POLICY}:hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)",
     "otpPolicyType": "totp",
     "otpPolicyAlgorithm": "HmacSHA1",
     "otpPolicyInitialCounter": 0,
@@ -1481,7 +1481,7 @@
           "displayName": "Google SSO",
           "internalId": "1538a301-8427-46d2-b59f-203f2f76e573",
           "providerId": "saml",
-          "enabled": "${REALM_GOOGLE_IDP_ENABLED}",
+          "enabled": "${REALM_GOOGLE_IDP_ENABLED:false}",
           "updateProfileFirstLoginMode": "on",
           "trustEmail": true,
           "storeToken": false,
@@ -2531,7 +2531,7 @@
                 "x509-cert-auth.canonical-dn-enabled": "false",
                 "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
                 "x509-cert-auth.serialnumber-hex-enabled": "false",
-                "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
+                "x509-cert-auth.ocsp-fail-open": "${REALM_X509_OCSP_FAIL_OPEN:false}",
                 "x509-cert-auth.regular-expression": "(.*?)(?:$)",
                 "x509-cert-auth.certificate-policy-mode": "All",
                 "x509-cert-auth.timestamp-validation-enabled": "true",
@@ -2560,7 +2560,7 @@
             "alias": "TERMS_AND_CONDITIONS",
             "name": "Terms and Conditions",
             "providerId": "TERMS_AND_CONDITIONS",
-            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
+            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED:false}",
             "defaultAction": true,
             "priority": 10,
             "config": {}
@@ -2569,7 +2569,7 @@
             "alias": "CONFIGURE_TOTP",
             "name": "Configure OTP",
             "providerId": "CONFIGURE_TOTP",
-            "enabled": "${REALM_OTP_ENABLED}",
+            "enabled": "${REALM_OTP_ENABLED:false}",
             "defaultAction": false,
             "priority": 20,
             "config": {}
@@ -2596,7 +2596,7 @@
             "alias": "VERIFY_EMAIL",
             "name": "Verify Email",
             "providerId": "VERIFY_EMAIL",
-            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
+            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED:false}",
             "defaultAction": true,
             "priority": 50,
             "config": {}

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -39,6 +39,7 @@
     "editUsernameAllowed": false,
     "bruteForceProtected": true,
     "permanentLockout": true,
+    "maxTemporaryLockouts": 0,
     "maxFailureWaitSeconds": 900,
     "minimumQuickLoginWaitSeconds": 60,
     "waitIncrementSeconds": 60,
@@ -53,7 +54,7 @@
             "credentials": [
                 {
                     "type": "password",
-                    "value": "testingpassword!!"
+                    "value": "testingpassword1!!"
                 }
             ],
             "firstName": "Testing",
@@ -64,396 +65,396 @@
         }
     ],
     "roles": {
-        "realm": [
-            {
-                "id": "9630aa66-af3d-4704-9063-a80c25fb24ae",
-                "name": "uma_authorization",
-                "description": "${role_uma_authorization}",
-                "composite": false,
-                "clientRole": false,
-                "containerId": "uds",
-                "attributes": {}
-            },
-            {
-                "id": "ee67a20a-d607-4ed8-8a77-f11f92e7157f",
-                "name": "offline_access",
-                "description": "${role_offline-access}",
-                "composite": false,
-                "clientRole": false,
-                "containerId": "uds",
-                "attributes": {}
-            },
-            {
-                "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
-                "name": "default-roles-uds",
-                "description": "${role_default-roles}",
-                "composite": true,
-                "composites": {
-                    "realm": [
-                        "offline_access",
-                        "uma_authorization"
-                    ],
-                    "client": {
-                        "account": [
-                            "manage-account",
-                            "view-profile",
-                            "view-groups"
-                        ]
-                    }
-                },
-                "clientRole": false,
-                "containerId": "uds",
-                "attributes": {}
+      "realm": [
+        {
+          "id": "9630aa66-af3d-4704-9063-a80c25fb24ae",
+          "name": "uma_authorization",
+          "description": "${role_uma_authorization}",
+          "composite": false,
+          "clientRole": false,
+          "containerId": "uds",
+          "attributes": {}
+        },
+        {
+          "id": "ee67a20a-d607-4ed8-8a77-f11f92e7157f",
+          "name": "offline_access",
+          "description": "${role_offline-access}",
+          "composite": false,
+          "clientRole": false,
+          "containerId": "uds",
+          "attributes": {}
+        },
+        {
+          "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
+          "name": "default-roles-uds",
+          "description": "${role_default-roles}",
+          "composite": true,
+          "composites": {
+            "realm": [
+              "offline_access",
+              "uma_authorization"
+            ],
+            "client": {
+              "account": [
+                "manage-account",
+                "view-profile",
+                "view-groups"
+              ]
             }
-        ],
-        "client": {
-            "realm-management": [
-                {
-                    "id": "b97936e6-d425-4dd2-a828-1444065d7b69",
-                    "name": "query-users",
-                    "description": "${role_query-users}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "89f798f8-f316-4588-8eef-51bfb0afb50a",
-                    "name": "view-authorization",
-                    "description": "${role_view-authorization}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "5d2ee7fb-0c5c-4abe-9424-5a6df6a2a9e3",
-                    "name": "query-realms",
-                    "description": "${role_query-realms}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "8dfc18ae-276f-4b8c-921c-3fad62390679",
-                    "name": "create-client",
-                    "description": "${role_create-client}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "145a11f5-38ba-46ff-aa7d-050780ff43d8",
-                    "name": "impersonation",
-                    "description": "${role_impersonation}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "8b6f75e9-fb44-40de-a998-c68f816a44fc",
-                    "name": "view-events",
-                    "description": "${role_view-events}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "1c07b7e2-3d16-428c-b68b-e3064f230ced",
-                    "name": "manage-authorization",
-                    "description": "${role_manage-authorization}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "ed54aef5-cac0-47b5-ab8b-fd2852835569",
-                    "name": "query-clients",
-                    "description": "${role_query-clients}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "997c82fa-0963-4161-80ba-6a93240c7328",
-                    "name": "view-identity-providers",
-                    "description": "${role_view-identity-providers}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "db96dcd7-7322-4e63-a45d-f3cb79d2735f",
-                    "name": "realm-admin",
-                    "description": "${role_realm-admin}",
-                    "composite": true,
-                    "composites": {
-                        "client": {
-                            "realm-management": [
-                                "view-authorization",
-                                "query-users",
-                                "query-realms",
-                                "impersonation",
-                                "view-events",
-                                "create-client",
-                                "manage-authorization",
-                                "view-identity-providers",
-                                "query-clients",
-                                "view-clients",
-                                "query-groups",
-                                "manage-realm",
-                                "manage-identity-providers",
-                                "view-users",
-                                "manage-events",
-                                "manage-clients",
-                                "manage-users",
-                                "view-realm"
-                            ]
-                        }
-                    },
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "f5a79a5f-2081-49c4-b5f2-a4de65872324",
-                    "name": "view-clients",
-                    "description": "${role_view-clients}",
-                    "composite": true,
-                    "composites": {
-                        "client": {
-                            "realm-management": [
-                                "query-clients"
-                            ]
-                        }
-                    },
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "b06aa3b9-2158-4368-a1c0-923ec601b612",
-                    "name": "query-groups",
-                    "description": "${role_query-groups}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "ea696cf6-a201-4959-8eb6-21ae767f55e2",
-                    "name": "manage-realm",
-                    "description": "${role_manage-realm}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "df80d4c8-5414-4fef-863f-2567e9ed3c06",
-                    "name": "manage-identity-providers",
-                    "description": "${role_manage-identity-providers}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "a59628c5-c193-4cee-9714-ec6936104f31",
-                    "name": "view-users",
-                    "description": "${role_view-users}",
-                    "composite": true,
-                    "composites": {
-                        "client": {
-                            "realm-management": [
-                                "query-groups",
-                                "query-users"
-                            ]
-                        }
-                    },
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "76358e4d-eb1c-4d20-9fc6-4a1fe66ce547",
-                    "name": "manage-events",
-                    "description": "${role_manage-events}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "0d86a9c9-d218-48ca-b362-b9cfb9f1cec7",
-                    "name": "manage-clients",
-                    "description": "${role_manage-clients}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "8daa5681-8c5e-4842-9454-f3ee52542b62",
-                    "name": "manage-users",
-                    "description": "${role_manage-users}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                },
-                {
-                    "id": "4b1f822c-9ad8-4f64-abac-d6d67d8b5c27",
-                    "name": "view-realm",
-                    "description": "${role_view-realm}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-                    "attributes": {}
-                }
-            ],
-            "security-admin-console": [],
-            "admin-cli": [],
-            "account-console": [],
-            "broker": [
-                {
-                    "id": "7781303d-b0d3-4c73-bfb8-4aafb4c6fe20",
-                    "name": "read-token",
-                    "description": "${role_read-token}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
-                    "attributes": {}
-                }
-            ],
-            "account": [
-                {
-                    "id": "66091206-7730-446e-9a55-7c68c990d60a",
-                    "name": "manage-consent",
-                    "description": "${role_manage-consent}",
-                    "composite": true,
-                    "composites": {
-                        "client": {
-                            "account": [
-                                "view-consent"
-                            ]
-                        }
-                    },
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                },
-                {
-                    "id": "b945fcb1-4882-4d55-bfac-dfdc8923ba80",
-                    "name": "view-applications",
-                    "description": "${role_view-applications}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                },
-                {
-                    "id": "1b79071c-e0c6-4b14-980d-a673410308f5",
-                    "name": "manage-account",
-                    "description": "${role_manage-account}",
-                    "composite": true,
-                    "composites": {
-                        "client": {
-                            "account": [
-                                "manage-account-links"
-                            ]
-                        }
-                    },
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                },
-                {
-                    "id": "76fb4026-c5e6-4a7c-948d-ef46cc837852",
-                    "name": "view-profile",
-                    "description": "${role_view-profile}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                },
-                {
-                    "id": "7a3e2678-e64d-43b7-a749-fd91c5f8e415",
-                    "name": "view-groups",
-                    "description": "${role_view-groups}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                },
-                {
-                    "id": "93feab65-1196-499a-ad78-c3d38b26a653",
-                    "name": "manage-account-links",
-                    "description": "${role_manage-account-links}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                },
-                {
-                    "id": "a985566b-6df2-48e5-a81d-f23f1509a074",
-                    "name": "delete-account",
-                    "description": "${role_delete-account}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                },
-                {
-                    "id": "8c9f1ab5-a69e-40e2-bf2f-294f6d483ce1",
-                    "name": "view-consent",
-                    "description": "${role_view-consent}",
-                    "composite": false,
-                    "clientRole": true,
-                    "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-                    "attributes": {}
-                }
-            ]
+          },
+          "clientRole": false,
+          "containerId": "uds",
+          "attributes": {}
         }
+      ],
+      "client": {
+        "realm-management": [
+          {
+            "id": "b97936e6-d425-4dd2-a828-1444065d7b69",
+            "name": "query-users",
+            "description": "${role_query-users}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "89f798f8-f316-4588-8eef-51bfb0afb50a",
+            "name": "view-authorization",
+            "description": "${role_view-authorization}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "5d2ee7fb-0c5c-4abe-9424-5a6df6a2a9e3",
+            "name": "query-realms",
+            "description": "${role_query-realms}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "8dfc18ae-276f-4b8c-921c-3fad62390679",
+            "name": "create-client",
+            "description": "${role_create-client}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "145a11f5-38ba-46ff-aa7d-050780ff43d8",
+            "name": "impersonation",
+            "description": "${role_impersonation}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "8b6f75e9-fb44-40de-a998-c68f816a44fc",
+            "name": "view-events",
+            "description": "${role_view-events}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "1c07b7e2-3d16-428c-b68b-e3064f230ced",
+            "name": "manage-authorization",
+            "description": "${role_manage-authorization}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "ed54aef5-cac0-47b5-ab8b-fd2852835569",
+            "name": "query-clients",
+            "description": "${role_query-clients}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "997c82fa-0963-4161-80ba-6a93240c7328",
+            "name": "view-identity-providers",
+            "description": "${role_view-identity-providers}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "db96dcd7-7322-4e63-a45d-f3cb79d2735f",
+            "name": "realm-admin",
+            "description": "${role_realm-admin}",
+            "composite": true,
+            "composites": {
+              "client": {
+                "realm-management": [
+                  "view-authorization",
+                  "query-users",
+                  "query-realms",
+                  "impersonation",
+                  "view-events",
+                  "create-client",
+                  "manage-authorization",
+                  "view-identity-providers",
+                  "query-clients",
+                  "view-clients",
+                  "query-groups",
+                  "manage-realm",
+                  "manage-identity-providers",
+                  "view-users",
+                  "manage-events",
+                  "manage-clients",
+                  "manage-users",
+                  "view-realm"
+                ]
+              }
+            },
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "f5a79a5f-2081-49c4-b5f2-a4de65872324",
+            "name": "view-clients",
+            "description": "${role_view-clients}",
+            "composite": true,
+            "composites": {
+              "client": {
+                "realm-management": [
+                  "query-clients"
+                ]
+              }
+            },
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "b06aa3b9-2158-4368-a1c0-923ec601b612",
+            "name": "query-groups",
+            "description": "${role_query-groups}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "ea696cf6-a201-4959-8eb6-21ae767f55e2",
+            "name": "manage-realm",
+            "description": "${role_manage-realm}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "df80d4c8-5414-4fef-863f-2567e9ed3c06",
+            "name": "manage-identity-providers",
+            "description": "${role_manage-identity-providers}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "a59628c5-c193-4cee-9714-ec6936104f31",
+            "name": "view-users",
+            "description": "${role_view-users}",
+            "composite": true,
+            "composites": {
+              "client": {
+                "realm-management": [
+                  "query-groups",
+                  "query-users"
+                ]
+              }
+            },
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "76358e4d-eb1c-4d20-9fc6-4a1fe66ce547",
+            "name": "manage-events",
+            "description": "${role_manage-events}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "0d86a9c9-d218-48ca-b362-b9cfb9f1cec7",
+            "name": "manage-clients",
+            "description": "${role_manage-clients}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "8daa5681-8c5e-4842-9454-f3ee52542b62",
+            "name": "manage-users",
+            "description": "${role_manage-users}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          },
+          {
+            "id": "4b1f822c-9ad8-4f64-abac-d6d67d8b5c27",
+            "name": "view-realm",
+            "description": "${role_view-realm}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+            "attributes": {}
+          }
+        ],
+        "security-admin-console": [],
+        "admin-cli": [],
+        "account-console": [],
+        "broker": [
+          {
+            "id": "7781303d-b0d3-4c73-bfb8-4aafb4c6fe20",
+            "name": "read-token",
+            "description": "${role_read-token}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
+            "attributes": {}
+          }
+        ],
+        "account": [
+          {
+            "id": "66091206-7730-446e-9a55-7c68c990d60a",
+            "name": "manage-consent",
+            "description": "${role_manage-consent}",
+            "composite": true,
+            "composites": {
+              "client": {
+                "account": [
+                  "view-consent"
+                ]
+              }
+            },
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          },
+          {
+            "id": "b945fcb1-4882-4d55-bfac-dfdc8923ba80",
+            "name": "view-applications",
+            "description": "${role_view-applications}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          },
+          {
+            "id": "1b79071c-e0c6-4b14-980d-a673410308f5",
+            "name": "manage-account",
+            "description": "${role_manage-account}",
+            "composite": true,
+            "composites": {
+              "client": {
+                "account": [
+                  "manage-account-links"
+                ]
+              }
+            },
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          },
+          {
+            "id": "76fb4026-c5e6-4a7c-948d-ef46cc837852",
+            "name": "view-profile",
+            "description": "${role_view-profile}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          },
+          {
+            "id": "7a3e2678-e64d-43b7-a749-fd91c5f8e415",
+            "name": "view-groups",
+            "description": "${role_view-groups}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          },
+          {
+            "id": "93feab65-1196-499a-ad78-c3d38b26a653",
+            "name": "manage-account-links",
+            "description": "${role_manage-account-links}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          },
+          {
+            "id": "a985566b-6df2-48e5-a81d-f23f1509a074",
+            "name": "delete-account",
+            "description": "${role_delete-account}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          },
+          {
+            "id": "8c9f1ab5-a69e-40e2-bf2f-294f6d483ce1",
+            "name": "view-consent",
+            "description": "${role_view-consent}",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+            "attributes": {}
+          }
+        ]
+      }
     },
     "groups": [
-        {
-            "id": "53521ed0-aa44-4007-9727-0015d5281c3e",
-            "name": "UDS Core",
-            "path": "/UDS Core",
-            "subGroups": [
-                {
-                    "id": "1ce48bde-e0e9-4bac-8b77-8b4cc96d2135",
-                    "name": "Admin",
-                    "path": "/UDS Core/Admin",
-                    "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
-                },
-                {
-                    "id": "03a34e8e-be2d-44cd-8ad2-75e90e28f6d9",
-                    "name": "Auditor",
-                    "path": "/UDS Core/Auditor",
-                    "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
-                }
-            ]
-        }
+      {
+        "id": "53521ed0-aa44-4007-9727-0015d5281c3e",
+        "name": "UDS Core",
+        "path": "/UDS Core",
+        "subGroups": [
+          {
+            "id": "1ce48bde-e0e9-4bac-8b77-8b4cc96d2135",
+            "name": "Admin",
+            "path": "/UDS Core/Admin",
+            "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
+          },
+          {
+            "id": "03a34e8e-be2d-44cd-8ad2-75e90e28f6d9",
+            "name": "Auditor",
+            "path": "/UDS Core/Auditor",
+            "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
+          }
+        ]
+      }
     ],
     "defaultRole": {
-        "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
-        "name": "default-roles-uds",
-        "description": "${role_default-roles}",
-        "composite": true,
-        "clientRole": false,
-        "containerId": "uds"
+      "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
+      "name": "default-roles-uds",
+      "description": "${role_default-roles}",
+      "composite": true,
+      "clientRole": false,
+      "containerId": "uds"
     },
     "requiredCredentials": [
-        "password"
+      "password"
     ],
     "passwordPolicy": "${REALM_PASSWORD_POLICY}",
     "otpPolicyType": "totp",
@@ -464,14 +465,14 @@
     "otpPolicyPeriod": 30,
     "otpPolicyCodeReusable": false,
     "otpSupportedApplications": [
-        "totpAppFreeOTPName",
-        "totpAppGoogleName",
-        "totpAppMicrosoftAuthenticatorName"
+      "totpAppFreeOTPName",
+      "totpAppGoogleName",
+      "totpAppMicrosoftAuthenticatorName"
     ],
     "localizationTexts": {},
     "webAuthnPolicyRpEntityName": "keycloak",
     "webAuthnPolicySignatureAlgorithms": [
-        "ES256"
+      "ES256"
     ],
     "webAuthnPolicyRpId": "",
     "webAuthnPolicyAttestationConveyancePreference": "not specified",
@@ -484,7 +485,7 @@
     "webAuthnPolicyExtraOrigins": [],
     "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
     "webAuthnPolicyPasswordlessSignatureAlgorithms": [
-        "ES256"
+      "ES256"
     ],
     "webAuthnPolicyPasswordlessRpId": "",
     "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
@@ -496,903 +497,903 @@
     "webAuthnPolicyPasswordlessAcceptableAaguids": [],
     "webAuthnPolicyPasswordlessExtraOrigins": [],
     "scopeMappings": [
-        {
-            "clientScope": "offline_access",
-            "roles": [
-                "offline_access"
-            ]
-        }
+      {
+        "clientScope": "offline_access",
+        "roles": [
+          "offline_access"
+        ]
+      }
     ],
     "clientScopeMappings": {
-        "account": [
-            {
-                "client": "account-console",
-                "roles": [
-                    "manage-account",
-                    "view-groups"
-                ]
-            }
-        ]
+      "account": [
+        {
+          "client": "account-console",
+          "roles": [
+            "manage-account",
+            "view-groups"
+          ]
+        }
+      ]
     },
     "clients": [
-        {
-            "id": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "clientId": "account",
-            "name": "Account",
-            "description": "",
-            "rootUrl": "${authBaseUrl}",
-            "adminUrl": "",
-            "baseUrl": "/realms/uds/account/",
-            "surrogateAuthRequired": false,
-            "enabled": true,
-            "alwaysDisplayInConsole": false,
-            "clientAuthenticatorType": "client-secret",
-            "redirectUris": [
-                "/realms/uds/account/*"
-            ],
-            "webOrigins": [],
-            "notBefore": 0,
-            "bearerOnly": false,
-            "consentRequired": false,
-            "standardFlowEnabled": true,
-            "implicitFlowEnabled": false,
-            "directAccessGrantsEnabled": false,
-            "serviceAccountsEnabled": false,
-            "publicClient": true,
-            "frontchannelLogout": false,
-            "protocol": "openid-connect",
-            "attributes": {
-                "oidc.ciba.grant.enabled": "false",
-                "backchannel.logout.session.required": "true",
-                "post.logout.redirect.uris": "+",
-                "oauth2.device.authorization.grant.enabled": "false",
-                "display.on.consent.screen": "false",
-                "backchannel.logout.revoke.offline.tokens": "false"
-            },
-            "authenticationFlowBindingOverrides": {},
-            "fullScopeAllowed": false,
-            "nodeReRegistrationTimeout": 0,
-            "defaultClientScopes": [
-                "web-origins",
-                "acr",
-                "profile",
-                "roles",
-                "email"
-            ],
-            "optionalClientScopes": [
-                "address",
-                "phone",
-                "offline_access",
-                "microprofile-jwt"
-            ]
+      {
+        "id": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+        "clientId": "account",
+        "name": "Account",
+        "description": "",
+        "rootUrl": "${authBaseUrl}",
+        "adminUrl": "",
+        "baseUrl": "/realms/uds/account/",
+        "surrogateAuthRequired": false,
+        "enabled": true,
+        "alwaysDisplayInConsole": false,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": [
+          "/realms/uds/account/*"
+        ],
+        "webOrigins": [],
+        "notBefore": 0,
+        "bearerOnly": false,
+        "consentRequired": false,
+        "standardFlowEnabled": true,
+        "implicitFlowEnabled": false,
+        "directAccessGrantsEnabled": false,
+        "serviceAccountsEnabled": false,
+        "publicClient": true,
+        "frontchannelLogout": false,
+        "protocol": "openid-connect",
+        "attributes": {
+          "oidc.ciba.grant.enabled": "false",
+          "backchannel.logout.session.required": "true",
+          "post.logout.redirect.uris": "+",
+          "oauth2.device.authorization.grant.enabled": "false",
+          "display.on.consent.screen": "false",
+          "backchannel.logout.revoke.offline.tokens": "false"
         },
-        {
-            "id": "f5c075d3-33ea-4bd6-8629-a3ecbeda72d9",
-            "clientId": "account-console",
-            "name": "My Account",
-            "description": "",
-            "rootUrl": "${authBaseUrl}",
-            "adminUrl": "",
-            "baseUrl": "/realms/uds/account/",
-            "surrogateAuthRequired": false,
-            "enabled": true,
-            "alwaysDisplayInConsole": false,
-            "clientAuthenticatorType": "client-secret",
-            "redirectUris": [
-                "/realms/uds/account/*"
-            ],
-            "webOrigins": [],
-            "notBefore": 0,
-            "bearerOnly": false,
-            "consentRequired": false,
-            "standardFlowEnabled": true,
-            "implicitFlowEnabled": false,
-            "directAccessGrantsEnabled": false,
-            "serviceAccountsEnabled": false,
-            "publicClient": true,
-            "frontchannelLogout": false,
-            "protocol": "openid-connect",
-            "attributes": {
-                "oidc.ciba.grant.enabled": "false",
-                "backchannel.logout.session.required": "true",
-                "post.logout.redirect.uris": "+",
-                "oauth2.device.authorization.grant.enabled": "false",
-                "display.on.consent.screen": "false",
-                "pkce.code.challenge.method": "S256",
-                "backchannel.logout.revoke.offline.tokens": "false"
-            },
-            "authenticationFlowBindingOverrides": {},
-            "fullScopeAllowed": false,
-            "nodeReRegistrationTimeout": 0,
-            "protocolMappers": [
-                {
-                    "id": "254c52b4-d381-4612-a26f-ba7586d1d9a3",
-                    "name": "audience resolve",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-audience-resolve-mapper",
-                    "consentRequired": false,
-                    "config": {}
-                }
-            ],
-            "defaultClientScopes": [
-                "web-origins",
-                "acr",
-                "profile",
-                "roles",
-                "email"
-            ],
-            "optionalClientScopes": [
-                "address",
-                "phone",
-                "offline_access",
-                "microprofile-jwt"
-            ]
+        "authenticationFlowBindingOverrides": {},
+        "fullScopeAllowed": false,
+        "nodeReRegistrationTimeout": 0,
+        "defaultClientScopes": [
+          "web-origins",
+          "acr",
+          "profile",
+          "roles",
+          "email"
+        ],
+        "optionalClientScopes": [
+          "address",
+          "phone",
+          "offline_access",
+          "microprofile-jwt"
+        ]
+      },
+      {
+        "id": "f5c075d3-33ea-4bd6-8629-a3ecbeda72d9",
+        "clientId": "account-console",
+        "name": "My Account",
+        "description": "",
+        "rootUrl": "${authBaseUrl}",
+        "adminUrl": "",
+        "baseUrl": "/realms/uds/account/",
+        "surrogateAuthRequired": false,
+        "enabled": true,
+        "alwaysDisplayInConsole": false,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": [
+          "/realms/uds/account/*"
+        ],
+        "webOrigins": [],
+        "notBefore": 0,
+        "bearerOnly": false,
+        "consentRequired": false,
+        "standardFlowEnabled": true,
+        "implicitFlowEnabled": false,
+        "directAccessGrantsEnabled": false,
+        "serviceAccountsEnabled": false,
+        "publicClient": true,
+        "frontchannelLogout": false,
+        "protocol": "openid-connect",
+        "attributes": {
+          "oidc.ciba.grant.enabled": "false",
+          "backchannel.logout.session.required": "true",
+          "post.logout.redirect.uris": "+",
+          "oauth2.device.authorization.grant.enabled": "false",
+          "display.on.consent.screen": "false",
+          "pkce.code.challenge.method": "S256",
+          "backchannel.logout.revoke.offline.tokens": "false"
         },
-        {
-            "id": "deca352c-0907-40ca-aea7-ea92792d6246",
-            "clientId": "admin-cli",
-            "name": "${client_admin-cli}",
-            "surrogateAuthRequired": false,
-            "enabled": true,
-            "alwaysDisplayInConsole": false,
-            "clientAuthenticatorType": "client-secret",
-            "redirectUris": [],
-            "webOrigins": [],
-            "notBefore": 0,
-            "bearerOnly": false,
-            "consentRequired": false,
-            "standardFlowEnabled": false,
-            "implicitFlowEnabled": false,
-            "directAccessGrantsEnabled": true,
-            "serviceAccountsEnabled": false,
-            "publicClient": true,
-            "frontchannelLogout": false,
+        "authenticationFlowBindingOverrides": {},
+        "fullScopeAllowed": false,
+        "nodeReRegistrationTimeout": 0,
+        "protocolMappers": [
+          {
+            "id": "254c52b4-d381-4612-a26f-ba7586d1d9a3",
+            "name": "audience resolve",
             "protocol": "openid-connect",
-            "attributes": {
-                "post.logout.redirect.uris": "+"
-            },
-            "authenticationFlowBindingOverrides": {},
-            "fullScopeAllowed": false,
-            "nodeReRegistrationTimeout": 0,
-            "defaultClientScopes": [
-                "web-origins",
-                "acr",
-                "profile",
-                "roles",
-                "email"
-            ],
-            "optionalClientScopes": [
-                "address",
-                "phone",
-                "offline_access",
-                "microprofile-jwt"
-            ]
+            "protocolMapper": "oidc-audience-resolve-mapper",
+            "consentRequired": false,
+            "config": {}
+          }
+        ],
+        "defaultClientScopes": [
+          "web-origins",
+          "acr",
+          "profile",
+          "roles",
+          "email"
+        ],
+        "optionalClientScopes": [
+          "address",
+          "phone",
+          "offline_access",
+          "microprofile-jwt"
+        ]
+      },
+      {
+        "id": "deca352c-0907-40ca-aea7-ea92792d6246",
+        "clientId": "admin-cli",
+        "name": "${client_admin-cli}",
+        "surrogateAuthRequired": false,
+        "enabled": true,
+        "alwaysDisplayInConsole": false,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": [],
+        "webOrigins": [],
+        "notBefore": 0,
+        "bearerOnly": false,
+        "consentRequired": false,
+        "standardFlowEnabled": false,
+        "implicitFlowEnabled": false,
+        "directAccessGrantsEnabled": true,
+        "serviceAccountsEnabled": false,
+        "publicClient": true,
+        "frontchannelLogout": false,
+        "protocol": "openid-connect",
+        "attributes": {
+          "post.logout.redirect.uris": "+"
         },
-        {
-            "id": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
-            "clientId": "broker",
-            "name": "Broker",
-            "surrogateAuthRequired": false,
-            "enabled": true,
-            "alwaysDisplayInConsole": false,
-            "clientAuthenticatorType": "client-secret",
-            "redirectUris": [],
-            "webOrigins": [],
-            "notBefore": 0,
-            "bearerOnly": true,
-            "consentRequired": false,
-            "standardFlowEnabled": true,
-            "implicitFlowEnabled": false,
-            "directAccessGrantsEnabled": false,
-            "serviceAccountsEnabled": false,
-            "publicClient": false,
-            "frontchannelLogout": false,
-            "protocol": "openid-connect",
-            "attributes": {
-                "post.logout.redirect.uris": "+"
-            },
-            "authenticationFlowBindingOverrides": {},
-            "fullScopeAllowed": false,
-            "nodeReRegistrationTimeout": 0,
-            "defaultClientScopes": [
-                "web-origins",
-                "acr",
-                "profile",
-                "roles",
-                "email"
-            ],
-            "optionalClientScopes": [
-                "address",
-                "phone",
-                "offline_access",
-                "microprofile-jwt"
-            ]
+        "authenticationFlowBindingOverrides": {},
+        "fullScopeAllowed": false,
+        "nodeReRegistrationTimeout": 0,
+        "defaultClientScopes": [
+          "web-origins",
+          "acr",
+          "profile",
+          "roles",
+          "email"
+        ],
+        "optionalClientScopes": [
+          "address",
+          "phone",
+          "offline_access",
+          "microprofile-jwt"
+        ]
+      },
+      {
+        "id": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
+        "clientId": "broker",
+        "name": "Broker",
+        "surrogateAuthRequired": false,
+        "enabled": true,
+        "alwaysDisplayInConsole": false,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": [],
+        "webOrigins": [],
+        "notBefore": 0,
+        "bearerOnly": true,
+        "consentRequired": false,
+        "standardFlowEnabled": true,
+        "implicitFlowEnabled": false,
+        "directAccessGrantsEnabled": false,
+        "serviceAccountsEnabled": false,
+        "publicClient": false,
+        "frontchannelLogout": false,
+        "protocol": "openid-connect",
+        "attributes": {
+          "post.logout.redirect.uris": "+"
         },
-        {
-            "id": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "clientId": "realm-management",
-            "name": "Realm Management",
-            "surrogateAuthRequired": false,
-            "enabled": true,
-            "alwaysDisplayInConsole": false,
-            "clientAuthenticatorType": "client-secret",
-            "redirectUris": [],
-            "webOrigins": [],
-            "notBefore": 0,
-            "bearerOnly": true,
-            "consentRequired": false,
-            "standardFlowEnabled": true,
-            "implicitFlowEnabled": false,
-            "directAccessGrantsEnabled": false,
-            "serviceAccountsEnabled": false,
-            "publicClient": false,
-            "frontchannelLogout": false,
-            "protocol": "openid-connect",
-            "attributes": {
-                "post.logout.redirect.uris": "+"
-            },
-            "authenticationFlowBindingOverrides": {},
-            "fullScopeAllowed": false,
-            "nodeReRegistrationTimeout": 0,
-            "defaultClientScopes": [
-                "web-origins",
-                "acr",
-                "profile",
-                "roles",
-                "email"
-            ],
-            "optionalClientScopes": [
-                "address",
-                "phone",
-                "offline_access",
-                "microprofile-jwt"
-            ]
+        "authenticationFlowBindingOverrides": {},
+        "fullScopeAllowed": false,
+        "nodeReRegistrationTimeout": 0,
+        "defaultClientScopes": [
+          "web-origins",
+          "acr",
+          "profile",
+          "roles",
+          "email"
+        ],
+        "optionalClientScopes": [
+          "address",
+          "phone",
+          "offline_access",
+          "microprofile-jwt"
+        ]
+      },
+      {
+        "id": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+        "clientId": "realm-management",
+        "name": "Realm Management",
+        "surrogateAuthRequired": false,
+        "enabled": true,
+        "alwaysDisplayInConsole": false,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": [],
+        "webOrigins": [],
+        "notBefore": 0,
+        "bearerOnly": true,
+        "consentRequired": false,
+        "standardFlowEnabled": true,
+        "implicitFlowEnabled": false,
+        "directAccessGrantsEnabled": false,
+        "serviceAccountsEnabled": false,
+        "publicClient": false,
+        "frontchannelLogout": false,
+        "protocol": "openid-connect",
+        "attributes": {
+          "post.logout.redirect.uris": "+"
         },
-        {
-            "id": "51bb67ac-a911-4594-96fa-0c9af22daead",
-            "clientId": "security-admin-console",
-            "name": "Security Admin Console",
-            "description": "",
-            "rootUrl": "${authAdminUrl}",
-            "adminUrl": "",
-            "baseUrl": "/admin/uds/console/",
-            "surrogateAuthRequired": false,
-            "enabled": true,
-            "alwaysDisplayInConsole": false,
-            "clientAuthenticatorType": "client-secret",
-            "redirectUris": [
-                "/admin/uds/console/*"
-            ],
-            "webOrigins": [
-                "+"
-            ],
-            "notBefore": 0,
-            "bearerOnly": false,
-            "consentRequired": false,
-            "standardFlowEnabled": true,
-            "implicitFlowEnabled": false,
-            "directAccessGrantsEnabled": false,
-            "serviceAccountsEnabled": false,
-            "publicClient": true,
-            "frontchannelLogout": false,
+        "authenticationFlowBindingOverrides": {},
+        "fullScopeAllowed": false,
+        "nodeReRegistrationTimeout": 0,
+        "defaultClientScopes": [
+          "web-origins",
+          "acr",
+          "profile",
+          "roles",
+          "email"
+        ],
+        "optionalClientScopes": [
+          "address",
+          "phone",
+          "offline_access",
+          "microprofile-jwt"
+        ]
+      },
+      {
+        "id": "51bb67ac-a911-4594-96fa-0c9af22daead",
+        "clientId": "security-admin-console",
+        "name": "Security Admin Console",
+        "description": "",
+        "rootUrl": "${authAdminUrl}",
+        "adminUrl": "",
+        "baseUrl": "/admin/uds/console/",
+        "surrogateAuthRequired": false,
+        "enabled": true,
+        "alwaysDisplayInConsole": false,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": [
+          "/admin/uds/console/*"
+        ],
+        "webOrigins": [
+          "+"
+        ],
+        "notBefore": 0,
+        "bearerOnly": false,
+        "consentRequired": false,
+        "standardFlowEnabled": true,
+        "implicitFlowEnabled": false,
+        "directAccessGrantsEnabled": false,
+        "serviceAccountsEnabled": false,
+        "publicClient": true,
+        "frontchannelLogout": false,
+        "protocol": "openid-connect",
+        "attributes": {
+          "oidc.ciba.grant.enabled": "false",
+          "backchannel.logout.session.required": "true",
+          "post.logout.redirect.uris": "+",
+          "oauth2.device.authorization.grant.enabled": "false",
+          "display.on.consent.screen": "false",
+          "pkce.code.challenge.method": "S256",
+          "backchannel.logout.revoke.offline.tokens": "false"
+        },
+        "authenticationFlowBindingOverrides": {},
+        "fullScopeAllowed": false,
+        "nodeReRegistrationTimeout": 0,
+        "protocolMappers": [
+          {
+            "id": "461284ab-c557-4d08-9ade-0328d2d6d0c0",
+            "name": "locale",
             "protocol": "openid-connect",
-            "attributes": {
-                "oidc.ciba.grant.enabled": "false",
-                "backchannel.logout.session.required": "true",
-                "post.logout.redirect.uris": "+",
-                "oauth2.device.authorization.grant.enabled": "false",
-                "display.on.consent.screen": "false",
-                "pkce.code.challenge.method": "S256",
-                "backchannel.logout.revoke.offline.tokens": "false"
-            },
-            "authenticationFlowBindingOverrides": {},
-            "fullScopeAllowed": false,
-            "nodeReRegistrationTimeout": 0,
-            "protocolMappers": [
-                {
-                    "id": "461284ab-c557-4d08-9ade-0328d2d6d0c0",
-                    "name": "locale",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "locale",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "locale",
-                        "jsonType.label": "String"
-                    }
-                }
-            ],
-            "defaultClientScopes": [
-                "web-origins",
-                "acr",
-                "profile",
-                "roles",
-                "email"
-            ],
-            "optionalClientScopes": [
-                "address",
-                "phone",
-                "offline_access",
-                "microprofile-jwt"
-            ]
-        }
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "locale",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "locale",
+              "jsonType.label": "String"
+            }
+          }
+        ],
+        "defaultClientScopes": [
+          "web-origins",
+          "acr",
+          "profile",
+          "roles",
+          "email"
+        ],
+        "optionalClientScopes": [
+          "address",
+          "phone",
+          "offline_access",
+          "microprofile-jwt"
+        ]
+      }
     ],
     "clientScopes": [
-        {
-            "id": "ad5955d0-5a02-4d77-9729-c9c50e3c614f",
-            "name": "role_list",
-            "description": "SAML role list",
+      {
+        "id": "ad5955d0-5a02-4d77-9729-c9c50e3c614f",
+        "name": "role_list",
+        "description": "SAML role list",
+        "protocol": "saml",
+        "attributes": {
+          "consent.screen.text": "${samlRoleListScopeConsentText}",
+          "display.on.consent.screen": "true"
+        },
+        "protocolMappers": [
+          {
+            "id": "8dbe7da2-9fae-4e24-b258-adffce4af581",
+            "name": "role list",
             "protocol": "saml",
-            "attributes": {
-                "consent.screen.text": "${samlRoleListScopeConsentText}",
-                "display.on.consent.screen": "true"
-            },
-            "protocolMappers": [
-                {
-                    "id": "8dbe7da2-9fae-4e24-b258-adffce4af581",
-                    "name": "role list",
-                    "protocol": "saml",
-                    "protocolMapper": "saml-role-list-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "single": "false",
-                        "attribute.nameformat": "Basic",
-                        "attribute.name": "Role"
-                    }
-                }
-            ]
+            "protocolMapper": "saml-role-list-mapper",
+            "consentRequired": false,
+            "config": {
+              "single": "false",
+              "attribute.nameformat": "Basic",
+              "attribute.name": "Role"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a56e312f-85f1-4c48-9822-b2c73ec29fef",
+        "name": "phone",
+        "description": "OpenID Connect built-in scope: phone",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "true",
+          "display.on.consent.screen": "true",
+          "consent.screen.text": "${phoneScopeConsentText}"
         },
-        {
-            "id": "a56e312f-85f1-4c48-9822-b2c73ec29fef",
-            "name": "phone",
-            "description": "OpenID Connect built-in scope: phone",
+        "protocolMappers": [
+          {
+            "id": "5cb0a293-9545-4125-9a93-be8ff09805e8",
+            "name": "phone number",
             "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "true",
-                "display.on.consent.screen": "true",
-                "consent.screen.text": "${phoneScopeConsentText}"
-            },
-            "protocolMappers": [
-                {
-                    "id": "5cb0a293-9545-4125-9a93-be8ff09805e8",
-                    "name": "phone number",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "phoneNumber",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "phone_number",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "f70f8a3d-2ef3-4b05-a33d-0b825406c703",
-                    "name": "phone number verified",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "phoneNumberVerified",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "phone_number_verified",
-                        "jsonType.label": "boolean"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "6970f878-3093-40f0-b48e-a749087760dc",
-            "name": "microprofile-jwt",
-            "description": "Microprofile - JWT built-in scope",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "phoneNumber",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "phone_number",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "f70f8a3d-2ef3-4b05-a33d-0b825406c703",
+            "name": "phone number verified",
             "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "true",
-                "display.on.consent.screen": "false"
-            },
-            "protocolMappers": [
-                {
-                    "id": "b1994403-6493-4e5c-92bf-b41db1342f74",
-                    "name": "upn",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "username",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "upn",
-                        "jsonType.label": "String"
-                    }
-                }
-            ]
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "phoneNumberVerified",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "phone_number_verified",
+              "jsonType.label": "boolean"
+            }
+          }
+        ]
+      },
+      {
+        "id": "6970f878-3093-40f0-b48e-a749087760dc",
+        "name": "microprofile-jwt",
+        "description": "Microprofile - JWT built-in scope",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "true",
+          "display.on.consent.screen": "false"
         },
-        {
-            "id": "15fd77dc-7f74-4c66-83bb-0b9350c6b554",
+        "protocolMappers": [
+          {
+            "id": "b1994403-6493-4e5c-92bf-b41db1342f74",
+            "name": "upn",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "username",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "upn",
+              "jsonType.label": "String"
+            }
+          }
+        ]
+      },
+      {
+        "id": "15fd77dc-7f74-4c66-83bb-0b9350c6b554",
+        "name": "email",
+        "description": "OpenID Connect built-in scope: email",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "true",
+          "display.on.consent.screen": "true",
+          "consent.screen.text": "${emailScopeConsentText}"
+        },
+        "protocolMappers": [
+          {
+            "id": "381b388d-b090-47b5-be92-713204f48163",
             "name": "email",
-            "description": "OpenID Connect built-in scope: email",
             "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "true",
-                "display.on.consent.screen": "true",
-                "consent.screen.text": "${emailScopeConsentText}"
-            },
-            "protocolMappers": [
-                {
-                    "id": "381b388d-b090-47b5-be92-713204f48163",
-                    "name": "email",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "email",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "email",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "eb386cd0-5efc-4087-ac56-8b3d0530a950",
-                    "name": "email verified",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-property-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "emailVerified",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "email_verified",
-                        "jsonType.label": "boolean"
-                    }
-                }
-            ]
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "email",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "email",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "eb386cd0-5efc-4087-ac56-8b3d0530a950",
+            "name": "email verified",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "emailVerified",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "email_verified",
+              "jsonType.label": "boolean"
+            }
+          }
+        ]
+      },
+      {
+        "id": "752a2fd8-ace8-407c-a1bf-d74f7f14b79c",
+        "name": "profile",
+        "description": "OpenID Connect built-in scope: profile",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "true",
+          "display.on.consent.screen": "true",
+          "consent.screen.text": "${profileScopeConsentText}"
         },
-        {
-            "id": "752a2fd8-ace8-407c-a1bf-d74f7f14b79c",
+        "protocolMappers": [
+          {
+            "id": "ca69a4e5-c386-477f-9f92-d4cc90e3e9c6",
+            "name": "picture",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "picture",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "picture",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "7d126b72-cc83-45b7-8213-e5a2e52df40d",
+            "name": "website",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "website",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "website",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "57a93d89-f1e0-4fb6-9abb-c709f5b265a5",
+            "name": "zoneinfo",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "zoneinfo",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "zoneinfo",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "958c9a5d-87a8-4c93-989e-3e41283bab1f",
+            "name": "birthdate",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "birthdate",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "birthdate",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "2f254814-1025-4290-8008-7a9ed422e53c",
+            "name": "username",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "username",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "preferred_username",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "1b28f611-9197-43cf-a1af-ac6a404553d6",
+            "name": "locale",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "locale",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "locale",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "fa02cb75-2f6c-44ee-b9b7-103efd0ae92b",
+            "name": "middle name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "middleName",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "middle_name",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "92b04117-abb1-4afe-ab2d-4863671d4b11",
+            "name": "updated at",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "updatedAt",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "updated_at",
+              "jsonType.label": "long"
+            }
+          },
+          {
+            "id": "f5965fdb-2351-4681-b0d6-8576f4b2186d",
+            "name": "nickname",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "nickname",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "nickname",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "574469f2-13ec-4240-ad18-f8ac02374cab",
+            "name": "given name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "firstName",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "given_name",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "39ed2777-22c8-428d-893e-3df346eea7e4",
+            "name": "groups",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-group-membership-mapper",
+            "consentRequired": false,
+            "config": {
+              "full.path": "true",
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "multivalued": "true",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "groups"
+            }
+          },
+          {
+            "id": "6d52407c-f35d-4f1f-8fee-46a3c1d25afe",
+            "name": "full name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-full-name-mapper",
+            "consentRequired": false,
+            "config": {
+              "id.token.claim": "true",
+              "introspection.token.claim": "true",
+              "access.token.claim": "true",
+              "userinfo.token.claim": "true"
+            }
+          },
+          {
+            "id": "e7dedcf0-2b37-45bd-a31c-f7a2b7f3c5ac",
+            "name": "family name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "lastName",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "family_name",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "bd488196-dcbf-434f-90ba-0a8b5f9a9e27",
+            "name": "gender",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "gender",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "gender",
+              "jsonType.label": "String"
+            }
+          },
+          {
+            "id": "f16482ec-79c4-491b-b1a7-67a14c882be5",
             "name": "profile",
-            "description": "OpenID Connect built-in scope: profile",
             "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "true",
-                "display.on.consent.screen": "true",
-                "consent.screen.text": "${profileScopeConsentText}"
-            },
-            "protocolMappers": [
-                {
-                    "id": "ca69a4e5-c386-477f-9f92-d4cc90e3e9c6",
-                    "name": "picture",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "picture",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "picture",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "7d126b72-cc83-45b7-8213-e5a2e52df40d",
-                    "name": "website",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "website",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "website",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "57a93d89-f1e0-4fb6-9abb-c709f5b265a5",
-                    "name": "zoneinfo",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "zoneinfo",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "zoneinfo",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "958c9a5d-87a8-4c93-989e-3e41283bab1f",
-                    "name": "birthdate",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "birthdate",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "birthdate",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "2f254814-1025-4290-8008-7a9ed422e53c",
-                    "name": "username",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "username",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "preferred_username",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "1b28f611-9197-43cf-a1af-ac6a404553d6",
-                    "name": "locale",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "locale",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "locale",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "fa02cb75-2f6c-44ee-b9b7-103efd0ae92b",
-                    "name": "middle name",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "middleName",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "middle_name",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "92b04117-abb1-4afe-ab2d-4863671d4b11",
-                    "name": "updated at",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "updatedAt",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "updated_at",
-                        "jsonType.label": "long"
-                    }
-                },
-                {
-                    "id": "f5965fdb-2351-4681-b0d6-8576f4b2186d",
-                    "name": "nickname",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "nickname",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "nickname",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "574469f2-13ec-4240-ad18-f8ac02374cab",
-                    "name": "given name",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "firstName",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "given_name",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "39ed2777-22c8-428d-893e-3df346eea7e4",
-                    "name": "groups",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-group-membership-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "full.path": "true",
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "multivalued": "true",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "groups"
-                    }
-                },
-                {
-                    "id": "6d52407c-f35d-4f1f-8fee-46a3c1d25afe",
-                    "name": "full name",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-full-name-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "id.token.claim": "true",
-                        "introspection.token.claim": "true",
-                        "access.token.claim": "true",
-                        "userinfo.token.claim": "true"
-                    }
-                },
-                {
-                    "id": "e7dedcf0-2b37-45bd-a31c-f7a2b7f3c5ac",
-                    "name": "family name",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "lastName",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "family_name",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "bd488196-dcbf-434f-90ba-0a8b5f9a9e27",
-                    "name": "gender",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "gender",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "gender",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "f16482ec-79c4-491b-b1a7-67a14c882be5",
-                    "name": "profile",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-attribute-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "userinfo.token.claim": "true",
-                        "user.attribute": "profile",
-                        "id.token.claim": "true",
-                        "access.token.claim": "true",
-                        "claim.name": "profile",
-                        "jsonType.label": "String"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "1a66d616-6eb0-45d7-89f7-df975f26a88e",
-            "name": "roles",
-            "description": "OpenID Connect scope for add user roles to the access token",
-            "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "false",
-                "display.on.consent.screen": "true",
-                "consent.screen.text": "${rolesScopeConsentText}"
-            },
-            "protocolMappers": [
-                {
-                    "id": "17a0e011-6792-4112-b787-e3748e2fe255",
-                    "name": "realm roles",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "multivalued": "true",
-                        "user.attribute": "foo",
-                        "access.token.claim": "true",
-                        "claim.name": "realm_access.roles",
-                        "jsonType.label": "String"
-                    }
-                },
-                {
-                    "id": "e91b9e2a-b20e-47c5-bb72-e4e999c0f9a7",
-                    "name": "audience resolve",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-audience-resolve-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "access.token.claim": "true"
-                    }
-                },
-                {
-                    "id": "021aabc9-aca3-4a31-9fa4-3b4d4fc5d129",
-                    "name": "client roles",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-usermodel-client-role-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "multivalued": "true",
-                        "user.attribute": "foo",
-                        "access.token.claim": "true",
-                        "claim.name": "resource_access.${client_id}.roles",
-                        "jsonType.label": "String"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "80bca4fb-c991-4f47-b941-90033d417619",
-            "name": "web-origins",
-            "description": "OpenID Connect scope for add allowed web origins to the access token",
-            "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "false",
-                "display.on.consent.screen": "false",
-                "consent.screen.text": ""
-            },
-            "protocolMappers": [
-                {
-                    "id": "65298359-14d0-4291-899e-3ca27dbf283b",
-                    "name": "allowed web origins",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-allowed-origins-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "introspection.token.claim": "true",
-                        "access.token.claim": "true"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "770edec1-8367-40cc-834c-ee2ef116cb0a",
-            "name": "offline_access",
-            "description": "OpenID Connect built-in scope: offline_access",
-            "protocol": "openid-connect",
-            "attributes": {
-                "consent.screen.text": "${offlineAccessScopeConsentText}",
-                "display.on.consent.screen": "true"
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "userinfo.token.claim": "true",
+              "user.attribute": "profile",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "profile",
+              "jsonType.label": "String"
             }
+          }
+        ]
+      },
+      {
+        "id": "1a66d616-6eb0-45d7-89f7-df975f26a88e",
+        "name": "roles",
+        "description": "OpenID Connect scope for add user roles to the access token",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "false",
+          "display.on.consent.screen": "true",
+          "consent.screen.text": "${rolesScopeConsentText}"
         },
-        {
-            "id": "0c4e8857-3a4c-4ef6-bac7-952b24a7591e",
-            "name": "acr",
-            "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+        "protocolMappers": [
+          {
+            "id": "17a0e011-6792-4112-b787-e3748e2fe255",
+            "name": "realm roles",
             "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "false",
-                "display.on.consent.screen": "false"
-            },
-            "protocolMappers": [
-                {
-                    "id": "3db9f004-36c9-4154-a076-6f027699aad4",
-                    "name": "acr loa level",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-acr-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "id.token.claim": "true",
-                        "introspection.token.claim": "true",
-                        "access.token.claim": "true",
-                        "userinfo.token.claim": "true"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "76a50ab0-c3e2-4224-b89f-6cec16ab87c4",
-            "name": "address",
-            "description": "OpenID Connect built-in scope: address",
-            "protocol": "openid-connect",
-            "attributes": {
-                "include.in.token.scope": "true",
-                "display.on.consent.screen": "true",
-                "consent.screen.text": "${addressScopeConsentText}"
-            },
-            "protocolMappers": [
-                {
-                    "id": "ab3891ab-f49e-4f23-b6fd-d456c0084d9b",
-                    "name": "address",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "oidc-address-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "user.attribute.formatted": "formatted",
-                        "user.attribute.country": "country",
-                        "introspection.token.claim": "true",
-                        "user.attribute.postal_code": "postal_code",
-                        "userinfo.token.claim": "true",
-                        "user.attribute.street": "street",
-                        "id.token.claim": "true",
-                        "user.attribute.region": "region",
-                        "access.token.claim": "true",
-                        "user.attribute.locality": "locality"
-                    }
-                }
-            ]
-        },
-        {
-            "id": "52fa0872-8912-4096-a124-da2c077b5539",
-            "name": "openid",
-            "description": "OpenID Connect built-in scope: openid",
-            "protocol": "openid-connect",
-            "attributes": {
-              "include.in.token.scope": "true",
-              "display.on.consent.screen": "true"
+            "protocolMapper": "oidc-usermodel-realm-role-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "multivalued": "true",
+              "user.attribute": "foo",
+              "access.token.claim": "true",
+              "claim.name": "realm_access.roles",
+              "jsonType.label": "String"
             }
+          },
+          {
+            "id": "e91b9e2a-b20e-47c5-bb72-e4e999c0f9a7",
+            "name": "audience resolve",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-audience-resolve-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "access.token.claim": "true"
+            }
+          },
+          {
+            "id": "021aabc9-aca3-4a31-9fa4-3b4d4fc5d129",
+            "name": "client roles",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-client-role-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "multivalued": "true",
+              "user.attribute": "foo",
+              "access.token.claim": "true",
+              "claim.name": "resource_access.${client_id}.roles",
+              "jsonType.label": "String"
+            }
+          }
+        ]
+      },
+      {
+        "id": "80bca4fb-c991-4f47-b941-90033d417619",
+        "name": "web-origins",
+        "description": "OpenID Connect scope for add allowed web origins to the access token",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "false",
+          "display.on.consent.screen": "false",
+          "consent.screen.text": ""
+        },
+        "protocolMappers": [
+          {
+            "id": "65298359-14d0-4291-899e-3ca27dbf283b",
+            "name": "allowed web origins",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-allowed-origins-mapper",
+            "consentRequired": false,
+            "config": {
+              "introspection.token.claim": "true",
+              "access.token.claim": "true"
+            }
+          }
+        ]
+      },
+      {
+        "id": "770edec1-8367-40cc-834c-ee2ef116cb0a",
+        "name": "offline_access",
+        "description": "OpenID Connect built-in scope: offline_access",
+        "protocol": "openid-connect",
+        "attributes": {
+          "consent.screen.text": "${offlineAccessScopeConsentText}",
+          "display.on.consent.screen": "true"
         }
+      },
+      {
+        "id": "0c4e8857-3a4c-4ef6-bac7-952b24a7591e",
+        "name": "acr",
+        "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "false",
+          "display.on.consent.screen": "false"
+        },
+        "protocolMappers": [
+          {
+            "id": "3db9f004-36c9-4154-a076-6f027699aad4",
+            "name": "acr loa level",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-acr-mapper",
+            "consentRequired": false,
+            "config": {
+              "id.token.claim": "true",
+              "introspection.token.claim": "true",
+              "access.token.claim": "true",
+              "userinfo.token.claim": "true"
+            }
+          }
+        ]
+      },
+      {
+        "id": "76a50ab0-c3e2-4224-b89f-6cec16ab87c4",
+        "name": "address",
+        "description": "OpenID Connect built-in scope: address",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "true",
+          "display.on.consent.screen": "true",
+          "consent.screen.text": "${addressScopeConsentText}"
+        },
+        "protocolMappers": [
+          {
+            "id": "ab3891ab-f49e-4f23-b6fd-d456c0084d9b",
+            "name": "address",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-address-mapper",
+            "consentRequired": false,
+            "config": {
+              "user.attribute.formatted": "formatted",
+              "user.attribute.country": "country",
+              "introspection.token.claim": "true",
+              "user.attribute.postal_code": "postal_code",
+              "userinfo.token.claim": "true",
+              "user.attribute.street": "street",
+              "id.token.claim": "true",
+              "user.attribute.region": "region",
+              "access.token.claim": "true",
+              "user.attribute.locality": "locality"
+            }
+          }
+        ]
+      },
+      {
+        "id": "52fa0872-8912-4096-a124-da2c077b5539",
+        "name": "openid",
+        "description": "OpenID Connect built-in scope: openid",
+        "protocol": "openid-connect",
+        "attributes": {
+          "include.in.token.scope": "true",
+          "display.on.consent.screen": "true"
+        }
+      }
     ],
     "defaultDefaultClientScopes": [
-        "role_list",
-        "profile",
-        "email",
-        "roles",
-        "web-origins",
-        "acr"
+      "role_list",
+      "profile",
+      "email",
+      "roles",
+      "web-origins",
+      "acr"
     ],
     "defaultOptionalClientScopes": [
-        "offline_access",
-        "address",
-        "phone",
-        "microprofile-jwt"
+      "offline_access",
+      "address",
+      "phone",
+      "microprofile-jwt"
     ],
     "browserSecurityHeaders": {
-        "contentSecurityPolicyReportOnly": "",
-        "xContentTypeOptions": "nosniff",
-        "referrerPolicy": "no-referrer",
-        "xRobotsTag": "none",
-        "xFrameOptions": "SAMEORIGIN",
-        "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-        "xXSSProtection": "1; mode=block",
-        "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+      "contentSecurityPolicyReportOnly": "",
+      "xContentTypeOptions": "nosniff",
+      "referrerPolicy": "no-referrer",
+      "xRobotsTag": "none",
+      "xFrameOptions": "SAMEORIGIN",
+      "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+      "xXSSProtection": "1; mode=block",
+      "strictTransportSecurity": "max-age=31536000; includeSubDomains"
     },
     "smtpServer": {},
     "loginTheme": "theme",
@@ -1400,1219 +1401,1233 @@
     "eventsEnabled": true,
     "eventsExpiration": 1800,
     "eventsListeners": [
-        "jboss-logging",
-        "custom-registration-listener"
+      "jboss-logging",
+      "custom-registration-listener"
     ],
     "enabledEventTypes": [
-        "SEND_RESET_PASSWORD",
-        "UPDATE_CONSENT_ERROR",
-        "GRANT_CONSENT",
-        "REMOVE_TOTP",
-        "REVOKE_GRANT",
-        "UPDATE_TOTP",
-        "LOGIN_ERROR",
-        "CLIENT_LOGIN",
-        "RESET_PASSWORD_ERROR",
-        "IMPERSONATE_ERROR",
-        "CODE_TO_TOKEN_ERROR",
-        "CUSTOM_REQUIRED_ACTION",
-        "RESTART_AUTHENTICATION",
-        "IMPERSONATE",
-        "UPDATE_PROFILE_ERROR",
-        "LOGIN",
-        "UPDATE_PASSWORD_ERROR",
-        "CLIENT_INITIATED_ACCOUNT_LINKING",
-        "TOKEN_EXCHANGE",
-        "LOGOUT",
-        "REGISTER",
-        "CLIENT_REGISTER",
-        "IDENTITY_PROVIDER_LINK_ACCOUNT",
-        "UPDATE_PASSWORD",
-        "CLIENT_DELETE",
-        "FEDERATED_IDENTITY_LINK_ERROR",
-        "IDENTITY_PROVIDER_FIRST_LOGIN",
-        "CLIENT_DELETE_ERROR",
-        "VERIFY_EMAIL",
-        "CLIENT_LOGIN_ERROR",
-        "RESTART_AUTHENTICATION_ERROR",
-        "EXECUTE_ACTIONS",
-        "REMOVE_FEDERATED_IDENTITY_ERROR",
-        "TOKEN_EXCHANGE_ERROR",
-        "PERMISSION_TOKEN",
-        "SEND_IDENTITY_PROVIDER_LINK_ERROR",
-        "EXECUTE_ACTION_TOKEN_ERROR",
-        "SEND_VERIFY_EMAIL",
-        "EXECUTE_ACTIONS_ERROR",
-        "REMOVE_FEDERATED_IDENTITY",
-        "IDENTITY_PROVIDER_POST_LOGIN",
-        "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
-        "UPDATE_EMAIL",
-        "REGISTER_ERROR",
-        "REVOKE_GRANT_ERROR",
-        "EXECUTE_ACTION_TOKEN",
-        "LOGOUT_ERROR",
-        "UPDATE_EMAIL_ERROR",
-        "CLIENT_UPDATE_ERROR",
-        "UPDATE_PROFILE",
-        "CLIENT_REGISTER_ERROR",
-        "FEDERATED_IDENTITY_LINK",
-        "SEND_IDENTITY_PROVIDER_LINK",
-        "SEND_VERIFY_EMAIL_ERROR",
-        "RESET_PASSWORD",
-        "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
-        "UPDATE_CONSENT",
-        "REMOVE_TOTP_ERROR",
-        "VERIFY_EMAIL_ERROR",
-        "SEND_RESET_PASSWORD_ERROR",
-        "CLIENT_UPDATE",
-        "CUSTOM_REQUIRED_ACTION_ERROR",
-        "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
-        "UPDATE_TOTP_ERROR",
-        "CODE_TO_TOKEN",
-        "GRANT_CONSENT_ERROR",
-        "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
+      "SEND_RESET_PASSWORD",
+      "UPDATE_CONSENT_ERROR",
+      "GRANT_CONSENT",
+      "REMOVE_TOTP",
+      "REVOKE_GRANT",
+      "UPDATE_TOTP",
+      "LOGIN_ERROR",
+      "CLIENT_LOGIN",
+      "RESET_PASSWORD_ERROR",
+      "IMPERSONATE_ERROR",
+      "CODE_TO_TOKEN_ERROR",
+      "CUSTOM_REQUIRED_ACTION",
+      "RESTART_AUTHENTICATION",
+      "IMPERSONATE",
+      "UPDATE_PROFILE_ERROR",
+      "LOGIN",
+      "UPDATE_PASSWORD_ERROR",
+      "CLIENT_INITIATED_ACCOUNT_LINKING",
+      "TOKEN_EXCHANGE",
+      "LOGOUT",
+      "REGISTER",
+      "CLIENT_REGISTER",
+      "IDENTITY_PROVIDER_LINK_ACCOUNT",
+      "UPDATE_PASSWORD",
+      "CLIENT_DELETE",
+      "FEDERATED_IDENTITY_LINK_ERROR",
+      "IDENTITY_PROVIDER_FIRST_LOGIN",
+      "CLIENT_DELETE_ERROR",
+      "VERIFY_EMAIL",
+      "CLIENT_LOGIN_ERROR",
+      "RESTART_AUTHENTICATION_ERROR",
+      "EXECUTE_ACTIONS",
+      "REMOVE_FEDERATED_IDENTITY_ERROR",
+      "TOKEN_EXCHANGE_ERROR",
+      "PERMISSION_TOKEN",
+      "SEND_IDENTITY_PROVIDER_LINK_ERROR",
+      "EXECUTE_ACTION_TOKEN_ERROR",
+      "SEND_VERIFY_EMAIL",
+      "EXECUTE_ACTIONS_ERROR",
+      "REMOVE_FEDERATED_IDENTITY",
+      "IDENTITY_PROVIDER_POST_LOGIN",
+      "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
+      "UPDATE_EMAIL",
+      "REGISTER_ERROR",
+      "REVOKE_GRANT_ERROR",
+      "EXECUTE_ACTION_TOKEN",
+      "LOGOUT_ERROR",
+      "UPDATE_EMAIL_ERROR",
+      "CLIENT_UPDATE_ERROR",
+      "UPDATE_PROFILE",
+      "CLIENT_REGISTER_ERROR",
+      "FEDERATED_IDENTITY_LINK",
+      "SEND_IDENTITY_PROVIDER_LINK",
+      "SEND_VERIFY_EMAIL_ERROR",
+      "RESET_PASSWORD",
+      "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
+      "UPDATE_CONSENT",
+      "REMOVE_TOTP_ERROR",
+      "VERIFY_EMAIL_ERROR",
+      "SEND_RESET_PASSWORD_ERROR",
+      "CLIENT_UPDATE",
+      "CUSTOM_REQUIRED_ACTION_ERROR",
+      "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
+      "UPDATE_TOTP_ERROR",
+      "CODE_TO_TOKEN",
+      "GRANT_CONSENT_ERROR",
+      "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
     ],
     "adminEventsEnabled": true,
     "adminEventsDetailsEnabled": true,
     "identityProviders": [
-        {
-          "alias": "saml",
-          "displayName": "Google SSO",
-          "internalId": "1538a301-8427-46d2-b59f-203f2f76e573",
-          "providerId": "saml",
-          "enabled": "${REALM_GOOGLE_IDP_ENABLED}",
-          "updateProfileFirstLoginMode": "on",
-          "trustEmail": true,
-          "storeToken": false,
-          "addReadTokenRoleOnCreate": false,
-          "authenticateByDefault": false,
-          "linkOnly": false,
-          "config": {
-            "postBindingLogout": "false",
-            "postBindingResponse": "true",
-            "backchannelSupported": "false",
-            "idpEntityId": "https://accounts.google.com/o/saml2?idpid=${REALM_GOOGLE_IDP_ID}",
-            "loginHint": "false",
-            "allowCreate": "true",
-            "enabledFromMetadata": "true",
-            "singleSignOnServiceUrl": "https://accounts.google.com/o/saml2/idp?idpid=${REALM_GOOGLE_IDP_ID}",
-            "wantAuthnRequestsSigned": "false",
-            "allowedClockSkew": "0",
-            "validateSignature": "false",
-            "signingCertificate": "${REALM_GOOGLE_IDP_SIGNING_CERT}",
-            "nameIDPolicyFormat": "${REALM_GOOGLE_IDP_NAME_ID_FORMAT}",
-            "entityId": "${REALM_GOOGLE_IDP_CORE_ENTITY_ID}",
-            "signSpMetadata": "false",
-            "wantAssertionsEncrypted": "false",
-            "sendClientIdOnLogout": "false",
-            "wantAssertionsSigned": "false",
-            "sendIdTokenOnLogout": "true",
-            "postBindingAuthnRequest": "true",
-            "forceAuthn": "false",
-            "attributeConsumingServiceIndex": "0",
-            "addExtensionsElementWithKeyInfo": "false",
-            "principalType": "Subject NameID"
-          }
+      {
+        "alias": "saml",
+        "displayName": "Google SSO",
+        "internalId": "1538a301-8427-46d2-b59f-203f2f76e573",
+        "providerId": "saml",
+        "enabled": "${REALM_GOOGLE_IDP_ENABLED}",
+        "updateProfileFirstLoginMode": "on",
+        "trustEmail": true,
+        "storeToken": false,
+        "addReadTokenRoleOnCreate": false,
+        "authenticateByDefault": false,
+        "linkOnly": false,
+        "config": {
+          "postBindingLogout": "false",
+          "postBindingResponse": "true",
+          "backchannelSupported": "false",
+          "idpEntityId": "https://accounts.google.com/o/saml2?idpid=${REALM_GOOGLE_IDP_ID}",
+          "loginHint": "false",
+          "allowCreate": "true",
+          "enabledFromMetadata": "true",
+          "singleSignOnServiceUrl": "https://accounts.google.com/o/saml2/idp?idpid=${REALM_GOOGLE_IDP_ID}",
+          "wantAuthnRequestsSigned": "false",
+          "allowedClockSkew": "0",
+          "validateSignature": "false",
+          "signingCertificate": "${REALM_GOOGLE_IDP_SIGNING_CERT}",
+          "nameIDPolicyFormat": "${REALM_GOOGLE_IDP_NAME_ID_FORMAT}",
+          "entityId": "${REALM_GOOGLE_IDP_CORE_ENTITY_ID}",
+          "signSpMetadata": "false",
+          "wantAssertionsEncrypted": "false",
+          "sendClientIdOnLogout": "false",
+          "wantAssertionsSigned": "false",
+          "sendIdTokenOnLogout": "true",
+          "postBindingAuthnRequest": "true",
+          "forceAuthn": "false",
+          "attributeConsumingServiceIndex": "0",
+          "addExtensionsElementWithKeyInfo": "false",
+          "principalType": "Subject NameID"
         }
-      ],
-      "identityProviderMappers": [
-        {
-          "id": "24c62f1a-9da4-4758-bc97-3310e04ea73b",
-          "name": "Email Mapper",
-          "identityProviderAlias": "saml",
-          "identityProviderMapper": "saml-user-attribute-idp-mapper",
-          "config": {
-            "syncMode": "INHERIT",
-            "user.attribute": "email",
-            "attribute.friendly.name": "email",
-            "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
-            "attribute.name": "email"
-          }
-        },
-        {
-          "id": "ae4f9a94-5e70-4eb2-be9f-752b7401f98e",
-          "name": "Admin Group Mapper",
-          "identityProviderAlias": "saml",
-          "identityProviderMapper": "saml-advanced-group-idp-mapper",
-          "config": {
-            "syncMode": "INHERIT",
-            "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_ADMIN_GROUP}\"}]",
-            "group": "/UDS Core/Admin"
-          }
-        },
-        {
-          "id": "ea435551-17dc-4096-8a26-e4585b48dbfa",
-          "name": "Auditor Group Mapper",
-          "identityProviderAlias": "saml",
-          "identityProviderMapper": "saml-advanced-group-idp-mapper",
-          "config": {
-            "syncMode": "INHERIT",
-            "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_AUDITOR_GROUP}\"}]",
-            "group": "/UDS Core/Auditor"
-          }
-        },
-        {
-          "id": "9492c99f-6d42-4127-9b29-4230b69f17b0",
-          "name": "firstName Mapper",
-          "identityProviderAlias": "saml",
-          "identityProviderMapper": "saml-user-attribute-idp-mapper",
-          "config": {
-            "syncMode": "INHERIT",
-            "user.attribute": "firstName",
-            "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
-            "attribute.name": "firstName"
-          }
-        },
-        {
-          "id": "affcb9cd-e27d-459f-8d69-c2b16ba5e5f7",
-          "name": "lastName Mapper",
-          "identityProviderAlias": "saml",
-          "identityProviderMapper": "saml-user-attribute-idp-mapper",
-          "config": {
-            "syncMode": "INHERIT",
-            "user.attribute": "lastName",
-            "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
-            "attribute.name": "lastName"
-          }
+      }
+    ],
+    "identityProviderMappers": [
+      {
+        "id": "24c62f1a-9da4-4758-bc97-3310e04ea73b",
+        "name": "Email Mapper",
+        "identityProviderAlias": "saml",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "config": {
+          "syncMode": "INHERIT",
+          "user.attribute": "email",
+          "attribute.friendly.name": "email",
+          "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+          "attribute.name": "email"
         }
-      ],
+      },
+      {
+        "id": "ae4f9a94-5e70-4eb2-be9f-752b7401f98e",
+        "name": "Admin Group Mapper",
+        "identityProviderAlias": "saml",
+        "identityProviderMapper": "saml-advanced-group-idp-mapper",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_ADMIN_GROUP}\"}]",
+          "group": "/UDS Core/Admin"
+        }
+      },
+      {
+        "id": "ea435551-17dc-4096-8a26-e4585b48dbfa",
+        "name": "Auditor Group Mapper",
+        "identityProviderAlias": "saml",
+        "identityProviderMapper": "saml-advanced-group-idp-mapper",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[{\"key\":\"groups\",\"value\":\"${REALM_GOOGLE_IDP_AUDITOR_GROUP}\"}]",
+          "group": "/UDS Core/Auditor"
+        }
+      },
+      {
+        "id": "9492c99f-6d42-4127-9b29-4230b69f17b0",
+        "name": "firstName Mapper",
+        "identityProviderAlias": "saml",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "config": {
+          "syncMode": "INHERIT",
+          "user.attribute": "firstName",
+          "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+          "attribute.name": "firstName"
+        }
+      },
+      {
+        "id": "affcb9cd-e27d-459f-8d69-c2b16ba5e5f7",
+        "name": "lastName Mapper",
+        "identityProviderAlias": "saml",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "config": {
+          "syncMode": "INHERIT",
+          "user.attribute": "lastName",
+          "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+          "attribute.name": "lastName"
+        }
+      }
+    ],
     "components": {
-        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
-            {
-                "id": "ccd57f68-3f54-4f9b-b2a7-47cbbedefe84",
-                "name": "Allowed Client Scopes",
-                "providerId": "allowed-client-templates",
-                "subType": "anonymous",
-                "subComponents": {},
-                "config": {
-                    "allow-default-scopes": [
-                        "true"
-                    ],
-                    "allowed-client-scopes": [
-                        "openid"
-                    ]
-                }
-            },
-            {
-                "id": "7717935d-a03c-46e0-82fd-78be66dab63b",
-                "name": "Allowed Client Scopes",
-                "providerId": "allowed-client-templates",
-                "subType": "authenticated",
-                "subComponents": {},
-                "config": {
-                    "allow-default-scopes": [
-                        "true"
-                    ]
-                }
-            },
-            {
-                "id": "e3d72400-e970-4fd1-85c6-130d1f0e9b4c",
-                "name": "Full Scope Disabled",
-                "providerId": "scope",
-                "subType": "anonymous",
-                "subComponents": {},
-                "config": {}
-            },
-            {
-                "id": "0bc6c803-7a6d-46dd-b4d9-4118d7fd465b",
-                "name": "Trusted Hosts",
-                "providerId": "trusted-hosts",
-                "subType": "anonymous",
-                "subComponents": {},
-                "config": {
-                    "host-sending-registration-request-must-match": [
-                        "true"
-                    ],
-                    "trusted-hosts": [
-                        "127.0.0.6",
-                        "*.${UDS_DOMAIN}",
-                        "*.admin.${UDS_DOMAIN}"
-                    ],
-                    "client-uris-must-match": [
-                        "true"
-                    ]
-                }
-            }
-        ],
-        "org.keycloak.userprofile.UserProfileProvider": [
-            {
-              "id": "3c5c068c-c9a5-4d68-8373-b30ae5e54c9c",
-              "providerId": "declarative-user-profile",
-              "subComponents": {},
-              "config": {
-                "kc.user.profile.config": [
-                  "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
-                ]
-              }
-            }
-        ],
-        "org.keycloak.keys.KeyProvider": [
-            {
-                "id": "649a4094-5312-4249-811d-82dcb8d1c5f8",
-                "name": "aes-generated",
-                "providerId": "aes-generated",
-                "subComponents": {},
-                "config": {
-                    "priority": [
-                        "100"
-                    ]
-                }
-            },
-            {
-                "id": "d4be2127-76f9-4539-b5cf-061ef408c1df",
-                "name": "rsa-generated",
-                "providerId": "rsa-generated",
-                "subComponents": {},
-                "config": {
-                    "priority": [
-                        "100"
-                    ]
-                }
-            },
-            {
-                "id": "40f57a34-8abf-4464-9f74-40566c215dc6",
-                "name": "hmac-generated",
-                "providerId": "hmac-generated",
-                "subComponents": {},
-                "config": {
-                    "priority": [
-                        "100"
-                    ],
-                    "algorithm": [
-                        "HS256"
-                    ]
-                }
-            },
-            {
-                "id": "8b3e77f4-0e3c-4bbd-b539-6df8d6dfa00e",
-                "name": "rsa-enc-generated",
-                "providerId": "rsa-enc-generated",
-                "subComponents": {},
-                "config": {
-                    "priority": [
-                        "100"
-                    ],
-                    "algorithm": [
-                        "RSA-OAEP"
-                    ]
-                }
-            }
-        ]
+      "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+        {
+          "id": "ccd57f68-3f54-4f9b-b2a7-47cbbedefe84",
+          "name": "Allowed Client Scopes",
+          "providerId": "allowed-client-templates",
+          "subType": "anonymous",
+          "subComponents": {},
+          "config": {
+            "allow-default-scopes": [
+              "true"
+            ],
+            "allowed-client-scopes": [
+              "openid"
+            ]
+          }
+        },
+        {
+          "id": "7717935d-a03c-46e0-82fd-78be66dab63b",
+          "name": "Allowed Client Scopes",
+          "providerId": "allowed-client-templates",
+          "subType": "authenticated",
+          "subComponents": {},
+          "config": {
+            "allow-default-scopes": [
+              "true"
+            ]
+          }
+        },
+        {
+          "id": "e3d72400-e970-4fd1-85c6-130d1f0e9b4c",
+          "name": "Full Scope Disabled",
+          "providerId": "scope",
+          "subType": "anonymous",
+          "subComponents": {},
+          "config": {}
+        },
+        {
+          "id": "0bc6c803-7a6d-46dd-b4d9-4118d7fd465b",
+          "name": "Trusted Hosts",
+          "providerId": "trusted-hosts",
+          "subType": "anonymous",
+          "subComponents": {},
+          "config": {
+            "host-sending-registration-request-must-match": [
+              "true"
+            ],
+            "trusted-hosts": [
+              "127.0.0.6",
+              "*.${UDS_DOMAIN}",
+              "*.admin.${UDS_DOMAIN}"
+            ],
+            "client-uris-must-match": [
+              "true"
+            ]
+          }
+        }
+      ],
+      "org.keycloak.userprofile.UserProfileProvider": [
+        {
+          "id": "3c5c068c-c9a5-4d68-8373-b30ae5e54c9c",
+          "providerId": "declarative-user-profile",
+          "subComponents": {},
+          "config": {
+            "kc.user.profile.config": [
+              "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
+            ]
+          }
+        }
+      ],
+      "org.keycloak.keys.KeyProvider": [
+        {
+          "id": "649a4094-5312-4249-811d-82dcb8d1c5f8",
+          "name": "aes-generated",
+          "providerId": "aes-generated",
+          "subComponents": {},
+          "config": {
+            "priority": [
+              "100"
+            ]
+          }
+        },
+        {
+          "id": "d4be2127-76f9-4539-b5cf-061ef408c1df",
+          "name": "rsa-generated",
+          "providerId": "rsa-generated",
+          "subComponents": {},
+          "config": {
+            "priority": [
+              "100"
+            ]
+          }
+        },
+        {
+          "id": "df923c3c-a0ef-457c-b66c-f2c623c87586",
+          "name": "fallback-HS512",
+          "providerId": "hmac-generated",
+          "subComponents": {},
+          "config": {
+            "priority": [
+              "-100"
+            ],
+            "algorithm": [
+              "HS512"
+            ]
+          }
+        },
+        {
+          "id": "40f57a34-8abf-4464-9f74-40566c215dc6",
+          "name": "hmac-generated",
+          "providerId": "hmac-generated",
+          "subComponents": {},
+          "config": {
+            "priority": [
+              "100"
+            ],
+            "algorithm": [
+              "HS256"
+            ]
+          }
+        },
+        {
+          "id": "8b3e77f4-0e3c-4bbd-b539-6df8d6dfa00e",
+          "name": "rsa-enc-generated",
+          "providerId": "rsa-enc-generated",
+          "subComponents": {},
+          "config": {
+            "priority": [
+              "100"
+            ],
+            "algorithm": [
+              "RSA-OAEP"
+            ]
+          }
+        }
+      ]
     },
     "internationalizationEnabled": false,
     "supportedLocales": [],
     "authenticationFlows": [
-        {
-            "id": "5fca3666-0018-4ca1-8ec9-4b00deb3d8f1",
-            "alias": "Account verification options",
-            "description": "Method with which to verity the existing account",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "idp-email-verification",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 20,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Verify Existing Account by Re-authentication",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "0c528a3a-e0d7-45f5-a458-f8c23842ab75",
-            "alias": "Authentication",
-            "description": "",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "auth-cookie",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 0,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorConfig": "dod-cac",
-                    "authenticator": "auth-x509-client-username-form",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 0,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "auth-username-password-form",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 1,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "a09f8f86-3df3-4397-91e2-d9dad1678ded",
-            "alias": "Authentication Options",
-            "description": "Authentication options.",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "basic-auth",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "basic-auth-otp",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "auth-spnego",
-                    "authenticatorFlow": false,
-                    "requirement": "DISABLED",
-                    "priority": 30,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "d61e1deb-921e-412f-baed-dc51c0fdc532",
-            "alias": "Browser - Conditional OTP",
-            "description": "Flow to determine if the OTP is required for the authentication",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "conditional-user-configured",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "auth-otp-form",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
-            "alias": "Conditional OTP",
-            "description": "",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "conditional-user-configured",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 0,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "auth-otp-form",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 1,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "2a37f1ea-9a71-46bf-8c76-34c480e90521",
-            "alias": "Direct Grant - Conditional OTP",
-            "description": "Flow to determine if the OTP is required for the authentication",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "conditional-user-configured",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "direct-grant-validate-otp",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "a8c9a858-6236-4e3d-8b07-716527264327",
-            "alias": "First broker login - Conditional OTP",
-            "description": "Flow to determine if the OTP is required for the authentication",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "conditional-user-configured",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "auth-otp-form",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "b44188c2-ddf7-4268-a860-b20e32c7fbcf",
-            "alias": "Handle Existing Account",
-            "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "idp-confirm-link",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Account verification options",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
-            "alias": "MFA Login",
-            "description": "",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "auth-username-password-form",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 0,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "REQUIRED",
-                    "priority": 1,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Conditional OTP",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "459c187e-eb0f-4f2e-8e15-0c0b245a406e",
-            "alias": "Reset - Conditional OTP",
-            "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "conditional-user-configured",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "reset-otp",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "f95bc9ff-dca8-4622-87d4-e89877091cc1",
-            "alias": "UDS Authentication",
-            "description": "browser based authentication",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "REQUIRED",
-                    "priority": 31,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Authentication",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
-            "alias": "UDS Authentication Browser - Conditional OTP",
-            "description": "Flow to determine if the OTP is required for the authentication",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "conditional-user-configured",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "auth-otp-form",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "2122677b-1a02-40a4-817b-66da58b1621a",
-            "alias": "UDS Registration",
-            "description": "registration flow",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "registration-page-form",
-                    "authenticatorFlow": true,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": true,
-                    "flowAlias": "UDS registration form",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "7f506bd3-70f7-4f99-b339-a57e5e4cb456",
-            "alias": "UDS Reset Credentials",
-            "description": "Reset credentials for a user if they forgot their password",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "reset-credentials-choose-user",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "reset-credential-email",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "reset-password",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 30,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "25a3d7b4-3d46-4d66-9a14-0fd4be935dff",
-            "alias": "UDS registration form",
-            "description": "registration form",
-            "providerId": "form-flow",
-            "topLevel": false,
-            "builtIn": false,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "registration-user-creation",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorConfig": "main",
-                    "authenticator": "registration-validation-action",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 50,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "registration-x509-password-action",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 51,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "51f952e6-d3ac-49bd-8e76-fd50128a2bea",
-            "alias": "User creation or linking",
-            "description": "Flow for the existing/non-existing user alternatives",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticatorConfig": "create unique user config",
-                    "authenticator": "idp-create-user-if-unique",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 20,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Handle Existing Account",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "1f94f667-ec06-4e24-9ce5-9fac2cb87892",
-            "alias": "Verify Existing Account by Re-authentication",
-            "description": "Reauthentication of existing account",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "idp-username-password-form",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "CONDITIONAL",
-                    "priority": 20,
-                    "autheticatorFlow": true,
-                    "flowAlias": "First broker login - Conditional OTP",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "128fa0e2-a2e5-4d99-87e8-e60aa672d516",
-            "alias": "browser",
-            "description": "browser based authentication",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "auth-cookie",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "auth-spnego",
-                    "authenticatorFlow": false,
-                    "requirement": "DISABLED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "identity-provider-redirector",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 25,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 30,
-                    "autheticatorFlow": true,
-                    "flowAlias": "forms",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "3053f59e-b554-4573-9a96-092b12cf9cfb",
-            "alias": "clients",
-            "description": "Base authentication for clients",
-            "providerId": "client-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "client-secret",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "client-jwt",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "client-secret-jwt",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 30,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "client-x509",
-                    "authenticatorFlow": false,
-                    "requirement": "ALTERNATIVE",
-                    "priority": 40,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "3b482c5b-59c5-4786-88f8-09123324d74d",
-            "alias": "direct grant",
-            "description": "OpenID Connect Resource Owner Grant",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "direct-grant-validate-username",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "direct-grant-validate-password",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "CONDITIONAL",
-                    "priority": 30,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Direct Grant - Conditional OTP",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "a2e76a41-9a2a-43ce-8a32-e82782f00d98",
-            "alias": "docker auth",
-            "description": "Used by Docker clients to authenticate against the IDP",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "docker-http-basic-authenticator",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "5785e630-7e91-4899-877d-569e3ac79871",
-            "alias": "first broker login",
-            "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticatorConfig": "review profile config",
-                    "authenticator": "idp-review-profile",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": true,
-                    "flowAlias": "User creation or linking",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "4950a920-1925-4deb-a45e-9035be7e7c2b",
-            "alias": "forms",
-            "description": "Username, password, otp and other auth forms.",
-            "providerId": "basic-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "auth-username-password-form",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "CONDITIONAL",
-                    "priority": 20,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Browser - Conditional OTP",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "458de539-a7ff-4038-968c-86066c36b825",
-            "alias": "http challenge",
-            "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "no-cookie-redirect",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Authentication Options",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "5a93f084-9395-4620-a918-47f17828cccd",
-            "alias": "registration",
-            "description": "registration flow",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "registration-page-form",
-                    "authenticatorFlow": true,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": true,
-                    "flowAlias": "registration form",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "6f96df4f-5955-4531-8af3-727a40a62e75",
-            "alias": "registration form",
-            "description": "registration form",
-            "providerId": "form-flow",
-            "topLevel": false,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "registration-user-creation",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "registration-profile-action",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 40,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "registration-password-action",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 50,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "registration-recaptcha-action",
-                    "authenticatorFlow": false,
-                    "requirement": "DISABLED",
-                    "priority": 60,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "ac02e171-c1ef-40da-be31-7b8bda5fc5ff",
-            "alias": "reset credentials",
-            "description": "Reset credentials for a user if they forgot their password or something",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "reset-credentials-choose-user",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "reset-credential-email",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 20,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticator": "reset-password",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 30,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                },
-                {
-                    "authenticatorFlow": true,
-                    "requirement": "CONDITIONAL",
-                    "priority": 40,
-                    "autheticatorFlow": true,
-                    "flowAlias": "Reset - Conditional OTP",
-                    "userSetupAllowed": false
-                }
-            ]
-        },
-        {
-            "id": "fd5f9d3b-7a95-4f93-9f5f-c839f3362e9a",
-            "alias": "saml ecp",
-            "description": "SAML ECP Profile Authentication Flow",
-            "providerId": "basic-flow",
-            "topLevel": true,
-            "builtIn": true,
-            "authenticationExecutions": [
-                {
-                    "authenticator": "http-basic-authenticator",
-                    "authenticatorFlow": false,
-                    "requirement": "REQUIRED",
-                    "priority": 10,
-                    "autheticatorFlow": false,
-                    "userSetupAllowed": false
-                }
-            ]
-        }
+      {
+        "id": "5fca3666-0018-4ca1-8ec9-4b00deb3d8f1",
+        "alias": "Account verification options",
+        "description": "Method with which to verity the existing account",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "idp-email-verification",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "ALTERNATIVE",
+            "priority": 20,
+            "autheticatorFlow": true,
+            "flowAlias": "Verify Existing Account by Re-authentication",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "0c528a3a-e0d7-45f5-a458-f8c23842ab75",
+        "alias": "Authentication",
+        "description": "",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticator": "auth-cookie",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 0,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorConfig": "dod-cac",
+            "authenticator": "auth-x509-client-username-form",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 0,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "auth-username-password-form",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 1,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "a09f8f86-3df3-4397-91e2-d9dad1678ded",
+        "alias": "Authentication Options",
+        "description": "Authentication options.",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "basic-auth",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "basic-auth-otp",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "auth-spnego",
+            "authenticatorFlow": false,
+            "requirement": "DISABLED",
+            "priority": 30,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "d61e1deb-921e-412f-baed-dc51c0fdc532",
+        "alias": "Browser - Conditional OTP",
+        "description": "Flow to determine if the OTP is required for the authentication",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "conditional-user-configured",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "auth-otp-form",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
+        "alias": "Conditional OTP",
+        "description": "",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticator": "conditional-user-configured",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 0,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "auth-otp-form",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 1,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "2a37f1ea-9a71-46bf-8c76-34c480e90521",
+        "alias": "Direct Grant - Conditional OTP",
+        "description": "Flow to determine if the OTP is required for the authentication",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "conditional-user-configured",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "direct-grant-validate-otp",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "a8c9a858-6236-4e3d-8b07-716527264327",
+        "alias": "First broker login - Conditional OTP",
+        "description": "Flow to determine if the OTP is required for the authentication",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "conditional-user-configured",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "auth-otp-form",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "b44188c2-ddf7-4268-a860-b20e32c7fbcf",
+        "alias": "Handle Existing Account",
+        "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "idp-confirm-link",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": true,
+            "flowAlias": "Account verification options",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
+        "alias": "MFA Login",
+        "description": "",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticator": "auth-username-password-form",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 0,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "REQUIRED",
+            "priority": 1,
+            "autheticatorFlow": true,
+            "flowAlias": "Conditional OTP",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "459c187e-eb0f-4f2e-8e15-0c0b245a406e",
+        "alias": "Reset - Conditional OTP",
+        "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "conditional-user-configured",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "reset-otp",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "f95bc9ff-dca8-4622-87d4-e89877091cc1",
+        "alias": "UDS Authentication",
+        "description": "browser based authentication",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticatorFlow": true,
+            "requirement": "REQUIRED",
+            "priority": 31,
+            "autheticatorFlow": true,
+            "flowAlias": "Authentication",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
+        "alias": "UDS Authentication Browser - Conditional OTP",
+        "description": "Flow to determine if the OTP is required for the authentication",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticator": "conditional-user-configured",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "auth-otp-form",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "2122677b-1a02-40a4-817b-66da58b1621a",
+        "alias": "UDS Registration",
+        "description": "registration flow",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticator": "registration-page-form",
+            "authenticatorFlow": true,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": true,
+            "flowAlias": "UDS registration form",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "7f506bd3-70f7-4f99-b339-a57e5e4cb456",
+        "alias": "UDS Reset Credentials",
+        "description": "Reset credentials for a user if they forgot their password",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticator": "reset-credentials-choose-user",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "reset-credential-email",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "reset-password",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 30,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "25a3d7b4-3d46-4d66-9a14-0fd4be935dff",
+        "alias": "UDS registration form",
+        "description": "registration form",
+        "providerId": "form-flow",
+        "topLevel": false,
+        "builtIn": false,
+        "authenticationExecutions": [
+          {
+            "authenticator": "registration-user-creation",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorConfig": "main",
+            "authenticator": "registration-validation-action",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 50,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "registration-x509-password-action",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 51,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "51f952e6-d3ac-49bd-8e76-fd50128a2bea",
+        "alias": "User creation or linking",
+        "description": "Flow for the existing/non-existing user alternatives",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticatorConfig": "create unique user config",
+            "authenticator": "idp-create-user-if-unique",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "ALTERNATIVE",
+            "priority": 20,
+            "autheticatorFlow": true,
+            "flowAlias": "Handle Existing Account",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "1f94f667-ec06-4e24-9ce5-9fac2cb87892",
+        "alias": "Verify Existing Account by Re-authentication",
+        "description": "Reauthentication of existing account",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "idp-username-password-form",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "CONDITIONAL",
+            "priority": 20,
+            "autheticatorFlow": true,
+            "flowAlias": "First broker login - Conditional OTP",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "128fa0e2-a2e5-4d99-87e8-e60aa672d516",
+        "alias": "browser",
+        "description": "browser based authentication",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "auth-cookie",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "auth-spnego",
+            "authenticatorFlow": false,
+            "requirement": "DISABLED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "identity-provider-redirector",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 25,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "ALTERNATIVE",
+            "priority": 30,
+            "autheticatorFlow": true,
+            "flowAlias": "forms",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "3053f59e-b554-4573-9a96-092b12cf9cfb",
+        "alias": "clients",
+        "description": "Base authentication for clients",
+        "providerId": "client-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "client-secret",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "client-jwt",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "client-secret-jwt",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 30,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "client-x509",
+            "authenticatorFlow": false,
+            "requirement": "ALTERNATIVE",
+            "priority": 40,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "3b482c5b-59c5-4786-88f8-09123324d74d",
+        "alias": "direct grant",
+        "description": "OpenID Connect Resource Owner Grant",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "direct-grant-validate-username",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "direct-grant-validate-password",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "CONDITIONAL",
+            "priority": 30,
+            "autheticatorFlow": true,
+            "flowAlias": "Direct Grant - Conditional OTP",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "a2e76a41-9a2a-43ce-8a32-e82782f00d98",
+        "alias": "docker auth",
+        "description": "Used by Docker clients to authenticate against the IDP",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "docker-http-basic-authenticator",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "5785e630-7e91-4899-877d-569e3ac79871",
+        "alias": "first broker login",
+        "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticatorConfig": "review profile config",
+            "authenticator": "idp-review-profile",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": true,
+            "flowAlias": "User creation or linking",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "4950a920-1925-4deb-a45e-9035be7e7c2b",
+        "alias": "forms",
+        "description": "Username, password, otp and other auth forms.",
+        "providerId": "basic-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "auth-username-password-form",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "CONDITIONAL",
+            "priority": 20,
+            "autheticatorFlow": true,
+            "flowAlias": "Browser - Conditional OTP",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "458de539-a7ff-4038-968c-86066c36b825",
+        "alias": "http challenge",
+        "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "no-cookie-redirect",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": true,
+            "flowAlias": "Authentication Options",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "5a93f084-9395-4620-a918-47f17828cccd",
+        "alias": "registration",
+        "description": "registration flow",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "registration-page-form",
+            "authenticatorFlow": true,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": true,
+            "flowAlias": "registration form",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "6f96df4f-5955-4531-8af3-727a40a62e75",
+        "alias": "registration form",
+        "description": "registration form",
+        "providerId": "form-flow",
+        "topLevel": false,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "registration-user-creation",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "registration-profile-action",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 40,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "registration-password-action",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 50,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "registration-recaptcha-action",
+            "authenticatorFlow": false,
+            "requirement": "DISABLED",
+            "priority": 60,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "ac02e171-c1ef-40da-be31-7b8bda5fc5ff",
+        "alias": "reset credentials",
+        "description": "Reset credentials for a user if they forgot their password or something",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "reset-credentials-choose-user",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "reset-credential-email",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 20,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticator": "reset-password",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 30,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          },
+          {
+            "authenticatorFlow": true,
+            "requirement": "CONDITIONAL",
+            "priority": 40,
+            "autheticatorFlow": true,
+            "flowAlias": "Reset - Conditional OTP",
+            "userSetupAllowed": false
+          }
+        ]
+      },
+      {
+        "id": "fd5f9d3b-7a95-4f93-9f5f-c839f3362e9a",
+        "alias": "saml ecp",
+        "description": "SAML ECP Profile Authentication Flow",
+        "providerId": "basic-flow",
+        "topLevel": true,
+        "builtIn": true,
+        "authenticationExecutions": [
+          {
+            "authenticator": "http-basic-authenticator",
+            "authenticatorFlow": false,
+            "requirement": "REQUIRED",
+            "priority": 10,
+            "autheticatorFlow": false,
+            "userSetupAllowed": false
+          }
+        ]
+      }
     ],
     "authenticatorConfig": [
-        {
-            "id": "bd49f97e-6ce0-42c7-b045-a16dc7a37649",
-            "alias": "create unique user config",
-            "config": {
-                "require.password.update.after.registration": "false"
-            }
-        },
-        {
-            "id": "86fd892b-86e0-4b42-944c-5b518706271c",
-            "alias": "dod-cac",
-            "config": {
-                "x509-cert-auth.canonical-dn-enabled": "false",
-                "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
-                "x509-cert-auth.serialnumber-hex-enabled": "false",
-                "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
-                "x509-cert-auth.regular-expression": "(.*?)(?:$)",
-                "x509-cert-auth.certificate-policy-mode": "All",
-                "x509-cert-auth.timestamp-validation-enabled": "true",
-                "x509-cert-auth.mapper-selection": "Custom Attribute Mapper",
-                "x509-cert-auth.crl-relative-path": "crl.pem",
-                "x509-cert-auth.crldp-checking-enabled": "false",
-                "x509-cert-auth.mapping-source-selection": "Subject's Alternative Name otherName (UPN)",
-                "x509-cert-auth.ocsp-checking-enabled": "false"
-            }
-        },
-        {
-            "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
-            "alias": "main",
-            "config": {}
-        },
-        {
-            "id": "d20d218e-9109-455d-9b03-bb453e209e81",
-            "alias": "review profile config",
-            "config": {
-                "update.profile.on.first.login": "missing"
-            }
+      {
+        "id": "bd49f97e-6ce0-42c7-b045-a16dc7a37649",
+        "alias": "create unique user config",
+        "config": {
+          "require.password.update.after.registration": "false"
         }
+      },
+      {
+        "id": "86fd892b-86e0-4b42-944c-5b518706271c",
+        "alias": "dod-cac",
+        "config": {
+          "x509-cert-auth.canonical-dn-enabled": "false",
+          "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
+          "x509-cert-auth.serialnumber-hex-enabled": "false",
+          "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
+          "x509-cert-auth.regular-expression": "(.*?)(?:$)",
+          "x509-cert-auth.certificate-policy-mode": "All",
+          "x509-cert-auth.timestamp-validation-enabled": "true",
+          "x509-cert-auth.mapper-selection": "Custom Attribute Mapper",
+          "x509-cert-auth.crl-relative-path": "crl.pem",
+          "x509-cert-auth.crldp-checking-enabled": "false",
+          "x509-cert-auth.mapping-source-selection": "Subject's Alternative Name otherName (UPN)",
+          "x509-cert-auth.ocsp-checking-enabled": "false"
+        }
+      },
+      {
+        "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
+        "alias": "main",
+        "config": {}
+      },
+      {
+        "id": "d20d218e-9109-455d-9b03-bb453e209e81",
+        "alias": "review profile config",
+        "config": {
+          "update.profile.on.first.login": "missing"
+        }
+      }
     ],
     "requiredActions": [
-        {
-            "alias": "TERMS_AND_CONDITIONS",
-            "name": "Terms and Conditions",
-            "providerId": "TERMS_AND_CONDITIONS",
-            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
-            "defaultAction": true,
-            "priority": 10,
-            "config": {}
-        },
-        {
-            "alias": "CONFIGURE_TOTP",
-            "name": "Configure OTP",
-            "providerId": "CONFIGURE_TOTP",
-            "enabled": "${REALM_OTP_ENABLED}",
-            "defaultAction": false,
-            "priority": 20,
-            "config": {}
-        },
-        {
-            "alias": "UPDATE_PASSWORD",
-            "name": "Update Password",
-            "providerId": "UPDATE_PASSWORD",
-            "enabled": true,
-            "defaultAction": false,
-            "priority": 30,
-            "config": {}
-        },
-        {
-            "alias": "UPDATE_PROFILE",
-            "name": "Update Profile",
-            "providerId": "UPDATE_PROFILE",
-            "enabled": true,
-            "defaultAction": false,
-            "priority": 40,
-            "config": {}
-        },
-        {
-            "alias": "VERIFY_EMAIL",
-            "name": "Verify Email",
-            "providerId": "VERIFY_EMAIL",
-            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
-            "defaultAction": true,
-            "priority": 50,
-            "config": {}
-        },
-        {
-            "alias": "delete_account",
-            "name": "Delete Account",
-            "providerId": "delete_account",
-            "enabled": false,
-            "defaultAction": false,
-            "priority": 60,
-            "config": {}
-        },
-        {
-            "alias": "update_user_locale",
-            "name": "Update User Locale",
-            "providerId": "update_user_locale",
-            "enabled": false,
-            "defaultAction": false,
-            "priority": 1000,
-            "config": {}
-        },
-        {
-            "alias": "UPDATE_X509",
-            "name": "Update X509",
-            "providerId": "UPDATE_X509",
-            "enabled": true,
-            "defaultAction": false,
-            "priority": 1001,
-            "config": {}
-        }
+      {
+        "alias": "TERMS_AND_CONDITIONS",
+        "name": "Terms and Conditions",
+        "providerId": "TERMS_AND_CONDITIONS",
+        "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
+        "defaultAction": true,
+        "priority": 10,
+        "config": {}
+      },
+      {
+        "alias": "CONFIGURE_TOTP",
+        "name": "Configure OTP",
+        "providerId": "CONFIGURE_TOTP",
+        "enabled": "${REALM_OTP_ENABLED}",
+        "defaultAction": false,
+        "priority": 20,
+        "config": {}
+      },
+      {
+        "alias": "UPDATE_PASSWORD",
+        "name": "Update Password",
+        "providerId": "UPDATE_PASSWORD",
+        "enabled": true,
+        "defaultAction": false,
+        "priority": 30,
+        "config": {}
+      },
+      {
+        "alias": "UPDATE_PROFILE",
+        "name": "Update Profile",
+        "providerId": "UPDATE_PROFILE",
+        "enabled": true,
+        "defaultAction": false,
+        "priority": 40,
+        "config": {}
+      },
+      {
+        "alias": "VERIFY_EMAIL",
+        "name": "Verify Email",
+        "providerId": "VERIFY_EMAIL",
+        "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
+        "defaultAction": true,
+        "priority": 50,
+        "config": {}
+      },
+      {
+        "alias": "delete_account",
+        "name": "Delete Account",
+        "providerId": "delete_account",
+        "enabled": false,
+        "defaultAction": false,
+        "priority": 60,
+        "config": {}
+      },
+      {
+        "alias": "update_user_locale",
+        "name": "Update User Locale",
+        "providerId": "update_user_locale",
+        "enabled": false,
+        "defaultAction": false,
+        "priority": 1000,
+        "config": {}
+      },
+      {
+        "alias": "UPDATE_X509",
+        "name": "Update X509",
+        "providerId": "UPDATE_X509",
+        "enabled": true,
+        "defaultAction": false,
+        "priority": 1001,
+        "config": {}
+      }
     ],
     "browserFlow": "UDS Authentication",
     "registrationFlow": "UDS Registration",
@@ -2621,27 +2636,28 @@
     "clientAuthenticationFlow": "clients",
     "dockerAuthenticationFlow": "docker auth",
     "attributes": {
-        "cibaBackchannelTokenDeliveryMode": "poll",
-        "cibaAuthRequestedUserHint": "login_hint",
-        "clientOfflineSessionMaxLifespan": "0",
-        "oauth2DevicePollingInterval": "5",
-        "clientSessionIdleTimeout": "0",
-        "userProfileEnabled": "false",
-        "clientOfflineSessionIdleTimeout": "0",
-        "cibaInterval": "5",
-        "realmReusableOtpCode": "false",
-        "cibaExpiresIn": "120",
-        "oauth2DeviceCodeLifespan": "600",
-        "parRequestUriLifespan": "60",
-        "clientSessionMaxLifespan": "0",
-        "frontendUrl": "",
-        "acr.loa.map": "{}"
+      "cibaBackchannelTokenDeliveryMode": "poll",
+      "cibaAuthRequestedUserHint": "login_hint",
+      "clientOfflineSessionMaxLifespan": "0",
+      "oauth2DevicePollingInterval": "5",
+      "clientSessionIdleTimeout": "0",
+      "userProfileEnabled": "false",
+      "clientOfflineSessionIdleTimeout": "0",
+      "cibaInterval": "5",
+      "realmReusableOtpCode": "false",
+      "cibaExpiresIn": "120",
+      "oauth2DeviceCodeLifespan": "600",
+      "parRequestUriLifespan": "60",
+      "clientSessionMaxLifespan": "0",
+      "frontendUrl": "",
+      "acr.loa.map": "{}"
     },
     "userManagedAccessAllowed": false,
     "clientProfiles": {
-        "profiles": []
+      "profiles": []
     },
     "clientPolicies": {
-        "policies": []
+      "policies": []
     }
-}
+  }
+  

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -455,7 +455,7 @@
     "requiredCredentials": [
         "password"
     ],
-    "passwordPolicy": "hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)",
+    "passwordPolicy": "${REALM_PASSWORD_POLICY}",
     "otpPolicyType": "totp",
     "otpPolicyAlgorithm": "HmacSHA1",
     "otpPolicyInitialCounter": 0,

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2570,7 +2570,7 @@
             "alias": "CONFIGURE_TOTP",
             "name": "Configure OTP",
             "providerId": "CONFIGURE_TOTP",
-            "enabled": "${REALM_OTP_ENABLED:false}",
+            "enabled": "${REALM_OTP_ENABLED:true}",
             "defaultAction": false,
             "priority": 20,
             "config": {}

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2516,7 +2516,7 @@
                 "x509-cert-auth.canonical-dn-enabled": "false",
                 "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
                 "x509-cert-auth.serialnumber-hex-enabled": "false",
-                "x509-cert-auth.ocsp-fail-open": "false",
+                "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
                 "x509-cert-auth.regular-expression": "(.*?)(?:$)",
                 "x509-cert-auth.certificate-policy-mode": "All",
                 "x509-cert-auth.timestamp-validation-enabled": "true",
@@ -2545,7 +2545,7 @@
             "alias": "TERMS_AND_CONDITIONS",
             "name": "Terms and Conditions",
             "providerId": "TERMS_AND_CONDITIONS",
-            "enabled": false,
+            "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
             "defaultAction": true,
             "priority": 10,
             "config": {}
@@ -2554,7 +2554,7 @@
             "alias": "CONFIGURE_TOTP",
             "name": "Configure OTP",
             "providerId": "CONFIGURE_TOTP",
-            "enabled": false,
+            "enabled": "${REALM_OTP_ENABLED}",
             "defaultAction": false,
             "priority": 20,
             "config": {}
@@ -2581,7 +2581,7 @@
             "alias": "VERIFY_EMAIL",
             "name": "Verify Email",
             "providerId": "VERIFY_EMAIL",
-            "enabled": false,
+            "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
             "defaultAction": true,
             "priority": 50,
             "config": {}

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -1,1391 +1,1391 @@
 {
-    "id": "uds",
-    "realm": "uds",
-    "displayName": "Unicorn Delivery Service",
-    "displayNameHtml": "Identity Service",
-    "notBefore": 0,
-    "defaultSignatureAlgorithm": "RS256",
-    "revokeRefreshToken": false,
-    "refreshTokenMaxReuse": 0,
-    "accessTokenLifespan": 300,
-    "accessTokenLifespanForImplicitFlow": 900,
-    "ssoSessionIdleTimeout": 1800,
-    "ssoSessionMaxLifespan": 36000,
-    "ssoSessionIdleTimeoutRememberMe": 0,
-    "ssoSessionMaxLifespanRememberMe": 0,
-    "offlineSessionIdleTimeout": 2592000,
-    "offlineSessionMaxLifespanEnabled": false,
-    "offlineSessionMaxLifespan": 5184000,
-    "clientSessionIdleTimeout": 0,
-    "clientSessionMaxLifespan": 0,
-    "clientOfflineSessionIdleTimeout": 0,
-    "clientOfflineSessionMaxLifespan": 0,
-    "accessCodeLifespan": 60,
-    "accessCodeLifespanUserAction": 300,
-    "accessCodeLifespanLogin": 1800,
-    "actionTokenGeneratedByAdminLifespan": 43200,
-    "actionTokenGeneratedByUserLifespan": 300,
-    "oauth2DeviceCodeLifespan": 600,
-    "oauth2DevicePollingInterval": 5,
-    "enabled": true,
-    "sslRequired": "external",
-    "registrationAllowed": true,
-    "registrationEmailAsUsername": false,
-    "rememberMe": false,
-    "verifyEmail": true,
-    "loginWithEmailAllowed": true,
-    "duplicateEmailsAllowed": false,
-    "resetPasswordAllowed": true,
-    "editUsernameAllowed": false,
-    "bruteForceProtected": true,
-    "permanentLockout": true,
-    "maxTemporaryLockouts": 0,
-    "maxFailureWaitSeconds": 900,
-    "minimumQuickLoginWaitSeconds": 60,
-    "waitIncrementSeconds": 60,
-    "quickLoginCheckMilliSeconds": 1000,
-    "maxDeltaTimeSeconds": 43200,
-    "failureFactor": 5,
-    "users": [
-        {
-            "id": "123",
-            "username": "testing_user",
-            "enabled": "true",
-            "credentials": [
-                {
-                    "type": "password",
-                    "value": "testingpassword1!!"
-                }
-            ],
-            "firstName": "Testing",
-            "lastName": "User",
-            "email": "testinguser@gmail.com",
-            "emailVerified": true,
-            "realmRoles": ["default-roles-uds"]
-        }
-    ],
-    "roles": {
+  "id": "uds",
+  "realm": "uds",
+  "displayName": "Unicorn Delivery Service",
+  "displayNameHtml": "Identity Service",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": true,
+  "maxTemporaryLockouts": 0,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 5,
+  "users": [
+      {
+          "id": "123",
+          "username": "testing_user",
+          "enabled": "true",
+          "credentials": [
+              {
+                  "type": "password",
+                  "value": "testingpassword1!!"
+              }
+          ],
+          "firstName": "Testing",
+          "lastName": "User",
+          "email": "testinguser@gmail.com",
+          "emailVerified": true,
+          "realmRoles": ["default-roles-uds"]
+      }
+  ],
+  "roles": {
       "realm": [
-        {
-          "id": "9630aa66-af3d-4704-9063-a80c25fb24ae",
-          "name": "uma_authorization",
-          "description": "${role_uma_authorization}",
-          "composite": false,
-          "clientRole": false,
-          "containerId": "uds",
-          "attributes": {}
-        },
-        {
-          "id": "ee67a20a-d607-4ed8-8a77-f11f92e7157f",
-          "name": "offline_access",
-          "description": "${role_offline-access}",
-          "composite": false,
-          "clientRole": false,
-          "containerId": "uds",
-          "attributes": {}
-        },
-        {
-          "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
-          "name": "default-roles-uds",
-          "description": "${role_default-roles}",
-          "composite": true,
-          "composites": {
-            "realm": [
-              "offline_access",
-              "uma_authorization"
-            ],
-            "client": {
-              "account": [
-                "manage-account",
-                "view-profile",
-                "view-groups"
-              ]
-            }
+          {
+              "id": "9630aa66-af3d-4704-9063-a80c25fb24ae",
+              "name": "uma_authorization",
+              "description": "${role_uma_authorization}",
+              "composite": false,
+              "clientRole": false,
+              "containerId": "uds",
+              "attributes": {}
           },
-          "clientRole": false,
-          "containerId": "uds",
-          "attributes": {}
-        }
+          {
+              "id": "ee67a20a-d607-4ed8-8a77-f11f92e7157f",
+              "name": "offline_access",
+              "description": "${role_offline-access}",
+              "composite": false,
+              "clientRole": false,
+              "containerId": "uds",
+              "attributes": {}
+          },
+          {
+              "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
+              "name": "default-roles-uds",
+              "description": "${role_default-roles}",
+              "composite": true,
+              "composites": {
+                  "realm": [
+                      "offline_access",
+                      "uma_authorization"
+                  ],
+                  "client": {
+                      "account": [
+                          "manage-account",
+                          "view-profile",
+                          "view-groups"
+                      ]
+                  }
+              },
+              "clientRole": false,
+              "containerId": "uds",
+              "attributes": {}
+          }
       ],
       "client": {
-        "realm-management": [
-          {
-            "id": "b97936e6-d425-4dd2-a828-1444065d7b69",
-            "name": "query-users",
-            "description": "${role_query-users}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "89f798f8-f316-4588-8eef-51bfb0afb50a",
-            "name": "view-authorization",
-            "description": "${role_view-authorization}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "5d2ee7fb-0c5c-4abe-9424-5a6df6a2a9e3",
-            "name": "query-realms",
-            "description": "${role_query-realms}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "8dfc18ae-276f-4b8c-921c-3fad62390679",
-            "name": "create-client",
-            "description": "${role_create-client}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "145a11f5-38ba-46ff-aa7d-050780ff43d8",
-            "name": "impersonation",
-            "description": "${role_impersonation}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "8b6f75e9-fb44-40de-a998-c68f816a44fc",
-            "name": "view-events",
-            "description": "${role_view-events}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "1c07b7e2-3d16-428c-b68b-e3064f230ced",
-            "name": "manage-authorization",
-            "description": "${role_manage-authorization}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "ed54aef5-cac0-47b5-ab8b-fd2852835569",
-            "name": "query-clients",
-            "description": "${role_query-clients}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "997c82fa-0963-4161-80ba-6a93240c7328",
-            "name": "view-identity-providers",
-            "description": "${role_view-identity-providers}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "db96dcd7-7322-4e63-a45d-f3cb79d2735f",
-            "name": "realm-admin",
-            "description": "${role_realm-admin}",
-            "composite": true,
-            "composites": {
-              "client": {
-                "realm-management": [
-                  "view-authorization",
-                  "query-users",
-                  "query-realms",
-                  "impersonation",
-                  "view-events",
-                  "create-client",
-                  "manage-authorization",
-                  "view-identity-providers",
-                  "query-clients",
-                  "view-clients",
-                  "query-groups",
-                  "manage-realm",
-                  "manage-identity-providers",
-                  "view-users",
-                  "manage-events",
-                  "manage-clients",
-                  "manage-users",
-                  "view-realm"
-                ]
+          "realm-management": [
+              {
+                  "id": "b97936e6-d425-4dd2-a828-1444065d7b69",
+                  "name": "query-users",
+                  "description": "${role_query-users}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "89f798f8-f316-4588-8eef-51bfb0afb50a",
+                  "name": "view-authorization",
+                  "description": "${role_view-authorization}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "5d2ee7fb-0c5c-4abe-9424-5a6df6a2a9e3",
+                  "name": "query-realms",
+                  "description": "${role_query-realms}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "8dfc18ae-276f-4b8c-921c-3fad62390679",
+                  "name": "create-client",
+                  "description": "${role_create-client}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "145a11f5-38ba-46ff-aa7d-050780ff43d8",
+                  "name": "impersonation",
+                  "description": "${role_impersonation}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "8b6f75e9-fb44-40de-a998-c68f816a44fc",
+                  "name": "view-events",
+                  "description": "${role_view-events}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "1c07b7e2-3d16-428c-b68b-e3064f230ced",
+                  "name": "manage-authorization",
+                  "description": "${role_manage-authorization}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "ed54aef5-cac0-47b5-ab8b-fd2852835569",
+                  "name": "query-clients",
+                  "description": "${role_query-clients}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "997c82fa-0963-4161-80ba-6a93240c7328",
+                  "name": "view-identity-providers",
+                  "description": "${role_view-identity-providers}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "db96dcd7-7322-4e63-a45d-f3cb79d2735f",
+                  "name": "realm-admin",
+                  "description": "${role_realm-admin}",
+                  "composite": true,
+                  "composites": {
+                      "client": {
+                          "realm-management": [
+                              "view-authorization",
+                              "query-users",
+                              "query-realms",
+                              "impersonation",
+                              "view-events",
+                              "create-client",
+                              "manage-authorization",
+                              "view-identity-providers",
+                              "query-clients",
+                              "view-clients",
+                              "query-groups",
+                              "manage-realm",
+                              "manage-identity-providers",
+                              "view-users",
+                              "manage-events",
+                              "manage-clients",
+                              "manage-users",
+                              "view-realm"
+                          ]
+                      }
+                  },
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "f5a79a5f-2081-49c4-b5f2-a4de65872324",
+                  "name": "view-clients",
+                  "description": "${role_view-clients}",
+                  "composite": true,
+                  "composites": {
+                      "client": {
+                          "realm-management": [
+                              "query-clients"
+                          ]
+                      }
+                  },
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "b06aa3b9-2158-4368-a1c0-923ec601b612",
+                  "name": "query-groups",
+                  "description": "${role_query-groups}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "ea696cf6-a201-4959-8eb6-21ae767f55e2",
+                  "name": "manage-realm",
+                  "description": "${role_manage-realm}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "df80d4c8-5414-4fef-863f-2567e9ed3c06",
+                  "name": "manage-identity-providers",
+                  "description": "${role_manage-identity-providers}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "a59628c5-c193-4cee-9714-ec6936104f31",
+                  "name": "view-users",
+                  "description": "${role_view-users}",
+                  "composite": true,
+                  "composites": {
+                      "client": {
+                          "realm-management": [
+                              "query-groups",
+                              "query-users"
+                          ]
+                      }
+                  },
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "76358e4d-eb1c-4d20-9fc6-4a1fe66ce547",
+                  "name": "manage-events",
+                  "description": "${role_manage-events}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "0d86a9c9-d218-48ca-b362-b9cfb9f1cec7",
+                  "name": "manage-clients",
+                  "description": "${role_manage-clients}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "8daa5681-8c5e-4842-9454-f3ee52542b62",
+                  "name": "manage-users",
+                  "description": "${role_manage-users}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
+              },
+              {
+                  "id": "4b1f822c-9ad8-4f64-abac-d6d67d8b5c27",
+                  "name": "view-realm",
+                  "description": "${role_view-realm}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+                  "attributes": {}
               }
-            },
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "f5a79a5f-2081-49c4-b5f2-a4de65872324",
-            "name": "view-clients",
-            "description": "${role_view-clients}",
-            "composite": true,
-            "composites": {
-              "client": {
-                "realm-management": [
-                  "query-clients"
-                ]
+          ],
+          "security-admin-console": [],
+          "admin-cli": [],
+          "account-console": [],
+          "broker": [
+              {
+                  "id": "7781303d-b0d3-4c73-bfb8-4aafb4c6fe20",
+                  "name": "read-token",
+                  "description": "${role_read-token}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
+                  "attributes": {}
               }
-            },
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "b06aa3b9-2158-4368-a1c0-923ec601b612",
-            "name": "query-groups",
-            "description": "${role_query-groups}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "ea696cf6-a201-4959-8eb6-21ae767f55e2",
-            "name": "manage-realm",
-            "description": "${role_manage-realm}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "df80d4c8-5414-4fef-863f-2567e9ed3c06",
-            "name": "manage-identity-providers",
-            "description": "${role_manage-identity-providers}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "a59628c5-c193-4cee-9714-ec6936104f31",
-            "name": "view-users",
-            "description": "${role_view-users}",
-            "composite": true,
-            "composites": {
-              "client": {
-                "realm-management": [
-                  "query-groups",
-                  "query-users"
-                ]
+          ],
+          "account": [
+              {
+                  "id": "66091206-7730-446e-9a55-7c68c990d60a",
+                  "name": "manage-consent",
+                  "description": "${role_manage-consent}",
+                  "composite": true,
+                  "composites": {
+                      "client": {
+                          "account": [
+                              "view-consent"
+                          ]
+                      }
+                  },
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
+              },
+              {
+                  "id": "b945fcb1-4882-4d55-bfac-dfdc8923ba80",
+                  "name": "view-applications",
+                  "description": "${role_view-applications}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
+              },
+              {
+                  "id": "1b79071c-e0c6-4b14-980d-a673410308f5",
+                  "name": "manage-account",
+                  "description": "${role_manage-account}",
+                  "composite": true,
+                  "composites": {
+                      "client": {
+                          "account": [
+                              "manage-account-links"
+                          ]
+                      }
+                  },
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
+              },
+              {
+                  "id": "76fb4026-c5e6-4a7c-948d-ef46cc837852",
+                  "name": "view-profile",
+                  "description": "${role_view-profile}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
+              },
+              {
+                  "id": "7a3e2678-e64d-43b7-a749-fd91c5f8e415",
+                  "name": "view-groups",
+                  "description": "${role_view-groups}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
+              },
+              {
+                  "id": "93feab65-1196-499a-ad78-c3d38b26a653",
+                  "name": "manage-account-links",
+                  "description": "${role_manage-account-links}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
+              },
+              {
+                  "id": "a985566b-6df2-48e5-a81d-f23f1509a074",
+                  "name": "delete-account",
+                  "description": "${role_delete-account}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
+              },
+              {
+                  "id": "8c9f1ab5-a69e-40e2-bf2f-294f6d483ce1",
+                  "name": "view-consent",
+                  "description": "${role_view-consent}",
+                  "composite": false,
+                  "clientRole": true,
+                  "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+                  "attributes": {}
               }
-            },
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "76358e4d-eb1c-4d20-9fc6-4a1fe66ce547",
-            "name": "manage-events",
-            "description": "${role_manage-events}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "0d86a9c9-d218-48ca-b362-b9cfb9f1cec7",
-            "name": "manage-clients",
-            "description": "${role_manage-clients}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "8daa5681-8c5e-4842-9454-f3ee52542b62",
-            "name": "manage-users",
-            "description": "${role_manage-users}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          },
-          {
-            "id": "4b1f822c-9ad8-4f64-abac-d6d67d8b5c27",
-            "name": "view-realm",
-            "description": "${role_view-realm}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-            "attributes": {}
-          }
-        ],
-        "security-admin-console": [],
-        "admin-cli": [],
-        "account-console": [],
-        "broker": [
-          {
-            "id": "7781303d-b0d3-4c73-bfb8-4aafb4c6fe20",
-            "name": "read-token",
-            "description": "${role_read-token}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
-            "attributes": {}
-          }
-        ],
-        "account": [
-          {
-            "id": "66091206-7730-446e-9a55-7c68c990d60a",
-            "name": "manage-consent",
-            "description": "${role_manage-consent}",
-            "composite": true,
-            "composites": {
-              "client": {
-                "account": [
-                  "view-consent"
-                ]
-              }
-            },
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          },
-          {
-            "id": "b945fcb1-4882-4d55-bfac-dfdc8923ba80",
-            "name": "view-applications",
-            "description": "${role_view-applications}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          },
-          {
-            "id": "1b79071c-e0c6-4b14-980d-a673410308f5",
-            "name": "manage-account",
-            "description": "${role_manage-account}",
-            "composite": true,
-            "composites": {
-              "client": {
-                "account": [
-                  "manage-account-links"
-                ]
-              }
-            },
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          },
-          {
-            "id": "76fb4026-c5e6-4a7c-948d-ef46cc837852",
-            "name": "view-profile",
-            "description": "${role_view-profile}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          },
-          {
-            "id": "7a3e2678-e64d-43b7-a749-fd91c5f8e415",
-            "name": "view-groups",
-            "description": "${role_view-groups}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          },
-          {
-            "id": "93feab65-1196-499a-ad78-c3d38b26a653",
-            "name": "manage-account-links",
-            "description": "${role_manage-account-links}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          },
-          {
-            "id": "a985566b-6df2-48e5-a81d-f23f1509a074",
-            "name": "delete-account",
-            "description": "${role_delete-account}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          },
-          {
-            "id": "8c9f1ab5-a69e-40e2-bf2f-294f6d483ce1",
-            "name": "view-consent",
-            "description": "${role_view-consent}",
-            "composite": false,
-            "clientRole": true,
-            "containerId": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-            "attributes": {}
-          }
-        ]
+          ]
       }
-    },
-    "groups": [
+  },
+  "groups": [
       {
-        "id": "53521ed0-aa44-4007-9727-0015d5281c3e",
-        "name": "UDS Core",
-        "path": "/UDS Core",
-        "subGroups": [
-          {
-            "id": "1ce48bde-e0e9-4bac-8b77-8b4cc96d2135",
-            "name": "Admin",
-            "path": "/UDS Core/Admin",
-            "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
-          },
-          {
-            "id": "03a34e8e-be2d-44cd-8ad2-75e90e28f6d9",
-            "name": "Auditor",
-            "path": "/UDS Core/Auditor",
-            "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
-          }
-        ]
+          "id": "53521ed0-aa44-4007-9727-0015d5281c3e",
+          "name": "UDS Core",
+          "path": "/UDS Core",
+          "subGroups": [
+              {
+                  "id": "1ce48bde-e0e9-4bac-8b77-8b4cc96d2135",
+                  "name": "Admin",
+                  "path": "/UDS Core/Admin",
+                  "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
+              },
+              {
+                  "id": "03a34e8e-be2d-44cd-8ad2-75e90e28f6d9",
+                  "name": "Auditor",
+                  "path": "/UDS Core/Auditor",
+                  "parentId": "53521ed0-aa44-4007-9727-0015d5281c3e"
+              }
+          ]
       }
-    ],
-    "defaultRole": {
+  ],
+  "defaultRole": {
       "id": "43896191-186c-4fbb-8ca5-cc912b5bc1ad",
       "name": "default-roles-uds",
       "description": "${role_default-roles}",
       "composite": true,
       "clientRole": false,
       "containerId": "uds"
-    },
-    "requiredCredentials": [
+  },
+  "requiredCredentials": [
       "password"
-    ],
-    "passwordPolicy": "${REALM_PASSWORD_POLICY}",
-    "otpPolicyType": "totp",
-    "otpPolicyAlgorithm": "HmacSHA1",
-    "otpPolicyInitialCounter": 0,
-    "otpPolicyDigits": 6,
-    "otpPolicyLookAheadWindow": 3,
-    "otpPolicyPeriod": 30,
-    "otpPolicyCodeReusable": false,
-    "otpSupportedApplications": [
+  ],
+  "passwordPolicy": "${REALM_PASSWORD_POLICY}",
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 3,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
       "totpAppFreeOTPName",
       "totpAppGoogleName",
       "totpAppMicrosoftAuthenticatorName"
-    ],
-    "localizationTexts": {},
-    "webAuthnPolicyRpEntityName": "keycloak",
-    "webAuthnPolicySignatureAlgorithms": [
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
       "ES256"
-    ],
-    "webAuthnPolicyRpId": "",
-    "webAuthnPolicyAttestationConveyancePreference": "not specified",
-    "webAuthnPolicyAuthenticatorAttachment": "not specified",
-    "webAuthnPolicyRequireResidentKey": "not specified",
-    "webAuthnPolicyUserVerificationRequirement": "not specified",
-    "webAuthnPolicyCreateTimeout": 0,
-    "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
-    "webAuthnPolicyAcceptableAaguids": [],
-    "webAuthnPolicyExtraOrigins": [],
-    "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
-    "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
       "ES256"
-    ],
-    "webAuthnPolicyPasswordlessRpId": "",
-    "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
-    "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
-    "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
-    "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
-    "webAuthnPolicyPasswordlessCreateTimeout": 0,
-    "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
-    "webAuthnPolicyPasswordlessAcceptableAaguids": [],
-    "webAuthnPolicyPasswordlessExtraOrigins": [],
-    "scopeMappings": [
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "scopeMappings": [
       {
-        "clientScope": "offline_access",
-        "roles": [
-          "offline_access"
-        ]
-      }
-    ],
-    "clientScopeMappings": {
-      "account": [
-        {
-          "client": "account-console",
+          "clientScope": "offline_access",
           "roles": [
-            "manage-account",
-            "view-groups"
+              "offline_access"
           ]
-        }
+      }
+  ],
+  "clientScopeMappings": {
+      "account": [
+          {
+              "client": "account-console",
+              "roles": [
+                  "manage-account",
+                  "view-groups"
+              ]
+          }
       ]
-    },
-    "clients": [
+  },
+  "clients": [
       {
-        "id": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
-        "clientId": "account",
-        "name": "Account",
-        "description": "",
-        "rootUrl": "${authBaseUrl}",
-        "adminUrl": "",
-        "baseUrl": "/realms/uds/account/",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [
-          "/realms/uds/account/*"
-        ],
-        "webOrigins": [],
-        "notBefore": 0,
-        "bearerOnly": false,
-        "consentRequired": false,
-        "standardFlowEnabled": true,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": false,
-        "serviceAccountsEnabled": false,
-        "publicClient": true,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-          "oidc.ciba.grant.enabled": "false",
-          "backchannel.logout.session.required": "true",
-          "post.logout.redirect.uris": "+",
-          "oauth2.device.authorization.grant.enabled": "false",
-          "display.on.consent.screen": "false",
-          "backchannel.logout.revoke.offline.tokens": "false"
-        },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": false,
-        "nodeReRegistrationTimeout": 0,
-        "defaultClientScopes": [
-          "web-origins",
-          "acr",
-          "profile",
-          "roles",
-          "email"
-        ],
-        "optionalClientScopes": [
-          "address",
-          "phone",
-          "offline_access",
-          "microprofile-jwt"
-        ]
+          "id": "516dd7b4-6edd-4a3d-b4ca-8b367c501b73",
+          "clientId": "account",
+          "name": "Account",
+          "description": "",
+          "rootUrl": "${authBaseUrl}",
+          "adminUrl": "",
+          "baseUrl": "/realms/uds/account/",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [
+              "/realms/uds/account/*"
+          ],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+              "oidc.ciba.grant.enabled": "false",
+              "backchannel.logout.session.required": "true",
+              "post.logout.redirect.uris": "+",
+              "oauth2.device.authorization.grant.enabled": "false",
+              "display.on.consent.screen": "false",
+              "backchannel.logout.revoke.offline.tokens": "false"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+              "web-origins",
+              "acr",
+              "profile",
+              "roles",
+              "email"
+          ],
+          "optionalClientScopes": [
+              "address",
+              "phone",
+              "offline_access",
+              "microprofile-jwt"
+          ]
       },
       {
-        "id": "f5c075d3-33ea-4bd6-8629-a3ecbeda72d9",
-        "clientId": "account-console",
-        "name": "My Account",
-        "description": "",
-        "rootUrl": "${authBaseUrl}",
-        "adminUrl": "",
-        "baseUrl": "/realms/uds/account/",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [
-          "/realms/uds/account/*"
-        ],
-        "webOrigins": [],
-        "notBefore": 0,
-        "bearerOnly": false,
-        "consentRequired": false,
-        "standardFlowEnabled": true,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": false,
-        "serviceAccountsEnabled": false,
-        "publicClient": true,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-          "oidc.ciba.grant.enabled": "false",
-          "backchannel.logout.session.required": "true",
-          "post.logout.redirect.uris": "+",
-          "oauth2.device.authorization.grant.enabled": "false",
-          "display.on.consent.screen": "false",
-          "pkce.code.challenge.method": "S256",
-          "backchannel.logout.revoke.offline.tokens": "false"
-        },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": false,
-        "nodeReRegistrationTimeout": 0,
-        "protocolMappers": [
-          {
-            "id": "254c52b4-d381-4612-a26f-ba7586d1d9a3",
-            "name": "audience resolve",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-audience-resolve-mapper",
-            "consentRequired": false,
-            "config": {}
-          }
-        ],
-        "defaultClientScopes": [
-          "web-origins",
-          "acr",
-          "profile",
-          "roles",
-          "email"
-        ],
-        "optionalClientScopes": [
-          "address",
-          "phone",
-          "offline_access",
-          "microprofile-jwt"
-        ]
+          "id": "f5c075d3-33ea-4bd6-8629-a3ecbeda72d9",
+          "clientId": "account-console",
+          "name": "My Account",
+          "description": "",
+          "rootUrl": "${authBaseUrl}",
+          "adminUrl": "",
+          "baseUrl": "/realms/uds/account/",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [
+              "/realms/uds/account/*"
+          ],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+              "oidc.ciba.grant.enabled": "false",
+              "backchannel.logout.session.required": "true",
+              "post.logout.redirect.uris": "+",
+              "oauth2.device.authorization.grant.enabled": "false",
+              "display.on.consent.screen": "false",
+              "pkce.code.challenge.method": "S256",
+              "backchannel.logout.revoke.offline.tokens": "false"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "protocolMappers": [
+              {
+                  "id": "254c52b4-d381-4612-a26f-ba7586d1d9a3",
+                  "name": "audience resolve",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-audience-resolve-mapper",
+                  "consentRequired": false,
+                  "config": {}
+              }
+          ],
+          "defaultClientScopes": [
+              "web-origins",
+              "acr",
+              "profile",
+              "roles",
+              "email"
+          ],
+          "optionalClientScopes": [
+              "address",
+              "phone",
+              "offline_access",
+              "microprofile-jwt"
+          ]
       },
       {
-        "id": "deca352c-0907-40ca-aea7-ea92792d6246",
-        "clientId": "admin-cli",
-        "name": "${client_admin-cli}",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [],
-        "webOrigins": [],
-        "notBefore": 0,
-        "bearerOnly": false,
-        "consentRequired": false,
-        "standardFlowEnabled": false,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": true,
-        "serviceAccountsEnabled": false,
-        "publicClient": true,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-          "post.logout.redirect.uris": "+"
-        },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": false,
-        "nodeReRegistrationTimeout": 0,
-        "defaultClientScopes": [
-          "web-origins",
-          "acr",
-          "profile",
-          "roles",
-          "email"
-        ],
-        "optionalClientScopes": [
-          "address",
-          "phone",
-          "offline_access",
-          "microprofile-jwt"
-        ]
+          "id": "deca352c-0907-40ca-aea7-ea92792d6246",
+          "clientId": "admin-cli",
+          "name": "${client_admin-cli}",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": false,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+              "post.logout.redirect.uris": "+"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+              "web-origins",
+              "acr",
+              "profile",
+              "roles",
+              "email"
+          ],
+          "optionalClientScopes": [
+              "address",
+              "phone",
+              "offline_access",
+              "microprofile-jwt"
+          ]
       },
       {
-        "id": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
-        "clientId": "broker",
-        "name": "Broker",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [],
-        "webOrigins": [],
-        "notBefore": 0,
-        "bearerOnly": true,
-        "consentRequired": false,
-        "standardFlowEnabled": true,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": false,
-        "serviceAccountsEnabled": false,
-        "publicClient": false,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-          "post.logout.redirect.uris": "+"
-        },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": false,
-        "nodeReRegistrationTimeout": 0,
-        "defaultClientScopes": [
-          "web-origins",
-          "acr",
-          "profile",
-          "roles",
-          "email"
-        ],
-        "optionalClientScopes": [
-          "address",
-          "phone",
-          "offline_access",
-          "microprofile-jwt"
-        ]
+          "id": "d5122807-79a3-4ee5-8765-ab070de4b8e4",
+          "clientId": "broker",
+          "name": "Broker",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": true,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": false,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+              "post.logout.redirect.uris": "+"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+              "web-origins",
+              "acr",
+              "profile",
+              "roles",
+              "email"
+          ],
+          "optionalClientScopes": [
+              "address",
+              "phone",
+              "offline_access",
+              "microprofile-jwt"
+          ]
       },
       {
-        "id": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
-        "clientId": "realm-management",
-        "name": "Realm Management",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [],
-        "webOrigins": [],
-        "notBefore": 0,
-        "bearerOnly": true,
-        "consentRequired": false,
-        "standardFlowEnabled": true,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": false,
-        "serviceAccountsEnabled": false,
-        "publicClient": false,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-          "post.logout.redirect.uris": "+"
-        },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": false,
-        "nodeReRegistrationTimeout": 0,
-        "defaultClientScopes": [
-          "web-origins",
-          "acr",
-          "profile",
-          "roles",
-          "email"
-        ],
-        "optionalClientScopes": [
-          "address",
-          "phone",
-          "offline_access",
-          "microprofile-jwt"
-        ]
+          "id": "910f78e7-980f-4072-8e80-a9bbbf9c5ca2",
+          "clientId": "realm-management",
+          "name": "Realm Management",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [],
+          "webOrigins": [],
+          "notBefore": 0,
+          "bearerOnly": true,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": false,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+              "post.logout.redirect.uris": "+"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "defaultClientScopes": [
+              "web-origins",
+              "acr",
+              "profile",
+              "roles",
+              "email"
+          ],
+          "optionalClientScopes": [
+              "address",
+              "phone",
+              "offline_access",
+              "microprofile-jwt"
+          ]
       },
       {
-        "id": "51bb67ac-a911-4594-96fa-0c9af22daead",
-        "clientId": "security-admin-console",
-        "name": "Security Admin Console",
-        "description": "",
-        "rootUrl": "${authAdminUrl}",
-        "adminUrl": "",
-        "baseUrl": "/admin/uds/console/",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [
-          "/admin/uds/console/*"
-        ],
-        "webOrigins": [
-          "+"
-        ],
-        "notBefore": 0,
-        "bearerOnly": false,
-        "consentRequired": false,
-        "standardFlowEnabled": true,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": false,
-        "serviceAccountsEnabled": false,
-        "publicClient": true,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-          "oidc.ciba.grant.enabled": "false",
-          "backchannel.logout.session.required": "true",
-          "post.logout.redirect.uris": "+",
-          "oauth2.device.authorization.grant.enabled": "false",
-          "display.on.consent.screen": "false",
-          "pkce.code.challenge.method": "S256",
-          "backchannel.logout.revoke.offline.tokens": "false"
-        },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": false,
-        "nodeReRegistrationTimeout": 0,
-        "protocolMappers": [
-          {
-            "id": "461284ab-c557-4d08-9ade-0328d2d6d0c0",
-            "name": "locale",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "locale",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "locale",
-              "jsonType.label": "String"
-            }
-          }
-        ],
-        "defaultClientScopes": [
-          "web-origins",
-          "acr",
-          "profile",
-          "roles",
-          "email"
-        ],
-        "optionalClientScopes": [
-          "address",
-          "phone",
-          "offline_access",
-          "microprofile-jwt"
-        ]
+          "id": "51bb67ac-a911-4594-96fa-0c9af22daead",
+          "clientId": "security-admin-console",
+          "name": "Security Admin Console",
+          "description": "",
+          "rootUrl": "${authAdminUrl}",
+          "adminUrl": "",
+          "baseUrl": "/admin/uds/console/",
+          "surrogateAuthRequired": false,
+          "enabled": true,
+          "alwaysDisplayInConsole": false,
+          "clientAuthenticatorType": "client-secret",
+          "redirectUris": [
+              "/admin/uds/console/*"
+          ],
+          "webOrigins": [
+              "+"
+          ],
+          "notBefore": 0,
+          "bearerOnly": false,
+          "consentRequired": false,
+          "standardFlowEnabled": true,
+          "implicitFlowEnabled": false,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "publicClient": true,
+          "frontchannelLogout": false,
+          "protocol": "openid-connect",
+          "attributes": {
+              "oidc.ciba.grant.enabled": "false",
+              "backchannel.logout.session.required": "true",
+              "post.logout.redirect.uris": "+",
+              "oauth2.device.authorization.grant.enabled": "false",
+              "display.on.consent.screen": "false",
+              "pkce.code.challenge.method": "S256",
+              "backchannel.logout.revoke.offline.tokens": "false"
+          },
+          "authenticationFlowBindingOverrides": {},
+          "fullScopeAllowed": false,
+          "nodeReRegistrationTimeout": 0,
+          "protocolMappers": [
+              {
+                  "id": "461284ab-c557-4d08-9ade-0328d2d6d0c0",
+                  "name": "locale",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                  }
+              }
+          ],
+          "defaultClientScopes": [
+              "web-origins",
+              "acr",
+              "profile",
+              "roles",
+              "email"
+          ],
+          "optionalClientScopes": [
+              "address",
+              "phone",
+              "offline_access",
+              "microprofile-jwt"
+          ]
       }
-    ],
-    "clientScopes": [
+  ],
+  "clientScopes": [
       {
-        "id": "ad5955d0-5a02-4d77-9729-c9c50e3c614f",
-        "name": "role_list",
-        "description": "SAML role list",
-        "protocol": "saml",
-        "attributes": {
-          "consent.screen.text": "${samlRoleListScopeConsentText}",
-          "display.on.consent.screen": "true"
-        },
-        "protocolMappers": [
-          {
-            "id": "8dbe7da2-9fae-4e24-b258-adffce4af581",
-            "name": "role list",
-            "protocol": "saml",
-            "protocolMapper": "saml-role-list-mapper",
-            "consentRequired": false,
-            "config": {
-              "single": "false",
-              "attribute.nameformat": "Basic",
-              "attribute.name": "Role"
-            }
+          "id": "ad5955d0-5a02-4d77-9729-c9c50e3c614f",
+          "name": "role_list",
+          "description": "SAML role list",
+          "protocol": "saml",
+          "attributes": {
+              "consent.screen.text": "${samlRoleListScopeConsentText}",
+              "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+              {
+                  "id": "8dbe7da2-9fae-4e24-b258-adffce4af581",
+                  "name": "role list",
+                  "protocol": "saml",
+                  "protocolMapper": "saml-role-list-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "single": "false",
+                      "attribute.nameformat": "Basic",
+                      "attribute.name": "Role"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "a56e312f-85f1-4c48-9822-b2c73ec29fef",
+          "name": "phone",
+          "description": "OpenID Connect built-in scope: phone",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "true",
+              "display.on.consent.screen": "true",
+              "consent.screen.text": "${phoneScopeConsentText}"
+          },
+          "protocolMappers": [
+              {
+                  "id": "5cb0a293-9545-4125-9a93-be8ff09805e8",
+                  "name": "phone number",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumber",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "f70f8a3d-2ef3-4b05-a33d-0b825406c703",
+                  "name": "phone number verified",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumberVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number_verified",
+                      "jsonType.label": "boolean"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "6970f878-3093-40f0-b48e-a749087760dc",
+          "name": "microprofile-jwt",
+          "description": "Microprofile - JWT built-in scope",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "true",
+              "display.on.consent.screen": "false"
+          },
+          "protocolMappers": [
+              {
+                  "id": "b1994403-6493-4e5c-92bf-b41db1342f74",
+                  "name": "upn",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "upn",
+                      "jsonType.label": "String"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "15fd77dc-7f74-4c66-83bb-0b9350c6b554",
+          "name": "email",
+          "description": "OpenID Connect built-in scope: email",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "true",
+              "display.on.consent.screen": "true",
+              "consent.screen.text": "${emailScopeConsentText}"
+          },
+          "protocolMappers": [
+              {
+                  "id": "381b388d-b090-47b5-be92-713204f48163",
+                  "name": "email",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "email",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "eb386cd0-5efc-4087-ac56-8b3d0530a950",
+                  "name": "email verified",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-property-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "emailVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email_verified",
+                      "jsonType.label": "boolean"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "752a2fd8-ace8-407c-a1bf-d74f7f14b79c",
+          "name": "profile",
+          "description": "OpenID Connect built-in scope: profile",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "true",
+              "display.on.consent.screen": "true",
+              "consent.screen.text": "${profileScopeConsentText}"
+          },
+          "protocolMappers": [
+              {
+                  "id": "ca69a4e5-c386-477f-9f92-d4cc90e3e9c6",
+                  "name": "picture",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "picture",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "picture",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "7d126b72-cc83-45b7-8213-e5a2e52df40d",
+                  "name": "website",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "website",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "website",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "57a93d89-f1e0-4fb6-9abb-c709f5b265a5",
+                  "name": "zoneinfo",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "zoneinfo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "zoneinfo",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "958c9a5d-87a8-4c93-989e-3e41283bab1f",
+                  "name": "birthdate",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "birthdate",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "birthdate",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "2f254814-1025-4290-8008-7a9ed422e53c",
+                  "name": "username",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "preferred_username",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "1b28f611-9197-43cf-a1af-ac6a404553d6",
+                  "name": "locale",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "fa02cb75-2f6c-44ee-b9b7-103efd0ae92b",
+                  "name": "middle name",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "middleName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "middle_name",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "92b04117-abb1-4afe-ab2d-4863671d4b11",
+                  "name": "updated at",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "updatedAt",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "updated_at",
+                      "jsonType.label": "long"
+                  }
+              },
+              {
+                  "id": "f5965fdb-2351-4681-b0d6-8576f4b2186d",
+                  "name": "nickname",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "nickname",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "nickname",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "574469f2-13ec-4240-ad18-f8ac02374cab",
+                  "name": "given name",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "firstName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "given_name",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "39ed2777-22c8-428d-893e-3df346eea7e4",
+                  "name": "groups",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-group-membership-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "full.path": "true",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "multivalued": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "groups"
+                  }
+              },
+              {
+                  "id": "6d52407c-f35d-4f1f-8fee-46a3c1d25afe",
+                  "name": "full name",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-full-name-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                  }
+              },
+              {
+                  "id": "e7dedcf0-2b37-45bd-a31c-f7a2b7f3c5ac",
+                  "name": "family name",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "lastName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "family_name",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "bd488196-dcbf-434f-90ba-0a8b5f9a9e27",
+                  "name": "gender",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "gender",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "gender",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "f16482ec-79c4-491b-b1a7-67a14c882be5",
+                  "name": "profile",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-attribute-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "profile",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "profile",
+                      "jsonType.label": "String"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "1a66d616-6eb0-45d7-89f7-df975f26a88e",
+          "name": "roles",
+          "description": "OpenID Connect scope for add user roles to the access token",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "false",
+              "display.on.consent.screen": "true",
+              "consent.screen.text": "${rolesScopeConsentText}"
+          },
+          "protocolMappers": [
+              {
+                  "id": "17a0e011-6792-4112-b787-e3748e2fe255",
+                  "name": "realm roles",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "realm_access.roles",
+                      "jsonType.label": "String"
+                  }
+              },
+              {
+                  "id": "e91b9e2a-b20e-47c5-bb72-e4e999c0f9a7",
+                  "name": "audience resolve",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-audience-resolve-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                  }
+              },
+              {
+                  "id": "021aabc9-aca3-4a31-9fa4-3b4d4fc5d129",
+                  "name": "client roles",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usermodel-client-role-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "resource_access.${client_id}.roles",
+                      "jsonType.label": "String"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "80bca4fb-c991-4f47-b941-90033d417619",
+          "name": "web-origins",
+          "description": "OpenID Connect scope for add allowed web origins to the access token",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "false",
+              "display.on.consent.screen": "false",
+              "consent.screen.text": ""
+          },
+          "protocolMappers": [
+              {
+                  "id": "65298359-14d0-4291-899e-3ca27dbf283b",
+                  "name": "allowed web origins",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-allowed-origins-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "770edec1-8367-40cc-834c-ee2ef116cb0a",
+          "name": "offline_access",
+          "description": "OpenID Connect built-in scope: offline_access",
+          "protocol": "openid-connect",
+          "attributes": {
+              "consent.screen.text": "${offlineAccessScopeConsentText}",
+              "display.on.consent.screen": "true"
           }
-        ]
       },
       {
-        "id": "a56e312f-85f1-4c48-9822-b2c73ec29fef",
-        "name": "phone",
-        "description": "OpenID Connect built-in scope: phone",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "true",
-          "display.on.consent.screen": "true",
-          "consent.screen.text": "${phoneScopeConsentText}"
-        },
-        "protocolMappers": [
-          {
-            "id": "5cb0a293-9545-4125-9a93-be8ff09805e8",
-            "name": "phone number",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "phoneNumber",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "phone_number",
-              "jsonType.label": "String"
-            }
+          "id": "0c4e8857-3a4c-4ef6-bac7-952b24a7591e",
+          "name": "acr",
+          "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "false",
+              "display.on.consent.screen": "false"
           },
-          {
-            "id": "f70f8a3d-2ef3-4b05-a33d-0b825406c703",
-            "name": "phone number verified",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "phoneNumberVerified",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "phone_number_verified",
-              "jsonType.label": "boolean"
-            }
+          "protocolMappers": [
+              {
+                  "id": "3db9f004-36c9-4154-a076-6f027699aad4",
+                  "name": "acr loa level",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-acr-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "76a50ab0-c3e2-4224-b89f-6cec16ab87c4",
+          "name": "address",
+          "description": "OpenID Connect built-in scope: address",
+          "protocol": "openid-connect",
+          "attributes": {
+              "include.in.token.scope": "true",
+              "display.on.consent.screen": "true",
+              "consent.screen.text": "${addressScopeConsentText}"
+          },
+          "protocolMappers": [
+              {
+                  "id": "ab3891ab-f49e-4f23-b6fd-d456c0084d9b",
+                  "name": "address",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-address-mapper",
+                  "consentRequired": false,
+                  "config": {
+                      "user.attribute.formatted": "formatted",
+                      "user.attribute.country": "country",
+                      "introspection.token.claim": "true",
+                      "user.attribute.postal_code": "postal_code",
+                      "userinfo.token.claim": "true",
+                      "user.attribute.street": "street",
+                      "id.token.claim": "true",
+                      "user.attribute.region": "region",
+                      "access.token.claim": "true",
+                      "user.attribute.locality": "locality"
+                  }
+              }
+          ]
+      },
+      {
+          "id": "52fa0872-8912-4096-a124-da2c077b5539",
+          "name": "openid",
+          "description": "OpenID Connect built-in scope: openid",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
           }
-        ]
-      },
-      {
-        "id": "6970f878-3093-40f0-b48e-a749087760dc",
-        "name": "microprofile-jwt",
-        "description": "Microprofile - JWT built-in scope",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "true",
-          "display.on.consent.screen": "false"
-        },
-        "protocolMappers": [
-          {
-            "id": "b1994403-6493-4e5c-92bf-b41db1342f74",
-            "name": "upn",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "username",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "upn",
-              "jsonType.label": "String"
-            }
-          }
-        ]
-      },
-      {
-        "id": "15fd77dc-7f74-4c66-83bb-0b9350c6b554",
-        "name": "email",
-        "description": "OpenID Connect built-in scope: email",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "true",
-          "display.on.consent.screen": "true",
-          "consent.screen.text": "${emailScopeConsentText}"
-        },
-        "protocolMappers": [
-          {
-            "id": "381b388d-b090-47b5-be92-713204f48163",
-            "name": "email",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "email",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "email",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "eb386cd0-5efc-4087-ac56-8b3d0530a950",
-            "name": "email verified",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-property-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "emailVerified",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "email_verified",
-              "jsonType.label": "boolean"
-            }
-          }
-        ]
-      },
-      {
-        "id": "752a2fd8-ace8-407c-a1bf-d74f7f14b79c",
-        "name": "profile",
-        "description": "OpenID Connect built-in scope: profile",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "true",
-          "display.on.consent.screen": "true",
-          "consent.screen.text": "${profileScopeConsentText}"
-        },
-        "protocolMappers": [
-          {
-            "id": "ca69a4e5-c386-477f-9f92-d4cc90e3e9c6",
-            "name": "picture",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "picture",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "picture",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "7d126b72-cc83-45b7-8213-e5a2e52df40d",
-            "name": "website",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "website",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "website",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "57a93d89-f1e0-4fb6-9abb-c709f5b265a5",
-            "name": "zoneinfo",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "zoneinfo",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "zoneinfo",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "958c9a5d-87a8-4c93-989e-3e41283bab1f",
-            "name": "birthdate",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "birthdate",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "birthdate",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "2f254814-1025-4290-8008-7a9ed422e53c",
-            "name": "username",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "username",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "preferred_username",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "1b28f611-9197-43cf-a1af-ac6a404553d6",
-            "name": "locale",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "locale",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "locale",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "fa02cb75-2f6c-44ee-b9b7-103efd0ae92b",
-            "name": "middle name",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "middleName",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "middle_name",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "92b04117-abb1-4afe-ab2d-4863671d4b11",
-            "name": "updated at",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "updatedAt",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "updated_at",
-              "jsonType.label": "long"
-            }
-          },
-          {
-            "id": "f5965fdb-2351-4681-b0d6-8576f4b2186d",
-            "name": "nickname",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "nickname",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "nickname",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "574469f2-13ec-4240-ad18-f8ac02374cab",
-            "name": "given name",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "firstName",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "given_name",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "39ed2777-22c8-428d-893e-3df346eea7e4",
-            "name": "groups",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-group-membership-mapper",
-            "consentRequired": false,
-            "config": {
-              "full.path": "true",
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "multivalued": "true",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "groups"
-            }
-          },
-          {
-            "id": "6d52407c-f35d-4f1f-8fee-46a3c1d25afe",
-            "name": "full name",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-full-name-mapper",
-            "consentRequired": false,
-            "config": {
-              "id.token.claim": "true",
-              "introspection.token.claim": "true",
-              "access.token.claim": "true",
-              "userinfo.token.claim": "true"
-            }
-          },
-          {
-            "id": "e7dedcf0-2b37-45bd-a31c-f7a2b7f3c5ac",
-            "name": "family name",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "lastName",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "family_name",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "bd488196-dcbf-434f-90ba-0a8b5f9a9e27",
-            "name": "gender",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "gender",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "gender",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "f16482ec-79c4-491b-b1a7-67a14c882be5",
-            "name": "profile",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-attribute-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "userinfo.token.claim": "true",
-              "user.attribute": "profile",
-              "id.token.claim": "true",
-              "access.token.claim": "true",
-              "claim.name": "profile",
-              "jsonType.label": "String"
-            }
-          }
-        ]
-      },
-      {
-        "id": "1a66d616-6eb0-45d7-89f7-df975f26a88e",
-        "name": "roles",
-        "description": "OpenID Connect scope for add user roles to the access token",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "false",
-          "display.on.consent.screen": "true",
-          "consent.screen.text": "${rolesScopeConsentText}"
-        },
-        "protocolMappers": [
-          {
-            "id": "17a0e011-6792-4112-b787-e3748e2fe255",
-            "name": "realm roles",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-realm-role-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "multivalued": "true",
-              "user.attribute": "foo",
-              "access.token.claim": "true",
-              "claim.name": "realm_access.roles",
-              "jsonType.label": "String"
-            }
-          },
-          {
-            "id": "e91b9e2a-b20e-47c5-bb72-e4e999c0f9a7",
-            "name": "audience resolve",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-audience-resolve-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "access.token.claim": "true"
-            }
-          },
-          {
-            "id": "021aabc9-aca3-4a31-9fa4-3b4d4fc5d129",
-            "name": "client roles",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-client-role-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "multivalued": "true",
-              "user.attribute": "foo",
-              "access.token.claim": "true",
-              "claim.name": "resource_access.${client_id}.roles",
-              "jsonType.label": "String"
-            }
-          }
-        ]
-      },
-      {
-        "id": "80bca4fb-c991-4f47-b941-90033d417619",
-        "name": "web-origins",
-        "description": "OpenID Connect scope for add allowed web origins to the access token",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "false",
-          "display.on.consent.screen": "false",
-          "consent.screen.text": ""
-        },
-        "protocolMappers": [
-          {
-            "id": "65298359-14d0-4291-899e-3ca27dbf283b",
-            "name": "allowed web origins",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-allowed-origins-mapper",
-            "consentRequired": false,
-            "config": {
-              "introspection.token.claim": "true",
-              "access.token.claim": "true"
-            }
-          }
-        ]
-      },
-      {
-        "id": "770edec1-8367-40cc-834c-ee2ef116cb0a",
-        "name": "offline_access",
-        "description": "OpenID Connect built-in scope: offline_access",
-        "protocol": "openid-connect",
-        "attributes": {
-          "consent.screen.text": "${offlineAccessScopeConsentText}",
-          "display.on.consent.screen": "true"
-        }
-      },
-      {
-        "id": "0c4e8857-3a4c-4ef6-bac7-952b24a7591e",
-        "name": "acr",
-        "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "false",
-          "display.on.consent.screen": "false"
-        },
-        "protocolMappers": [
-          {
-            "id": "3db9f004-36c9-4154-a076-6f027699aad4",
-            "name": "acr loa level",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-acr-mapper",
-            "consentRequired": false,
-            "config": {
-              "id.token.claim": "true",
-              "introspection.token.claim": "true",
-              "access.token.claim": "true",
-              "userinfo.token.claim": "true"
-            }
-          }
-        ]
-      },
-      {
-        "id": "76a50ab0-c3e2-4224-b89f-6cec16ab87c4",
-        "name": "address",
-        "description": "OpenID Connect built-in scope: address",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "true",
-          "display.on.consent.screen": "true",
-          "consent.screen.text": "${addressScopeConsentText}"
-        },
-        "protocolMappers": [
-          {
-            "id": "ab3891ab-f49e-4f23-b6fd-d456c0084d9b",
-            "name": "address",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-address-mapper",
-            "consentRequired": false,
-            "config": {
-              "user.attribute.formatted": "formatted",
-              "user.attribute.country": "country",
-              "introspection.token.claim": "true",
-              "user.attribute.postal_code": "postal_code",
-              "userinfo.token.claim": "true",
-              "user.attribute.street": "street",
-              "id.token.claim": "true",
-              "user.attribute.region": "region",
-              "access.token.claim": "true",
-              "user.attribute.locality": "locality"
-            }
-          }
-        ]
-      },
-      {
-        "id": "52fa0872-8912-4096-a124-da2c077b5539",
-        "name": "openid",
-        "description": "OpenID Connect built-in scope: openid",
-        "protocol": "openid-connect",
-        "attributes": {
-          "include.in.token.scope": "true",
-          "display.on.consent.screen": "true"
-        }
       }
-    ],
-    "defaultDefaultClientScopes": [
+  ],
+  "defaultDefaultClientScopes": [
       "role_list",
       "profile",
       "email",
       "roles",
       "web-origins",
       "acr"
-    ],
-    "defaultOptionalClientScopes": [
+  ],
+  "defaultOptionalClientScopes": [
       "offline_access",
       "address",
       "phone",
       "microprofile-jwt"
-    ],
-    "browserSecurityHeaders": {
+  ],
+  "browserSecurityHeaders": {
       "contentSecurityPolicyReportOnly": "",
       "xContentTypeOptions": "nosniff",
       "referrerPolicy": "no-referrer",
@@ -1394,17 +1394,17 @@
       "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
       "xXSSProtection": "1; mode=block",
       "strictTransportSecurity": "max-age=31536000; includeSubDomains"
-    },
-    "smtpServer": {},
-    "loginTheme": "theme",
-    "accountTheme": "theme",
-    "eventsEnabled": true,
-    "eventsExpiration": 1800,
-    "eventsListeners": [
+  },
+  "smtpServer": {},
+  "loginTheme": "theme",
+  "accountTheme": "theme",
+  "eventsEnabled": true,
+  "eventsExpiration": 1800,
+  "eventsListeners": [
       "jboss-logging",
       "custom-registration-listener"
-    ],
-    "enabledEventTypes": [
+  ],
+  "enabledEventTypes": [
       "SEND_RESET_PASSWORD",
       "UPDATE_CONSENT_ERROR",
       "GRANT_CONSENT",
@@ -1472,10 +1472,10 @@
       "CODE_TO_TOKEN",
       "GRANT_CONSENT_ERROR",
       "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
-    ],
-    "adminEventsEnabled": true,
-    "adminEventsDetailsEnabled": true,
-    "identityProviders": [
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": true,
+  "identityProviders": [
       {
         "alias": "saml",
         "displayName": "Google SSO",
@@ -1577,1065 +1577,1065 @@
         }
       }
     ],
-    "components": {
+  "components": {
       "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
-        {
-          "id": "ccd57f68-3f54-4f9b-b2a7-47cbbedefe84",
-          "name": "Allowed Client Scopes",
-          "providerId": "allowed-client-templates",
-          "subType": "anonymous",
-          "subComponents": {},
-          "config": {
-            "allow-default-scopes": [
-              "true"
-            ],
-            "allowed-client-scopes": [
-              "openid"
-            ]
+          {
+              "id": "ccd57f68-3f54-4f9b-b2a7-47cbbedefe84",
+              "name": "Allowed Client Scopes",
+              "providerId": "allowed-client-templates",
+              "subType": "anonymous",
+              "subComponents": {},
+              "config": {
+                  "allow-default-scopes": [
+                      "true"
+                  ],
+                  "allowed-client-scopes": [
+                      "openid"
+                  ]
+              }
+          },
+          {
+              "id": "7717935d-a03c-46e0-82fd-78be66dab63b",
+              "name": "Allowed Client Scopes",
+              "providerId": "allowed-client-templates",
+              "subType": "authenticated",
+              "subComponents": {},
+              "config": {
+                  "allow-default-scopes": [
+                      "true"
+                  ]
+              }
+          },
+          {
+              "id": "e3d72400-e970-4fd1-85c6-130d1f0e9b4c",
+              "name": "Full Scope Disabled",
+              "providerId": "scope",
+              "subType": "anonymous",
+              "subComponents": {},
+              "config": {}
+          },
+          {
+              "id": "0bc6c803-7a6d-46dd-b4d9-4118d7fd465b",
+              "name": "Trusted Hosts",
+              "providerId": "trusted-hosts",
+              "subType": "anonymous",
+              "subComponents": {},
+              "config": {
+                  "host-sending-registration-request-must-match": [
+                      "true"
+                  ],
+                  "trusted-hosts": [
+                      "127.0.0.6",
+                      "*.${UDS_DOMAIN}",
+                      "*.admin.${UDS_DOMAIN}"
+                  ],
+                  "client-uris-must-match": [
+                      "true"
+                  ]
+              }
           }
-        },
-        {
-          "id": "7717935d-a03c-46e0-82fd-78be66dab63b",
-          "name": "Allowed Client Scopes",
-          "providerId": "allowed-client-templates",
-          "subType": "authenticated",
-          "subComponents": {},
-          "config": {
-            "allow-default-scopes": [
-              "true"
-            ]
-          }
-        },
-        {
-          "id": "e3d72400-e970-4fd1-85c6-130d1f0e9b4c",
-          "name": "Full Scope Disabled",
-          "providerId": "scope",
-          "subType": "anonymous",
-          "subComponents": {},
-          "config": {}
-        },
-        {
-          "id": "0bc6c803-7a6d-46dd-b4d9-4118d7fd465b",
-          "name": "Trusted Hosts",
-          "providerId": "trusted-hosts",
-          "subType": "anonymous",
-          "subComponents": {},
-          "config": {
-            "host-sending-registration-request-must-match": [
-              "true"
-            ],
-            "trusted-hosts": [
-              "127.0.0.6",
-              "*.${UDS_DOMAIN}",
-              "*.admin.${UDS_DOMAIN}"
-            ],
-            "client-uris-must-match": [
-              "true"
-            ]
-          }
-        }
       ],
       "org.keycloak.userprofile.UserProfileProvider": [
-        {
-          "id": "3c5c068c-c9a5-4d68-8373-b30ae5e54c9c",
-          "providerId": "declarative-user-profile",
-          "subComponents": {},
-          "config": {
-            "kc.user.profile.config": [
-              "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
-            ]
+          {
+            "id": "3c5c068c-c9a5-4d68-8373-b30ae5e54c9c",
+            "providerId": "declarative-user-profile",
+            "subComponents": {},
+            "config": {
+              "kc.user.profile.config": [
+                "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
+              ]
+            }
           }
-        }
       ],
       "org.keycloak.keys.KeyProvider": [
-        {
-          "id": "649a4094-5312-4249-811d-82dcb8d1c5f8",
-          "name": "aes-generated",
-          "providerId": "aes-generated",
-          "subComponents": {},
-          "config": {
-            "priority": [
-              "100"
-            ]
+          {
+              "id": "649a4094-5312-4249-811d-82dcb8d1c5f8",
+              "name": "aes-generated",
+              "providerId": "aes-generated",
+              "subComponents": {},
+              "config": {
+                  "priority": [
+                      "100"
+                  ]
+              }
+          },
+          {
+              "id": "d4be2127-76f9-4539-b5cf-061ef408c1df",
+              "name": "rsa-generated",
+              "providerId": "rsa-generated",
+              "subComponents": {},
+              "config": {
+                  "priority": [
+                      "100"
+                  ]
+              }
+          },
+          {
+            "id": "df923c3c-a0ef-457c-b66c-f2c623c87586",
+            "name": "fallback-HS512",
+            "providerId": "hmac-generated",
+            "subComponents": {},
+            "config": {
+              "priority": [
+                "-100"
+              ],
+              "algorithm": [
+                "HS512"
+              ]
+            }
+          },
+          {
+              "id": "40f57a34-8abf-4464-9f74-40566c215dc6",
+              "name": "hmac-generated",
+              "providerId": "hmac-generated",
+              "subComponents": {},
+              "config": {
+                  "priority": [
+                      "100"
+                  ],
+                  "algorithm": [
+                      "HS256"
+                  ]
+              }
+          },
+          {
+              "id": "8b3e77f4-0e3c-4bbd-b539-6df8d6dfa00e",
+              "name": "rsa-enc-generated",
+              "providerId": "rsa-enc-generated",
+              "subComponents": {},
+              "config": {
+                  "priority": [
+                      "100"
+                  ],
+                  "algorithm": [
+                      "RSA-OAEP"
+                  ]
+              }
           }
-        },
-        {
-          "id": "d4be2127-76f9-4539-b5cf-061ef408c1df",
-          "name": "rsa-generated",
-          "providerId": "rsa-generated",
-          "subComponents": {},
-          "config": {
-            "priority": [
-              "100"
-            ]
-          }
-        },
-        {
-          "id": "df923c3c-a0ef-457c-b66c-f2c623c87586",
-          "name": "fallback-HS512",
-          "providerId": "hmac-generated",
-          "subComponents": {},
-          "config": {
-            "priority": [
-              "-100"
-            ],
-            "algorithm": [
-              "HS512"
-            ]
-          }
-        },
-        {
-          "id": "40f57a34-8abf-4464-9f74-40566c215dc6",
-          "name": "hmac-generated",
-          "providerId": "hmac-generated",
-          "subComponents": {},
-          "config": {
-            "priority": [
-              "100"
-            ],
-            "algorithm": [
-              "HS256"
-            ]
-          }
-        },
-        {
-          "id": "8b3e77f4-0e3c-4bbd-b539-6df8d6dfa00e",
-          "name": "rsa-enc-generated",
-          "providerId": "rsa-enc-generated",
-          "subComponents": {},
-          "config": {
-            "priority": [
-              "100"
-            ],
-            "algorithm": [
-              "RSA-OAEP"
-            ]
-          }
-        }
       ]
-    },
-    "internationalizationEnabled": false,
-    "supportedLocales": [],
-    "authenticationFlows": [
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
       {
-        "id": "5fca3666-0018-4ca1-8ec9-4b00deb3d8f1",
-        "alias": "Account verification options",
-        "description": "Method with which to verity the existing account",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "idp-email-verification",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "ALTERNATIVE",
-            "priority": 20,
-            "autheticatorFlow": true,
-            "flowAlias": "Verify Existing Account by Re-authentication",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "5fca3666-0018-4ca1-8ec9-4b00deb3d8f1",
+          "alias": "Account verification options",
+          "description": "Method with which to verity the existing account",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "idp-email-verification",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 20,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Verify Existing Account by Re-authentication",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "0c528a3a-e0d7-45f5-a458-f8c23842ab75",
-        "alias": "Authentication",
-        "description": "",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticator": "auth-cookie",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 0,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorConfig": "dod-cac",
-            "authenticator": "auth-x509-client-username-form",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 0,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "auth-username-password-form",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 1,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "0c528a3a-e0d7-45f5-a458-f8c23842ab75",
+          "alias": "Authentication",
+          "description": "",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "auth-cookie",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 0,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorConfig": "dod-cac",
+                  "authenticator": "auth-x509-client-username-form",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 0,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "auth-username-password-form",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 1,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "a09f8f86-3df3-4397-91e2-d9dad1678ded",
-        "alias": "Authentication Options",
-        "description": "Authentication options.",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "basic-auth",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "basic-auth-otp",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "auth-spnego",
-            "authenticatorFlow": false,
-            "requirement": "DISABLED",
-            "priority": 30,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "a09f8f86-3df3-4397-91e2-d9dad1678ded",
+          "alias": "Authentication Options",
+          "description": "Authentication options.",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "basic-auth",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "basic-auth-otp",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "auth-spnego",
+                  "authenticatorFlow": false,
+                  "requirement": "DISABLED",
+                  "priority": 30,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "d61e1deb-921e-412f-baed-dc51c0fdc532",
-        "alias": "Browser - Conditional OTP",
-        "description": "Flow to determine if the OTP is required for the authentication",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "conditional-user-configured",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "auth-otp-form",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "d61e1deb-921e-412f-baed-dc51c0fdc532",
+          "alias": "Browser - Conditional OTP",
+          "description": "Flow to determine if the OTP is required for the authentication",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "conditional-user-configured",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "auth-otp-form",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
-        "alias": "Conditional OTP",
-        "description": "",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticator": "conditional-user-configured",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 0,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "auth-otp-form",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 1,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
+          "alias": "Conditional OTP",
+          "description": "",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "conditional-user-configured",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 0,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "auth-otp-form",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 1,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "2a37f1ea-9a71-46bf-8c76-34c480e90521",
-        "alias": "Direct Grant - Conditional OTP",
-        "description": "Flow to determine if the OTP is required for the authentication",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "conditional-user-configured",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "direct-grant-validate-otp",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "2a37f1ea-9a71-46bf-8c76-34c480e90521",
+          "alias": "Direct Grant - Conditional OTP",
+          "description": "Flow to determine if the OTP is required for the authentication",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "conditional-user-configured",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "direct-grant-validate-otp",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "a8c9a858-6236-4e3d-8b07-716527264327",
-        "alias": "First broker login - Conditional OTP",
-        "description": "Flow to determine if the OTP is required for the authentication",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "conditional-user-configured",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "auth-otp-form",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "a8c9a858-6236-4e3d-8b07-716527264327",
+          "alias": "First broker login - Conditional OTP",
+          "description": "Flow to determine if the OTP is required for the authentication",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "conditional-user-configured",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "auth-otp-form",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "b44188c2-ddf7-4268-a860-b20e32c7fbcf",
-        "alias": "Handle Existing Account",
-        "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "idp-confirm-link",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": true,
-            "flowAlias": "Account verification options",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "b44188c2-ddf7-4268-a860-b20e32c7fbcf",
+          "alias": "Handle Existing Account",
+          "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "idp-confirm-link",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Account verification options",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
-        "alias": "MFA Login",
-        "description": "",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticator": "auth-username-password-form",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 0,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "REQUIRED",
-            "priority": 1,
-            "autheticatorFlow": true,
-            "flowAlias": "Conditional OTP",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
+          "alias": "MFA Login",
+          "description": "",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "auth-username-password-form",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 0,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "REQUIRED",
+                  "priority": 1,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Conditional OTP",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "459c187e-eb0f-4f2e-8e15-0c0b245a406e",
-        "alias": "Reset - Conditional OTP",
-        "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "conditional-user-configured",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "reset-otp",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "459c187e-eb0f-4f2e-8e15-0c0b245a406e",
+          "alias": "Reset - Conditional OTP",
+          "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "conditional-user-configured",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "reset-otp",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "f95bc9ff-dca8-4622-87d4-e89877091cc1",
-        "alias": "UDS Authentication",
-        "description": "browser based authentication",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticatorFlow": true,
-            "requirement": "REQUIRED",
-            "priority": 31,
-            "autheticatorFlow": true,
-            "flowAlias": "Authentication",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "f95bc9ff-dca8-4622-87d4-e89877091cc1",
+          "alias": "UDS Authentication",
+          "description": "browser based authentication",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "REQUIRED",
+                  "priority": 31,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Authentication",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
-        "alias": "UDS Authentication Browser - Conditional OTP",
-        "description": "Flow to determine if the OTP is required for the authentication",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticator": "conditional-user-configured",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "auth-otp-form",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
+          "alias": "UDS Authentication Browser - Conditional OTP",
+          "description": "Flow to determine if the OTP is required for the authentication",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "conditional-user-configured",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "auth-otp-form",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "2122677b-1a02-40a4-817b-66da58b1621a",
-        "alias": "UDS Registration",
-        "description": "registration flow",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticator": "registration-page-form",
-            "authenticatorFlow": true,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": true,
-            "flowAlias": "UDS registration form",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "2122677b-1a02-40a4-817b-66da58b1621a",
+          "alias": "UDS Registration",
+          "description": "registration flow",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "registration-page-form",
+                  "authenticatorFlow": true,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": true,
+                  "flowAlias": "UDS registration form",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "7f506bd3-70f7-4f99-b339-a57e5e4cb456",
-        "alias": "UDS Reset Credentials",
-        "description": "Reset credentials for a user if they forgot their password",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticator": "reset-credentials-choose-user",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "reset-credential-email",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "reset-password",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 30,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "7f506bd3-70f7-4f99-b339-a57e5e4cb456",
+          "alias": "UDS Reset Credentials",
+          "description": "Reset credentials for a user if they forgot their password",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "reset-credentials-choose-user",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "reset-credential-email",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "reset-password",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 30,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "25a3d7b4-3d46-4d66-9a14-0fd4be935dff",
-        "alias": "UDS registration form",
-        "description": "registration form",
-        "providerId": "form-flow",
-        "topLevel": false,
-        "builtIn": false,
-        "authenticationExecutions": [
-          {
-            "authenticator": "registration-user-creation",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorConfig": "main",
-            "authenticator": "registration-validation-action",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 50,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "registration-x509-password-action",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 51,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "25a3d7b4-3d46-4d66-9a14-0fd4be935dff",
+          "alias": "UDS registration form",
+          "description": "registration form",
+          "providerId": "form-flow",
+          "topLevel": false,
+          "builtIn": false,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "registration-user-creation",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorConfig": "main",
+                  "authenticator": "registration-validation-action",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 50,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "registration-x509-password-action",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 51,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "51f952e6-d3ac-49bd-8e76-fd50128a2bea",
-        "alias": "User creation or linking",
-        "description": "Flow for the existing/non-existing user alternatives",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticatorConfig": "create unique user config",
-            "authenticator": "idp-create-user-if-unique",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "ALTERNATIVE",
-            "priority": 20,
-            "autheticatorFlow": true,
-            "flowAlias": "Handle Existing Account",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "51f952e6-d3ac-49bd-8e76-fd50128a2bea",
+          "alias": "User creation or linking",
+          "description": "Flow for the existing/non-existing user alternatives",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticatorConfig": "create unique user config",
+                  "authenticator": "idp-create-user-if-unique",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 20,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Handle Existing Account",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "1f94f667-ec06-4e24-9ce5-9fac2cb87892",
-        "alias": "Verify Existing Account by Re-authentication",
-        "description": "Reauthentication of existing account",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "idp-username-password-form",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "CONDITIONAL",
-            "priority": 20,
-            "autheticatorFlow": true,
-            "flowAlias": "First broker login - Conditional OTP",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "1f94f667-ec06-4e24-9ce5-9fac2cb87892",
+          "alias": "Verify Existing Account by Re-authentication",
+          "description": "Reauthentication of existing account",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "idp-username-password-form",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "CONDITIONAL",
+                  "priority": 20,
+                  "autheticatorFlow": true,
+                  "flowAlias": "First broker login - Conditional OTP",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "128fa0e2-a2e5-4d99-87e8-e60aa672d516",
-        "alias": "browser",
-        "description": "browser based authentication",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "auth-cookie",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "auth-spnego",
-            "authenticatorFlow": false,
-            "requirement": "DISABLED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "identity-provider-redirector",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 25,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "ALTERNATIVE",
-            "priority": 30,
-            "autheticatorFlow": true,
-            "flowAlias": "forms",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "128fa0e2-a2e5-4d99-87e8-e60aa672d516",
+          "alias": "browser",
+          "description": "browser based authentication",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "auth-cookie",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "auth-spnego",
+                  "authenticatorFlow": false,
+                  "requirement": "DISABLED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "identity-provider-redirector",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 25,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 30,
+                  "autheticatorFlow": true,
+                  "flowAlias": "forms",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "3053f59e-b554-4573-9a96-092b12cf9cfb",
-        "alias": "clients",
-        "description": "Base authentication for clients",
-        "providerId": "client-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "client-secret",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "client-jwt",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "client-secret-jwt",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 30,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "client-x509",
-            "authenticatorFlow": false,
-            "requirement": "ALTERNATIVE",
-            "priority": 40,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "3053f59e-b554-4573-9a96-092b12cf9cfb",
+          "alias": "clients",
+          "description": "Base authentication for clients",
+          "providerId": "client-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "client-secret",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "client-jwt",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "client-secret-jwt",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 30,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "client-x509",
+                  "authenticatorFlow": false,
+                  "requirement": "ALTERNATIVE",
+                  "priority": 40,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "3b482c5b-59c5-4786-88f8-09123324d74d",
-        "alias": "direct grant",
-        "description": "OpenID Connect Resource Owner Grant",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "direct-grant-validate-username",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "direct-grant-validate-password",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "CONDITIONAL",
-            "priority": 30,
-            "autheticatorFlow": true,
-            "flowAlias": "Direct Grant - Conditional OTP",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "3b482c5b-59c5-4786-88f8-09123324d74d",
+          "alias": "direct grant",
+          "description": "OpenID Connect Resource Owner Grant",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "direct-grant-validate-username",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "direct-grant-validate-password",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "CONDITIONAL",
+                  "priority": 30,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Direct Grant - Conditional OTP",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "a2e76a41-9a2a-43ce-8a32-e82782f00d98",
-        "alias": "docker auth",
-        "description": "Used by Docker clients to authenticate against the IDP",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "docker-http-basic-authenticator",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "a2e76a41-9a2a-43ce-8a32-e82782f00d98",
+          "alias": "docker auth",
+          "description": "Used by Docker clients to authenticate against the IDP",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "docker-http-basic-authenticator",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "5785e630-7e91-4899-877d-569e3ac79871",
-        "alias": "first broker login",
-        "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticatorConfig": "review profile config",
-            "authenticator": "idp-review-profile",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": true,
-            "flowAlias": "User creation or linking",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "5785e630-7e91-4899-877d-569e3ac79871",
+          "alias": "first broker login",
+          "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticatorConfig": "review profile config",
+                  "authenticator": "idp-review-profile",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": true,
+                  "flowAlias": "User creation or linking",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "4950a920-1925-4deb-a45e-9035be7e7c2b",
-        "alias": "forms",
-        "description": "Username, password, otp and other auth forms.",
-        "providerId": "basic-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "auth-username-password-form",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "CONDITIONAL",
-            "priority": 20,
-            "autheticatorFlow": true,
-            "flowAlias": "Browser - Conditional OTP",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "4950a920-1925-4deb-a45e-9035be7e7c2b",
+          "alias": "forms",
+          "description": "Username, password, otp and other auth forms.",
+          "providerId": "basic-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "auth-username-password-form",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "CONDITIONAL",
+                  "priority": 20,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Browser - Conditional OTP",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "458de539-a7ff-4038-968c-86066c36b825",
-        "alias": "http challenge",
-        "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "no-cookie-redirect",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": true,
-            "flowAlias": "Authentication Options",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "458de539-a7ff-4038-968c-86066c36b825",
+          "alias": "http challenge",
+          "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "no-cookie-redirect",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Authentication Options",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "5a93f084-9395-4620-a918-47f17828cccd",
-        "alias": "registration",
-        "description": "registration flow",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "registration-page-form",
-            "authenticatorFlow": true,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": true,
-            "flowAlias": "registration form",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "5a93f084-9395-4620-a918-47f17828cccd",
+          "alias": "registration",
+          "description": "registration flow",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "registration-page-form",
+                  "authenticatorFlow": true,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": true,
+                  "flowAlias": "registration form",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "6f96df4f-5955-4531-8af3-727a40a62e75",
-        "alias": "registration form",
-        "description": "registration form",
-        "providerId": "form-flow",
-        "topLevel": false,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "registration-user-creation",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "registration-profile-action",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 40,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "registration-password-action",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 50,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "registration-recaptcha-action",
-            "authenticatorFlow": false,
-            "requirement": "DISABLED",
-            "priority": 60,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "6f96df4f-5955-4531-8af3-727a40a62e75",
+          "alias": "registration form",
+          "description": "registration form",
+          "providerId": "form-flow",
+          "topLevel": false,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "registration-user-creation",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "registration-profile-action",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 40,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "registration-password-action",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 50,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "registration-recaptcha-action",
+                  "authenticatorFlow": false,
+                  "requirement": "DISABLED",
+                  "priority": 60,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "ac02e171-c1ef-40da-be31-7b8bda5fc5ff",
-        "alias": "reset credentials",
-        "description": "Reset credentials for a user if they forgot their password or something",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "reset-credentials-choose-user",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "reset-credential-email",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 20,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticator": "reset-password",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 30,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          },
-          {
-            "authenticatorFlow": true,
-            "requirement": "CONDITIONAL",
-            "priority": 40,
-            "autheticatorFlow": true,
-            "flowAlias": "Reset - Conditional OTP",
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "ac02e171-c1ef-40da-be31-7b8bda5fc5ff",
+          "alias": "reset credentials",
+          "description": "Reset credentials for a user if they forgot their password or something",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "reset-credentials-choose-user",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "reset-credential-email",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 20,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticator": "reset-password",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 30,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              },
+              {
+                  "authenticatorFlow": true,
+                  "requirement": "CONDITIONAL",
+                  "priority": 40,
+                  "autheticatorFlow": true,
+                  "flowAlias": "Reset - Conditional OTP",
+                  "userSetupAllowed": false
+              }
+          ]
       },
       {
-        "id": "fd5f9d3b-7a95-4f93-9f5f-c839f3362e9a",
-        "alias": "saml ecp",
-        "description": "SAML ECP Profile Authentication Flow",
-        "providerId": "basic-flow",
-        "topLevel": true,
-        "builtIn": true,
-        "authenticationExecutions": [
-          {
-            "authenticator": "http-basic-authenticator",
-            "authenticatorFlow": false,
-            "requirement": "REQUIRED",
-            "priority": 10,
-            "autheticatorFlow": false,
-            "userSetupAllowed": false
-          }
-        ]
+          "id": "fd5f9d3b-7a95-4f93-9f5f-c839f3362e9a",
+          "alias": "saml ecp",
+          "description": "SAML ECP Profile Authentication Flow",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+              {
+                  "authenticator": "http-basic-authenticator",
+                  "authenticatorFlow": false,
+                  "requirement": "REQUIRED",
+                  "priority": 10,
+                  "autheticatorFlow": false,
+                  "userSetupAllowed": false
+              }
+          ]
       }
-    ],
-    "authenticatorConfig": [
+  ],
+  "authenticatorConfig": [
       {
-        "id": "bd49f97e-6ce0-42c7-b045-a16dc7a37649",
-        "alias": "create unique user config",
-        "config": {
-          "require.password.update.after.registration": "false"
-        }
+          "id": "bd49f97e-6ce0-42c7-b045-a16dc7a37649",
+          "alias": "create unique user config",
+          "config": {
+              "require.password.update.after.registration": "false"
+          }
       },
       {
-        "id": "86fd892b-86e0-4b42-944c-5b518706271c",
-        "alias": "dod-cac",
-        "config": {
-          "x509-cert-auth.canonical-dn-enabled": "false",
-          "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
-          "x509-cert-auth.serialnumber-hex-enabled": "false",
-          "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
-          "x509-cert-auth.regular-expression": "(.*?)(?:$)",
-          "x509-cert-auth.certificate-policy-mode": "All",
-          "x509-cert-auth.timestamp-validation-enabled": "true",
-          "x509-cert-auth.mapper-selection": "Custom Attribute Mapper",
-          "x509-cert-auth.crl-relative-path": "crl.pem",
-          "x509-cert-auth.crldp-checking-enabled": "false",
-          "x509-cert-auth.mapping-source-selection": "Subject's Alternative Name otherName (UPN)",
-          "x509-cert-auth.ocsp-checking-enabled": "false"
-        }
+          "id": "86fd892b-86e0-4b42-944c-5b518706271c",
+          "alias": "dod-cac",
+          "config": {
+              "x509-cert-auth.canonical-dn-enabled": "false",
+              "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificate",
+              "x509-cert-auth.serialnumber-hex-enabled": "false",
+              "x509-cert-auth.ocsp-fail-open": "$(REALM_X509_OCSP_FAIL_OPEN)",
+              "x509-cert-auth.regular-expression": "(.*?)(?:$)",
+              "x509-cert-auth.certificate-policy-mode": "All",
+              "x509-cert-auth.timestamp-validation-enabled": "true",
+              "x509-cert-auth.mapper-selection": "Custom Attribute Mapper",
+              "x509-cert-auth.crl-relative-path": "crl.pem",
+              "x509-cert-auth.crldp-checking-enabled": "false",
+              "x509-cert-auth.mapping-source-selection": "Subject's Alternative Name otherName (UPN)",
+              "x509-cert-auth.ocsp-checking-enabled": "false"
+          }
       },
       {
-        "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
-        "alias": "main",
-        "config": {}
+          "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
+          "alias": "main",
+          "config": {}
       },
       {
-        "id": "d20d218e-9109-455d-9b03-bb453e209e81",
-        "alias": "review profile config",
-        "config": {
-          "update.profile.on.first.login": "missing"
-        }
+          "id": "d20d218e-9109-455d-9b03-bb453e209e81",
+          "alias": "review profile config",
+          "config": {
+              "update.profile.on.first.login": "missing"
+          }
       }
-    ],
-    "requiredActions": [
+  ],
+  "requiredActions": [
       {
-        "alias": "TERMS_AND_CONDITIONS",
-        "name": "Terms and Conditions",
-        "providerId": "TERMS_AND_CONDITIONS",
-        "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
-        "defaultAction": true,
-        "priority": 10,
-        "config": {}
+          "alias": "TERMS_AND_CONDITIONS",
+          "name": "Terms and Conditions",
+          "providerId": "TERMS_AND_CONDITIONS",
+          "enabled": "${REALM_TERMS_AND_CONDITIONS_ENABLED}",
+          "defaultAction": true,
+          "priority": 10,
+          "config": {}
       },
       {
-        "alias": "CONFIGURE_TOTP",
-        "name": "Configure OTP",
-        "providerId": "CONFIGURE_TOTP",
-        "enabled": "${REALM_OTP_ENABLED}",
-        "defaultAction": false,
-        "priority": 20,
-        "config": {}
+          "alias": "CONFIGURE_TOTP",
+          "name": "Configure OTP",
+          "providerId": "CONFIGURE_TOTP",
+          "enabled": "${REALM_OTP_ENABLED}",
+          "defaultAction": false,
+          "priority": 20,
+          "config": {}
       },
       {
-        "alias": "UPDATE_PASSWORD",
-        "name": "Update Password",
-        "providerId": "UPDATE_PASSWORD",
-        "enabled": true,
-        "defaultAction": false,
-        "priority": 30,
-        "config": {}
+          "alias": "UPDATE_PASSWORD",
+          "name": "Update Password",
+          "providerId": "UPDATE_PASSWORD",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 30,
+          "config": {}
       },
       {
-        "alias": "UPDATE_PROFILE",
-        "name": "Update Profile",
-        "providerId": "UPDATE_PROFILE",
-        "enabled": true,
-        "defaultAction": false,
-        "priority": 40,
-        "config": {}
+          "alias": "UPDATE_PROFILE",
+          "name": "Update Profile",
+          "providerId": "UPDATE_PROFILE",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 40,
+          "config": {}
       },
       {
-        "alias": "VERIFY_EMAIL",
-        "name": "Verify Email",
-        "providerId": "VERIFY_EMAIL",
-        "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
-        "defaultAction": true,
-        "priority": 50,
-        "config": {}
+          "alias": "VERIFY_EMAIL",
+          "name": "Verify Email",
+          "providerId": "VERIFY_EMAIL",
+          "enabled": "${REALM_EMAIL_VERIFICATION_ENABLED}",
+          "defaultAction": true,
+          "priority": 50,
+          "config": {}
       },
       {
-        "alias": "delete_account",
-        "name": "Delete Account",
-        "providerId": "delete_account",
-        "enabled": false,
-        "defaultAction": false,
-        "priority": 60,
-        "config": {}
+          "alias": "delete_account",
+          "name": "Delete Account",
+          "providerId": "delete_account",
+          "enabled": false,
+          "defaultAction": false,
+          "priority": 60,
+          "config": {}
       },
       {
-        "alias": "update_user_locale",
-        "name": "Update User Locale",
-        "providerId": "update_user_locale",
-        "enabled": false,
-        "defaultAction": false,
-        "priority": 1000,
-        "config": {}
+          "alias": "update_user_locale",
+          "name": "Update User Locale",
+          "providerId": "update_user_locale",
+          "enabled": false,
+          "defaultAction": false,
+          "priority": 1000,
+          "config": {}
       },
       {
-        "alias": "UPDATE_X509",
-        "name": "Update X509",
-        "providerId": "UPDATE_X509",
-        "enabled": true,
-        "defaultAction": false,
-        "priority": 1001,
-        "config": {}
+          "alias": "UPDATE_X509",
+          "name": "Update X509",
+          "providerId": "UPDATE_X509",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 1001,
+          "config": {}
       }
-    ],
-    "browserFlow": "UDS Authentication",
-    "registrationFlow": "UDS Registration",
-    "directGrantFlow": "direct grant",
-    "resetCredentialsFlow": "UDS Reset Credentials",
-    "clientAuthenticationFlow": "clients",
-    "dockerAuthenticationFlow": "docker auth",
-    "attributes": {
+  ],
+  "browserFlow": "UDS Authentication",
+  "registrationFlow": "UDS Registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "UDS Reset Credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
       "cibaBackchannelTokenDeliveryMode": "poll",
       "cibaAuthRequestedUserHint": "login_hint",
       "clientOfflineSessionMaxLifespan": "0",
@@ -2651,13 +2651,12 @@
       "clientSessionMaxLifespan": "0",
       "frontendUrl": "",
       "acr.loa.map": "{}"
-    },
-    "userManagedAccessAllowed": false,
-    "clientProfiles": {
+  },
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
       "profiles": []
-    },
-    "clientPolicies": {
+  },
+  "clientPolicies": {
       "policies": []
-    }
   }
-  
+}

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -456,7 +456,7 @@
     "requiredCredentials": [
         "password"
     ],
-    "passwordPolicy": "${REALM_PASSWORD_POLICY}:hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)",
+    "passwordPolicy": "${REALM_PASSWORD_POLICY:hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(90) and specialChars(2) and passwordHistory(5) and length(12) and notUsername(undefined)}",
     "otpPolicyType": "totp",
     "otpPolicyAlgorithm": "HmacSHA1",
     "otpPolicyInitialCounter": 0,


### PR DESCRIPTION
## Description
We've been asked by more than a couple people to expose some additional keycloak realm settings. This is that.

Added env vars for the following:
* Required Actions
  * Terms and Conditions
  * One Time Password ( OTP )
  * Email Verification
* Password Policy
* X509 OCSP Fail Open

In updating/testing the changes to the password policy, there was a couple changes necessary for the realms to handle the use of the `digits` in the `passwordPolicy`. While not strictly necessary a preemptive change to the cypress tests for user registration and login to update the passwords used was done as well.

#### There is an additional PR in the [uds-core repo](https://github.com/defenseunicorns/uds-core/pull/455) for setting the default uds-core variables for these changes.

The uds-core PR will need to be merged and uds-core released before CI jobs here will pass because of the dependency on the default env variables set in uds-core.

## Related Issue
Relates to #32 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed