### PR TITLE
fix: force sync to ensure copy occurs

### DIFF
--- a/src/sync.sh
+++ b/src/sync.sh
@@ -10,9 +10,9 @@ mkdir -p /opt/keycloak/conf/truststores
 mkdir -p /opt/keycloak/themes/theme/
 
 # Copy the files to their respective directories
-cp -fvu realm.json /opt/keycloak/data/import/realm.json
-cp -fvur theme/* /opt/keycloak/themes/theme/
-cp -fvu *.jar /opt/keycloak/providers/
-cp -fvu certs/* /opt/keycloak/conf/truststores
+cp -fv realm.json /opt/keycloak/data/import/realm.json
+cp -fvr theme/* /opt/keycloak/themes/theme/
+cp -fv *.jar /opt/keycloak/providers/
+cp -fv certs/* /opt/keycloak/conf/truststores
 
 echo "Sync complete"


### PR DESCRIPTION
## Description
Addresses an issue where existing files on disk are technically newer than files being copied in because of instances where initial installs have happened after the release of the `uds-identity-config` image. 