### PR TITLE
fix: uds-cli version in vscode/settings.json captured with other uds-…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,9 +62,9 @@
       "labels": ["renovate/helm-release", "dependency/patch"]
     },
     {   
-        "description": "Group Github Actions updates.",
-        "matchPaths": [".github/**"],
-        "groupName": "GHA-DEPS"
+      "description": "Group Github Actions and vscode/settings.json updates.",
+      "matchPaths": [".github/**", ".vscode/settings.json"],
+      "groupName": "GHA-DEPS"
     }
   ],
   "regexManagers":[


### PR DESCRIPTION
## Description
At the moment uds-cli renovate versions get picked up in two different PR's. Making it a pain to push in those changes. The .vscode/settings.json only has one dependency in it which is uds-cli and the other references to uds-cli are in the github actions files. So added the .vscode/settings.json file to the github-actions renovate package rule so that all uds-cli renovate PR's are captured in the GHA-DEPS package rule.

Also fixed formatting.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed