### PR TITLE
fix: idp sync mode force

### DIFF
--- a/src/realm.json
+++ b/src/realm.json
@@ -1746,7 +1746,8 @@
             "forceAuthn": "false",
             "attributeConsumingServiceIndex": "0",
             "addExtensionsElementWithKeyInfo": "false",
-            "principalType": "Subject NameID"
+            "principalType": "Subject NameID",
+            "syncMode": "FORCE"
           }
         }
       ],

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -1511,7 +1511,8 @@
             "forceAuthn": "false",
             "attributeConsumingServiceIndex": "0",
             "addExtensionsElementWithKeyInfo": "false",
-            "principalType": "Subject NameID"
+            "principalType": "Subject NameID",
+            "syncMode": "FORCE"
           }
         }
       ],


### PR DESCRIPTION
## Description
when users create an idp user, the idp was configured to only set user attributes once ( on registration ). Instead we want the idp to update those existing users after we've made changes to Google idp or whatever else. This is done by forcing the sync mode.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed