### PR TITLE
feat: basic group authz

### DIFF
--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -43,7 +43,6 @@ public class RequireGroupAuthenticator implements Authenticator {
             LOGGER.infof("%s user %s / %s", logPrefix, user.getId(), user.getUsername());
         } else {
             LOGGER.warnf("%s invalid user", logPrefix);
-
         }
         LOGGER.infof("%s client %s / %s", logPrefix, clientId, client.getName());
 
@@ -79,19 +78,13 @@ public class RequireGroupAuthenticator implements Authenticator {
         final String logPrefix,
         final GroupModel group) {
 
-        // Must be a valid environment name
-        if (group == null) {
-            LOGGER.warnf("%s invalid group {}", logPrefix);
-            context.failure(AuthenticationFlowError.CLIENT_DISABLED);
+        // Check if the user is a member of the specified group
+        if (isMemberOfGroup(realm, user, group, logPrefix)) {
+            LOGGER.infof("%s matched authorized group", logPrefix);
+            success(context, user);
         } else {
-            // Check if the user is a member of the specified group
-            if (isMemberOfGroup(realm, user, group, logPrefix)) {
-                LOGGER.infof("%s matched authorized group", logPrefix);
-                success(context, user);
-            } else {
-                LOGGER.warnf("%s failed authorized group match", logPrefix);
-                context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-            }
+            LOGGER.warnf("%s failed authorized group match", logPrefix);
+            context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
         }
     }
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -46,10 +46,9 @@ public class RequireGroupAuthenticator implements Authenticator {
 
         }
         LOGGER.infof("%s client %s / %s", logPrefix, clientId, client.getName());
-        LOGGER.infof("%s %s client has group attribute %s", logPrefix, client.getName(), groupName);
 
         // Check for a valid match
-        if (groupName.length() > 0) {
+        if (groupName != null && groupName.length() > 0) {
             LOGGER.infof("%s %s client has group attribute %s", logPrefix, client.getName(), groupName);
             Optional<GroupModel> foundGroup = getGroupByName(groupName, realm);
 
@@ -59,7 +58,6 @@ public class RequireGroupAuthenticator implements Authenticator {
                 LOGGER.warnf("%s Groups attribute (%s) failed to find matching group for %s client - the group does not exist in realm.", logPrefix, groupName, client.getName());
                 // This failure (group not existing) is surfaced the same to the user as if the user is not a member of the group
                 // Perhaps should be separate error
-                LOGGER.warnf("test adding a line");
                 context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
             }
         } else {

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -1,0 +1,164 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import java.util.stream.Collectors;
+import java.util.Optional;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+
+/**
+ * Simple {@link Authenticator} that checks of a user is member of a given {@link GroupModel Group}.
+ */
+public class RequireGroupAuthenticator implements Authenticator {
+
+    /**
+     * Logger variable.
+     */
+    private static final Logger LOGGER = Logger.getLogger(RequireGroupAuthenticator.class.getName());
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public void authenticate(final AuthenticationFlowContext context) {
+
+        RealmModel realm = context.getRealm();
+        UserModel user = context.getUser();
+        AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+        ClientModel client = authenticationSession.getClient();
+        String clientId = client.getClientId();
+        String groupName = client.getAttribute("groups");
+        String logPrefix = "UDS_GROUP_PROTECTION_AUTHENTICATE_" + authenticationSession.getParentSession().getId();
+
+        if (user != null) {
+            LOGGER.infof("%s user %s / %s", logPrefix, user.getId(), user.getUsername());
+        } else {
+            LOGGER.warnf("%s invalid user", logPrefix);
+
+        }
+        LOGGER.infof("%s client %s / %s", logPrefix, clientId, client.getName());
+        LOGGER.infof("%s %s client has group attribute %s", logPrefix, client.getName(), groupName);
+
+        // Check for a valid match
+        if (groupName.length() > 0) {
+            LOGGER.infof("%s %s client has group attribute %s", logPrefix, client.getName(), groupName);
+            Optional<GroupModel> foundGroup = realm.getGroupsStream()
+                .filter(group -> group.getName().equals(groupName))
+                .findFirst();
+
+            if (foundGroup.isPresent()) {
+                checkIfUserIsAuthorized(context, realm, user, logPrefix, foundGroup.get().getId());
+            } else {
+                LOGGER.warnf("%s Groups attribute (%s) failed to find matching group for %s client - the group does not exist in realm.", logPrefix, groupName, client.getName());
+                // This failure (group not existing) is surfaced the same to the user as if the user is not a member of the group
+                // Perhaps should be separate error
+                LOGGER.warnf("test adding a line");
+                context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+            }
+        } else {
+            LOGGER.warnf("%s No groups detected for %s client", logPrefix, client.getName());
+        }
+    }
+
+    private void checkIfUserIsAuthorized(
+        final AuthenticationFlowContext context,
+        final RealmModel realm,
+        final UserModel user,
+        final String logPrefix,
+        final String groupId) {
+
+        GroupModel group = null;
+
+        if (realm != null) {
+            group = realm.getGroupById(groupId);
+        }
+
+        // Must be a valid environment name
+        if (groupId == null || group == null) {
+            LOGGER.warnf("%s invalid group {}", logPrefix, groupId);
+            context.failure(AuthenticationFlowError.CLIENT_DISABLED);
+        } else {
+            // Check if the user is a member of the specified group
+            if (isMemberOfGroup(realm, user, group, logPrefix)) {
+                LOGGER.infof("%s matched authorized group", logPrefix);
+                success(context, user);
+            } else {
+                LOGGER.warnf("%s failed authorized group match", logPrefix);
+                context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+            }
+        }
+    }
+
+    private void success(final AuthenticationFlowContext context, final UserModel user) {
+        context.success();
+    }
+
+    private boolean isMemberOfGroup(
+        final RealmModel realm,
+        final UserModel user,
+        final GroupModel group,
+        final String logPrefix) {
+
+        // No one likes null pointers
+        if (realm == null || user == null || group == null) {
+            LOGGER.warnf("%s realm, group or user null", logPrefix);
+            return false;
+        }
+
+        String groupList = user.getGroupsStream()
+                .map(GroupModel::getId)
+                .collect(Collectors.joining(","));
+
+        LOGGER.infof("%s user groups %s", logPrefix, groupList);
+
+        return user.isMemberOf(group);
+    }
+
+    @Override
+    public void action(final AuthenticationFlowContext authenticationFlowContext) {
+        // no implementation needed here
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean configuredFor(
+        final KeycloakSession keycloakSession,
+        final RealmModel realmModel,
+        final UserModel userModel) {
+
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(
+        final KeycloakSession keycloakSession,
+        final RealmModel realmModel,
+        final UserModel userModel) {
+
+        // no implementation needed here
+    }
+
+    @Override
+    public void close() {
+        // no implementation needed here
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorFactory.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorFactory.java
@@ -1,0 +1,118 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class RequireGroupAuthenticatorFactory implements AuthenticatorFactory {
+
+    /**
+     * provider id variable.
+     */
+    public static final String PROVIDER_ID = "uds-group-restriction";
+    /**
+     * group authenticator variable.
+     */
+    public static final RequireGroupAuthenticator GROUP_AUTHENTICATOR = new RequireGroupAuthenticator();
+    /**
+     * requirement choices variable.
+     */
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED
+    };
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public Authenticator create(final KeycloakSession session) {
+        return GROUP_AUTHENTICATOR;
+    }
+
+    @Override
+    public void init(final Config.Scope scope) {
+        // no implementation needed here
+    }
+
+    @Override
+    public void postInit(final KeycloakSessionFactory keycloakSessionFactory) {
+        // no implementation needed here
+    }
+
+    @Override
+    public void close() {
+        // no implementation needed here
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getDisplayType() {
+        return "UDS Operator Group Authentication Validation";
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getReferenceCategory() {
+        return null;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getHelpText() {
+        return null;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        // no implementation needed here. Just return empty collection
+        return new ArrayList<>();
+    }
+}

--- a/src/plugin/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/plugin/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+com.defenseunicorns.uds.keycloak.plugin.authentication.RequireGroupAuthenticatorFactory

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatonFactoryTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatonFactoryTest.java
@@ -1,0 +1,62 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.AuthenticationExecutionModel;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequireGroupAuthenticatonFactoryTest {
+
+    private final RequireGroupAuthenticatorFactory factory = new RequireGroupAuthenticatorFactory();
+
+    @Test
+    public void testGetId() {
+        assertEquals("uds-group-restriction", factory.getId());
+    }
+
+    @Test
+    public void testCreate() {
+        Authenticator authenticator = factory.create(null); // Pass null as session, as it's not needed for create method
+
+        assertNotNull(authenticator);
+        assertTrue(authenticator instanceof RequireGroupAuthenticator);
+    }
+
+    @Test
+    public void testGetDisplayType() {
+        assertEquals("UDS Operator Group Authentication Validation", factory.getDisplayType());
+    }
+
+    @Test
+    public void testGetRequirementChoices() {
+        AuthenticationExecutionModel.Requirement[] requirementChoices = factory.getRequirementChoices();
+
+        assertNotNull(requirementChoices);
+        assertEquals(1, requirementChoices.length);
+        assertEquals(AuthenticationExecutionModel.Requirement.REQUIRED, requirementChoices[0]);
+    }
+
+    @Test
+    public void testIsConfigurable() {
+        assertFalse(factory.isConfigurable());
+    }
+
+    @Test
+    public void testIsUserSetupAllowed() {
+        assertFalse(factory.isUserSetupAllowed());
+    }
+
+    @Test
+    public void testGetConfigProperties() {
+        List<?> configProperties = factory.getConfigProperties();
+
+        assertNotNull(configProperties);
+        assertTrue(configProperties.isEmpty());
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
@@ -1,0 +1,103 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupProvider;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static com.defenseunicorns.uds.keycloak.plugin.utils.Utils.setupFileMocks;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ FileInputStream.class, File.class })
+@PowerMockIgnore("javax.management.*")
+public class RequireGroupAuthenticatorTest {
+
+    private RequireGroupAuthenticator subject;
+    private AuthenticationFlowContext context;
+    private RealmModel realm;
+    private UserModel user;
+    private GroupModel group;
+    private KeycloakSession session;
+    private AuthenticationSessionModel authenticationSession;
+    private RootAuthenticationSessionModel parentAuthenticationSession;
+    private ClientModel client;
+    private GroupProvider groupProvider;
+
+    @Before
+    public void setup() throws Exception {
+
+        setupFileMocks();
+
+        subject = new RequireGroupAuthenticator();
+
+        context = mock(AuthenticationFlowContext.class);
+        realm = mock(RealmModel.class);
+        user = mock(UserModel.class);
+        group = mock(GroupModel.class);
+        session = mock(KeycloakSession.class);
+        authenticationSession = mock(AuthenticationSessionModel.class);
+        parentAuthenticationSession = mock(RootAuthenticationSessionModel.class);
+        client = mock(ClientModel.class);
+        groupProvider = mock(GroupProvider.class);
+
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getUser()).thenReturn(user);
+        when(context.getSession()).thenReturn(session);
+        when(context.getAuthenticationSession()).thenReturn(authenticationSession);
+        when(authenticationSession.getClient()).thenReturn(client);
+        when(authenticationSession.getParentSession()).thenReturn(parentAuthenticationSession);
+        when(parentAuthenticationSession.getId()).thenReturn("bleh");
+        when(realm.getGroupById(anyString())).thenReturn(group);
+        when(session.groups()).thenReturn(groupProvider);
+
+    }
+
+    @Test
+    public void testShouldRejectUnknownGroups() {
+        when(client.getClientId()).thenReturn("random-bad-client");
+        when(client.getAttribute("groups")).thenReturn("httpbin");
+        subject.authenticate(context);
+        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    }
+
+    @Test
+    public void testShouldRejectNonGroupMembers() {
+        List<GroupModel> groupList = new ArrayList<>(); 
+        group.setName("httpbin");
+        groupList.add(group);
+
+        when(client.getClientId()).thenReturn("random-bad-client");
+        when(client.getAttribute("groups")).thenReturn("httpbin");
+        when(group.getName()).thenReturn("httpbin");
+        subject.authenticate(context);
+        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    }
+
+    @Test
+    public void testShouldAcceptEmptyGroups() {
+        when(client.getClientId()).thenReturn("random-bad-client");
+        when(client.getAttribute("groups")).thenReturn("");
+        subject.authenticate(context);
+        verify(context).success();
+    }
+}

--- a/src/realm.json
+++ b/src/realm.json
@@ -1723,6 +1723,7 @@
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,
           "linkOnly": false,
+          "postBrokerLoginFlowAlias": "Authorization",
           "config": {
             "postBindingLogout": "false",
             "postBindingResponse": "true",
@@ -2250,13 +2251,41 @@
                 {
                     "authenticatorFlow": true,
                     "requirement": "REQUIRED",
-                    "priority": 31,
+                    "priority": 0,
                     "autheticatorFlow": true,
                     "flowAlias": "Authentication",
                     "userSetupAllowed": false
-                }
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 1,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
+                  }
+          
             ]
         },
+        {
+            "id": "7d53187d-13f4-4ec6-ade0-20b7d88d9aa4",
+            "alias": "Authorization",
+            "description": "",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": false,
+            "authenticationExecutions": [
+              {
+                "authenticator": "uds-group-restriction",
+                "authenticatorFlow": false,
+                "requirement": "REQUIRED",
+                "priority": 0,
+                "userSetupAllowed": false,
+                "autheticatorFlow": false
+              }
+            ]
+          },
+      
         {
             "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
             "alias": "UDS Authentication Browser - Conditional OTP",

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -61,7 +61,25 @@
             "lastName": "User",
             "email": "testinguser@gmail.com",
             "emailVerified": true,
-            "realmRoles": ["default-roles-uds"]
+            "realmRoles": ["default-roles-uds"],
+            "groups": ["/UDS Core/Auditor"]
+        },
+        {
+            "id": "123456",
+            "username": "testing_admin",
+            "enabled": "true",
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "testingpassword1!!"
+                }
+            ],
+            "firstName": "Testing",
+            "lastName": "Admin",
+            "email": "testingadmin@gmail.com",
+            "emailVerified": true,
+            "realmRoles": ["default-roles-uds"],
+            "groups": ["/UDS Core/Admin"]
         }
     ],
     "roles": {
@@ -1488,6 +1506,7 @@
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,
           "linkOnly": false,
+          "postBrokerLoginFlowAlias": "Authorization",
           "config": {
             "postBindingLogout": "false",
             "postBindingResponse": "true",
@@ -2006,10 +2025,36 @@
                 {
                     "authenticatorFlow": true,
                     "requirement": "REQUIRED",
-                    "priority": 31,
+                    "priority": 0,
                     "autheticatorFlow": true,
                     "flowAlias": "Authentication",
                     "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 1,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
+                }
+            ]
+        },
+        {
+            "id": "7d53187d-13f4-4ec6-ade0-20b7d88d9aa4",
+            "alias": "Authorization",
+            "description": "",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 0,
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": false
                 }
             ]
         },

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -94,7 +94,7 @@ tasks:
     description: "UDS Core + Identity Config smoke test with base realm.json"
     actions:
       - task: dev-build
-      - task: clone-core
+      # - task: clone-core
       - task: build-deploy-custom-slim
 
   - name: uds-core-integration-tests
@@ -103,12 +103,15 @@ tasks:
       - description: Build identity config image
         cmd: docker build --build-arg CA_ZIP_URL="test/cypress/certs/authorized_certs.zip" --build-arg REALM_FILE="test/cypress/realm.json" -t uds-core-config:keycloak --no-cache src
 
-      - task: clone-core
+      # - task: clone-core
 
       - description: Copy cacert value into uds-core istio gateways
         task: uds-core-gateway-cacert
 
       - task: build-deploy-custom-slim
+
+      - description: Deploy grafana for testing group authz
+        cmd: cd uds-core && UDS_PKG=grafana uds run create-single-package && uds zarf package deploy build/zarf-package-uds-core-grafana-amd64.tar.zst --confirm --no-progress
 
       - description: Run integration cypress tests
         task: cypress-tests
@@ -130,6 +133,7 @@ tasks:
   - name: cypress-tests
     description: "Run all cypress tests ( requires an existing deployed UDS Core Identity )"
     actions:
-      - cmd: |
+      - description: Setup cypress tests and run
+        cmd: |
           npm --prefix src/test/cypress install
           npm --prefix src/test/cypress run cy.run


### PR DESCRIPTION
## Description
* Adds authenticator that enforces client.attribute.groups membership
* Denies access if group does not exist
* Adds group authenticator to default realm configuration
* Adds group authenticator for IDP flow

This can be used with UDS Core by adding `attributes.groups` to  your client configuration in a Package:
```
apiVersion: uds.dev/v1alpha1
kind: Package
metadata:
  name: httpbin-other
  namespace: authservice-test-app
spec:
  sso:
    - name: Demo SSO
      clientId: uds-core-httpbin
      attributes:
        groups: httpbin
      redirectUris:
        - "https://protected.uds.dev/login"
```        
Wanting to note I also had to add the Custom Authenticator to our default UDS Authentication flow as well as our configured Google SSO IDP as the post login flow:
![2024-06-14_12-06-1718384722](https://github.com/defenseunicorns/uds-identity-config/assets/1746282/9b9009c2-a2d0-4612-a682-35f94f01acd7)
![2024-06-14_12-06-1718384734](https://github.com/defenseunicorns/uds-identity-config/assets/1746282/de1c629c-3d25-4aa0-bfa2-4fa59164ea72)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed