### PR TITLE
feat: group authorization plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,12 @@ If the default realm, plugin, theme, truststore, or jars do not provide enough f
 
 This version upgrade brings in a new Authentication Flow for group authorization.
 
-If upgrading without a full redeploy of identity-config the following steps will be necessary to create and use group authorization:
+If upgrading without a full redeploy of keycloak the following steps will be necessary to create and use group authorization:
 1. In keycloak admin portal, in `UDS` realm, navigate to `Authentication` sidebar tab
 2. In `Authentication` tab add the `Authorization` flow to `UDS Authentication`, `UDS Registration`, `UDS Reset Credentials`
-   1. In each `Authentication` flow, `Add sub-flow`
-      1. `Name` -> `Authorization`
-      2. `Create`
-   2. Select the plus sign to `Add step` into the `Authorization` sub-flow
-      1. `Add` the `UDS Operator Group Authentication Validation`
-   * Make sure the `Authorization` flow is added at the base level and at the end of each `Authentication` flow
+   1. In each `Authentication` flow
+      1. `Add step` -> `UDS Operator Group Authentication Validation`
+      * Make sure that the step is at the base level and bottom of the Authentication flow
 3. Finally if using `SAML` IDP
    1. In the `Authentication` tab
       1. `Create Flow`

--- a/README.md
+++ b/README.md
@@ -23,3 +23,31 @@ This repo builds the UDS Identity (Keycloak) Config image used by UDS Identity. 
 ## Customizing UDS Identity Config
 
 If the default realm, plugin, theme, truststore, or jars do not provide enough functionality ( or provide too much functionality ), take a look at the [CUSTOMIZE.md](./docs/CUSTOMIZE.md) docs for making changes to the identity config.
+
+
+## Upgrading Identity Config
+
+### From v0.4.5 to v0.5.0
+
+This version upgrade brings in a new Authentication Flow for group authorization.
+
+If upgrading without a full redeploy of identity-config the following steps will be necessary to create and use group authorization:
+1. In keycloak admin portal, in `UDS` realm, navigate to `Authentication` sidebar tab
+2. In `Authentication` tab add the `Authorization` flow to `UDS Authentication`, `UDS Registration`, `UDS Reset Credentials`
+   1. In each `Authentication` flow, `Add sub-flow`
+      1. `Name` -> `Authorization`
+      2. `Create`
+   2. Select the plus sign to `Add step` into the `Authorization` sub-flow
+      1. `Add` the `UDS Operator Group Authentication Validation`
+   * Make sure the `Authorization` flow is added at the base level and at the end of each `Authentication` flow
+3. Finally if using `SAML` IDP
+   1. In the `Authentication` tab
+      1. `Create Flow`
+      2. `Name` -> `Authorization`
+      3. `Description` -> `UDS Operator Group Authentication Validation`
+      4. `Basic Flow`
+      5. `Create`
+      6. `Add execution`
+      7. `Add` the `UDS Operator Group Authentication Validation`
+   2. In the `Identity Providers` tab, select the `SAML` Provider
+      1. Add the `Authorization` flow to the `Post login flow` in the `Advanced settings` section

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/Groups.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/Groups.java
@@ -1,0 +1,19 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Groups {
+    @JsonProperty("anyOf")
+    public String[] anyOf;
+
+    public JsonNode path(String fieldName) {
+        if (!"anyOf".equals(fieldName)) {
+            throw new UnsupportedOperationException("Invalid field name: " + fieldName);
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.valueToTree(anyOf);
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/Groups.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/Groups.java
@@ -1,19 +1,8 @@
 package com.defenseunicorns.uds.keycloak.plugin.authentication;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class Groups {
     @JsonProperty("anyOf")
     public String[] anyOf;
-
-    public JsonNode path(String fieldName) {
-        if (!"anyOf".equals(fieldName)) {
-            throw new UnsupportedOperationException("Invalid field name: " + fieldName);
-        }
-
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.valueToTree(anyOf);
-    }
 }

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -1,7 +1,6 @@
 package com.defenseunicorns.uds.keycloak.plugin.authentication;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Optional;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -48,10 +47,8 @@ public class RequireGroupAuthenticator implements Authenticator {
 
         RealmModel realm = context.getRealm();
         boolean foundGroup = false;
-        List<String> requiredGroups = new ArrayList<>();
 
         for (String groupName : groups.anyOf) {
-            requiredGroups.add(groupName);
             Optional<GroupModel> group = getGroupByPath(groupName, realm);
 
             if (group.isPresent()) {
@@ -69,7 +66,7 @@ public class RequireGroupAuthenticator implements Authenticator {
             context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
             return;
         }
-        LOGGER.warnf("Required group(s) %s do not exist in realm", requiredGroups);
+        LOGGER.warnf("Required group(s) %s do not exist in realm", Arrays.toString(groups.anyOf));
         context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
     }
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -95,7 +95,12 @@ public class RequireGroupAuthenticator implements Authenticator {
         StringBuilder path = new StringBuilder();
         GroupModel currentGroup = group;
         while (currentGroup != null) {
-            path.insert(0, "/" + currentGroup.getName());
+            String groupName = currentGroup.getName();
+            if (groupName.contains("/")) {
+                LOGGER.errorf("Group name '%s' contains a slash", groupName);
+                throw new IllegalArgumentException("Group names cannot contain slashes");
+            }
+            path.insert(0, "/" + groupName);
             currentGroup = currentGroup.getParent();
         }
         return path.toString();

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -1,8 +1,6 @@
 package com.defenseunicorns.uds.keycloak.plugin.authentication;
 
-import java.util.stream.Collectors;
 import java.util.Optional;
-
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
@@ -12,126 +10,107 @@ import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.sessions.AuthenticationSessionModel;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * Simple {@link Authenticator} that checks of a user is member of a given {@link GroupModel Group}.
+ * Simple {@link Authenticator} that checks if a user is a member of a given {@link GroupModel Group}.
  */
 public class RequireGroupAuthenticator implements Authenticator {
 
-    /**
-     * Logger variable.
-     */
     private static final Logger LOGGER = Logger.getLogger(RequireGroupAuthenticator.class.getName());
 
-    /**
-     * This implementation is not intended to be overridden.
-     */
     @Override
     public void authenticate(final AuthenticationFlowContext context) {
-
-        RealmModel realm = context.getRealm();
         UserModel user = context.getUser();
-        AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
-        ClientModel client = authenticationSession.getClient();
-        String clientId = client.getClientId();
-        String logPrefix = "UDS_GROUP_PROTECTION_AUTHENTICATE_" + authenticationSession.getParentSession().getId();
-    
-        String groupsAttribute = client.getAttribute("uds.core.groups");
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode groupsNode = null;
-    
-        if (user != null) {
-            LOGGER.infof("%s user %s / %s", logPrefix, user.getId(), user.getUsername());
-        } else {
-            LOGGER.warnf("%s invalid user", logPrefix);
-            context.failure(AuthenticationFlowError.INVALID_USER);
+        if (user == null) {
+            logAndFail(context, "Invalid user", AuthenticationFlowError.INVALID_USER);
+            return;
         }
-        LOGGER.infof("%s client %s / %s", logPrefix, clientId, client.getName());
-    
-        if (groupsAttribute != null && !groupsAttribute.isEmpty()) {
-            try {
-                groupsNode = objectMapper.readTree(groupsAttribute).path("anyOf");
-            } catch (Exception e) {
-                LOGGER.errorf("%s Failed to parse groups JSON: %s", logPrefix, e.getMessage());
-                context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-                return;
-            }
-    
-            if (groupsNode.isArray() && groupsNode.size() > 0) {
-                LOGGER.infof("%s %s client has group attribute %s", logPrefix, client.getName(), groupsNode.toString());
-                
-                // limit the number of log statements from for loop
-                boolean foundGroup = false;
-    
-                for (JsonNode groupNode : groupsNode) {
-                    String groupName = groupNode.asText();
-                    Optional<GroupModel> group = getGroupByName(groupName, realm);
-    
-                    if (group.isPresent()) {
-                        checkIfUserIsAuthorized(context, realm, user, logPrefix, group.get());
-                        foundGroup = true;
-                        break;
-                    }
-                }
-    
-                if (!foundGroup) {
-                    LOGGER.warnf("%s Groups attribute (%s) failed to find any matching group for %s client - the groups do not exist in realm.", logPrefix, groupsNode.toString(), client.getName());
-                    context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-                }
-            } else {
-                LOGGER.warnf("%s Groups attribute for %s client does not contain a valid anyOf array", logPrefix, client.getName());
-                context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-            }
-        } else {
-            LOGGER.infof("%s No groups detected for %s client", logPrefix, client.getName());
-            success(context, user);
+
+        ClientModel client = context.getAuthenticationSession().getClient();
+        String groupsAttribute = client.getAttribute("uds.core.groups");
+
+        if (groupsAttribute == null || groupsAttribute.isEmpty()) {
+            LOGGER.infof("No groups detected for client %s", client.getName());
+            context.success();
+            return;
+        }
+
+        JsonNode groupsNode = parseGroupsAttribute(groupsAttribute);
+        if (groupsNode == null) {
+            logAndFail(context, "Failed to parse groups JSON", AuthenticationFlowError.INVALID_CLIENT_SESSION);
+            return;
+        }
+
+        handleGroupAuthentication(context, user, groupsNode);
+    }
+
+    private JsonNode parseGroupsAttribute(String groupsAttribute) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readTree(groupsAttribute).path("anyOf");
+        } catch (Exception e) {
+            LOGGER.errorf("Failed to parse groups JSON: %s", e.getMessage());
+            return null;
         }
     }
 
-    private Optional<GroupModel> getGroupByName(final String groupName, final RealmModel realm) {
+    private void handleGroupAuthentication(AuthenticationFlowContext context, UserModel user, JsonNode groupsNode) {
+        if (!groupsNode.isArray() || groupsNode.size() == 0) {
+            logAndFail(context, "Groups attribute does not contain a valid anyOf array", AuthenticationFlowError.INVALID_CLIENT_SESSION);
+            return;
+        }
+
+        RealmModel realm = context.getRealm();
+        boolean foundGroup = false;
+
+        for (JsonNode groupNode : groupsNode) {
+            String groupName = groupNode.asText();
+            Optional<GroupModel> group = getGroupByPath(groupName, realm);
+
+            if (group.isPresent()) {
+                if (isMemberOfExactGroup(user, group.get())) {
+                    LOGGER.infof("User %s is authorized for group %s", user.getUsername(), groupName);
+                    context.success();
+                    return;
+                } else {
+                    foundGroup = true;
+                }
+            }
+        }
+
+        if (foundGroup) {
+            logAndFail(context, "User is not a member of the required group(s)", AuthenticationFlowError.INVALID_CLIENT_SESSION);
+        } else {
+            logAndFail(context, "Required group(s) do not exist in realm", AuthenticationFlowError.INVALID_CLIENT_SESSION);
+        }
+    }
+
+    private Optional<GroupModel> getGroupByPath(final String groupPath, final RealmModel realm) {
         return realm.getGroupsStream()
-            .filter(group -> group.getName().equals(groupName))
+            .filter(group -> buildGroupPath(group).equals(groupPath))
             .findFirst();
     }
 
-    private void checkIfUserIsAuthorized(
-        final AuthenticationFlowContext context,
-        final RealmModel realm,
-        final UserModel user,
-        final String logPrefix,
-        final GroupModel group) {
-
-        // Check if the user is a member of the specified group
-        if (isMemberOfGroup(realm, user, group, logPrefix)) {
-            LOGGER.infof("%s matched authorized group", logPrefix);
-            success(context, user);
-        } else {
-            LOGGER.warnf("%s failed authorized group match", logPrefix);
-            context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    private String buildGroupPath(GroupModel group) {
+        StringBuilder path = new StringBuilder();
+        GroupModel currentGroup = group;
+        while (currentGroup != null) {
+            path.insert(0, "/" + currentGroup.getName());
+            currentGroup = currentGroup.getParent();
         }
+        return path.toString();
     }
 
-    private void success(final AuthenticationFlowContext context, final UserModel user) {
-        context.success();
+    private boolean isMemberOfExactGroup(UserModel user, GroupModel group) {
+        return user.getGroupsStream()
+            .anyMatch(userGroup -> buildGroupPath(userGroup).equals(buildGroupPath(group)));
     }
 
-    private boolean isMemberOfGroup(
-        final RealmModel realm,
-        final UserModel user,
-        final GroupModel group,
-        final String logPrefix) {
-
-        String groupList = user.getGroupsStream()
-                .map(GroupModel::getId)
-                .collect(Collectors.joining(","));
-
-        LOGGER.infof("%s user groups %s", logPrefix, groupList);
-
-        return user.isMemberOf(group);
+    private void logAndFail(AuthenticationFlowContext context, String message, AuthenticationFlowError error) {
+        LOGGER.warn(message);
+        context.failure(error);
     }
 
     @Override
@@ -139,17 +118,11 @@ public class RequireGroupAuthenticator implements Authenticator {
         // no implementation needed here
     }
 
-    /**
-     * This implementation is not intended to be overridden.
-     */
     @Override
     public boolean requiresUser() {
         return false;
     }
 
-    /**
-     * This implementation is not intended to be overridden.
-     */
     @Override
     public boolean configuredFor(
         final KeycloakSession keycloakSession,

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -74,11 +74,11 @@ public class RequireGroupAuthenticator implements Authenticator {
         ObjectMapper objectMapper = new ObjectMapper();
         try {
             Groups groups = objectMapper.readValue(groupsAttribute, Groups.class);
-            if(groups.anyOf.length == 0) {
+            if (groups.anyOf.length == 0) {
                 LOGGER.errorf("Groups attribute does not contain a valid anyOf array");
                 return null;
             }
-            return  groups;
+            return groups;
         } catch (Exception e) {
             LOGGER.errorf("Failed to parse groups JSON: %s", e.getMessage());
             return null;

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -47,12 +47,6 @@ public class RequireGroupAuthenticator implements Authenticator {
             return;
         }
 
-        if (groupsNode.size() == 0) {
-            LOGGER.warn("Groups attribute does not contain a valid anyOf array");
-            context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-            return;
-        }
-
         RealmModel realm = context.getRealm();
         boolean foundGroup = false;
         List<String> requiredGroups = new ArrayList<>();
@@ -84,7 +78,12 @@ public class RequireGroupAuthenticator implements Authenticator {
     private JsonNode parseGroupsAttribute(String groupsAttribute) {
         ObjectMapper objectMapper = new ObjectMapper();
         try {
-            return  objectMapper.readValue(groupsAttribute, Groups.class).path("anyOf");
+            JsonNode groups = objectMapper.readValue(groupsAttribute, Groups.class).path("anyOf");
+            if(groups.size() == 0) {
+                LOGGER.errorf("Groups attribute does not contain a valid anyOf array");
+                return null;
+            }
+            return  groups;
         } catch (Exception e) {
             LOGGER.errorf("Failed to parse groups JSON: %s", e.getMessage());
             return null;

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -96,6 +96,7 @@ public class RequireGroupAuthenticator implements Authenticator {
         GroupModel currentGroup = group;
         while (currentGroup != null) {
             String groupName = currentGroup.getName();
+            //  disallow slashes in group names to protect against Keycloak allowing unescaped slashes in group names until https://github.com/defenseunicorns/uds-identity-config/issues/118
             if (groupName.contains("/")) {
                 LOGGER.errorf("Group name '%s' contains a slash", groupName);
                 throw new IllegalArgumentException("Group names cannot contain slashes");

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -1,0 +1,164 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+/**
+ * Simple {@link Authenticator} that checks of a user is member of a given {@link GroupModel Group}.
+ */
+public class RequireGroupAuthenticator implements Authenticator {
+
+    /**
+     * Logger variable.
+     */
+    private static final Logger LOGGER = Logger.getLogger(RequireGroupAuthenticator.class.getName());
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public void authenticate(final AuthenticationFlowContext context) {
+
+        RealmModel realm = context.getRealm();
+        UserModel user = context.getUser();
+        AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+        ClientModel client = authenticationSession.getClient();
+        String clientId = client.getClientId();
+        String logPrefix = "P1_GROUP_PROTECTION_AUTHENTICATE_" + authenticationSession.getParentSession().getId();
+
+        if (user != null) {
+            LOGGER.infof("{} user {} / {}", logPrefix, user.getId(), user.getUsername());
+        } else {
+            LOGGER.warnf("{} invalid user", logPrefix);
+
+        }
+        LOGGER.infof("{} client {} / {}", logPrefix, clientId, client.getName());
+
+        // Match the pattern "test_b4e4ae70-5b78-47ff-ad5c-7ebf3c10e452_app"
+        // where "test" is the short name and "b4e4ae70-5b78-47ff-ad5c-7ebf3c10e452" is the group id
+        String clientIdPatternMatch =
+            "^[a-z0-9-]+_([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})_[_a-z0-9-]+$";
+        Pattern pattern = Pattern.compile(clientIdPatternMatch);
+        Matcher matcher = pattern.matcher(clientId);
+
+        // Check for a valid match
+        if (matcher.find() && matcher.groupCount() == 1) {
+            String groupId = matcher.group(1);
+            checkIfUserIsAuthorized(context, realm, user, logPrefix, groupId);
+        } else {
+            if (client.getAttribute("groups").length() > 0
+                && user != null) {
+                LOGGER.infof("{} matched authorized ignored group protect client", logPrefix);
+                success(context, user);
+            } else {
+                LOGGER.warnf("{} failed ignored group protect client test", logPrefix);
+                context.failure(AuthenticationFlowError.CLIENT_DISABLED);
+            }
+        }
+    }
+
+    private void checkIfUserIsAuthorized(
+        final AuthenticationFlowContext context,
+        final RealmModel realm,
+        final UserModel user,
+        final String logPrefix,
+        final String groupId) {
+
+        GroupModel group = null;
+
+        if (realm != null) {
+            group = realm.getGroupById(groupId);
+        }
+
+        // Must be a valid environment name
+        if (groupId == null || group == null) {
+            LOGGER.warnf("{} invalid group {}", logPrefix, groupId);
+            context.failure(AuthenticationFlowError.CLIENT_DISABLED);
+        } else {
+            // Check if the user is a member of the specified group
+            if (isMemberOfGroup(realm, user, group, logPrefix)) {
+                LOGGER.infof("{} matched authorized group", logPrefix);
+                success(context, user);
+            } else {
+                LOGGER.warnf("{} failed authorized group match", logPrefix);
+                context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+            }
+        }
+    }
+
+    private void success(final AuthenticationFlowContext context, final UserModel user) {
+        context.success();
+    }
+
+    private boolean isMemberOfGroup(
+        final RealmModel realm,
+        final UserModel user,
+        final GroupModel group,
+        final String logPrefix) {
+
+        // No one likes null pointers
+        if (realm == null || user == null || group == null) {
+            LOGGER.warnf("{} realm, group or user null", logPrefix);
+            return false;
+        }
+
+        String groupList = user.getGroupsStream()
+                .map(GroupModel::getId)
+                .collect(Collectors.joining(","));
+
+        LOGGER.infof("{} user groups {}", logPrefix, groupList);
+
+        return user.isMemberOf(group);
+    }
+
+    @Override
+    public void action(final AuthenticationFlowContext authenticationFlowContext) {
+        // no implementation needed here
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean configuredFor(
+        final KeycloakSession keycloakSession,
+        final RealmModel realmModel,
+        final UserModel userModel) {
+
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(
+        final KeycloakSession keycloakSession,
+        final RealmModel realmModel,
+        final UserModel userModel) {
+
+        // no implementation needed here
+    }
+
+    @Override
+    public void close() {
+        // no implementation needed here
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorFactory.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorFactory.java
@@ -16,7 +16,7 @@ public class RequireGroupAuthenticatorFactory implements AuthenticatorFactory {
     /**
      * provider id variable.
      */
-    public static final String PROVIDER_ID = "p1-group-restriction";
+    public static final String PROVIDER_ID = "uds-group-restriction";
     /**
      * group authenticator variable.
      */
@@ -64,7 +64,7 @@ public class RequireGroupAuthenticatorFactory implements AuthenticatorFactory {
      */
     @Override
     public String getDisplayType() {
-        return "Platform One Group Authentication Validation";
+        return "UDS Operator Group Authentication Validation";
     }
 
     /**
@@ -116,4 +116,3 @@ public class RequireGroupAuthenticatorFactory implements AuthenticatorFactory {
         return new ArrayList<>();
     }
 }
-

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorFactory.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorFactory.java
@@ -1,0 +1,119 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class RequireGroupAuthenticatorFactory implements AuthenticatorFactory {
+
+    /**
+     * provider id variable.
+     */
+    public static final String PROVIDER_ID = "p1-group-restriction";
+    /**
+     * group authenticator variable.
+     */
+    public static final RequireGroupAuthenticator GROUP_AUTHENTICATOR = new RequireGroupAuthenticator();
+    /**
+     * requirement choices variable.
+     */
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED
+    };
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public Authenticator create(final KeycloakSession session) {
+        return GROUP_AUTHENTICATOR;
+    }
+
+    @Override
+    public void init(final Config.Scope scope) {
+        // no implementation needed here
+    }
+
+    @Override
+    public void postInit(final KeycloakSessionFactory keycloakSessionFactory) {
+        // no implementation needed here
+    }
+
+    @Override
+    public void close() {
+        // no implementation needed here
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getDisplayType() {
+        return "Platform One Group Authentication Validation";
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getReferenceCategory() {
+        return null;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public String getHelpText() {
+        return null;
+    }
+
+    /**
+     * This implementation is not intended to be overridden.
+     */
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        // no implementation needed here. Just return empty collection
+        return new ArrayList<>();
+    }
+}
+

--- a/src/plugin/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/plugin/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+com.defenseunicorns.uds.keycloak.plugin.authentication.RequireGroupAuthenticatorFactory

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatonFactoryTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatonFactoryTest.java
@@ -1,0 +1,62 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.AuthenticationExecutionModel;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequireGroupAuthenticatonFactoryTest {
+
+    private final RequireGroupAuthenticatorFactory factory = new RequireGroupAuthenticatorFactory();
+
+    @Test
+    public void testGetId() {
+        assertEquals("uds-group-restriction", factory.getId());
+    }
+
+    @Test
+    public void testCreate() {
+        Authenticator authenticator = factory.create(null); // Pass null as session, as it's not needed for create method
+
+        assertNotNull(authenticator);
+        assertTrue(authenticator instanceof RequireGroupAuthenticator);
+    }
+
+    @Test
+    public void testGetDisplayType() {
+        assertEquals("UDS Operator Group Authentication Validation", factory.getDisplayType());
+    }
+
+    @Test
+    public void testGetRequirementChoices() {
+        AuthenticationExecutionModel.Requirement[] requirementChoices = factory.getRequirementChoices();
+
+        assertNotNull(requirementChoices);
+        assertEquals(1, requirementChoices.length);
+        assertEquals(AuthenticationExecutionModel.Requirement.REQUIRED, requirementChoices[0]);
+    }
+
+    @Test
+    public void testIsConfigurable() {
+        assertFalse(factory.isConfigurable());
+    }
+
+    @Test
+    public void testIsUserSetupAllowed() {
+        assertFalse(factory.isUserSetupAllowed());
+    }
+
+    @Test
+    public void testGetConfigProperties() {
+        List<?> configProperties = factory.getConfigProperties();
+
+        assertNotNull(configProperties);
+        assertTrue(configProperties.isEmpty());
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
@@ -178,4 +178,15 @@ public class RequireGroupAuthenticatorTest {
 
         verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testShouldThrowExceptionForInvalidGroupName() {
+        GroupModel invalidGroup = mock(GroupModel.class);
+        when(invalidGroup.getName()).thenReturn("Invalid/Group");
+
+        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"Invalid/Group\"]}");
+        when(realm.getGroupsStream()).thenReturn(Stream.of(invalidGroup));
+        
+        authenticator.authenticate(context);
+    }
 }

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
@@ -1,0 +1,144 @@
+package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupProvider;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequireGroupAuthenticatorTest {
+
+    @InjectMocks
+    private RequireGroupAuthenticator authenticator;
+
+    @Mock
+    private AuthenticationFlowContext context;
+
+    @Mock
+    private RealmModel realm;
+
+    @Mock
+    private UserModel user;
+
+    @Mock
+    private GroupModel group;
+
+    @Mock
+    private AuthenticationSessionModel authenticationSession;
+
+    @Mock
+    private RootAuthenticationSessionModel parentAuthenticationSession;
+
+    @Mock
+    private ClientModel client;
+
+    @Mock
+    private GroupProvider groupProvider;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getUser()).thenReturn(user);
+        when(context.getAuthenticationSession()).thenReturn(authenticationSession);
+        when(authenticationSession.getClient()).thenReturn(client);
+        when(authenticationSession.getParentSession()).thenReturn(parentAuthenticationSession);
+        when(parentAuthenticationSession.getId()).thenReturn("test-session-id");
+
+        when(group.getName()).thenReturn("httpbin");
+        when(realm.getGroupsStream()).thenReturn(Stream.of(group));
+    }
+
+    @Test
+    public void testShouldRejectUnknownGroups() throws Exception {
+        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"unknown-group\"]}");
+
+        authenticator.authenticate(context);
+
+        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    }
+
+    @Test
+    public void testShouldRejectNonGroupMembers() throws Exception {
+        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"httpbin\"]}");
+        when(group.getName()).thenReturn("httpbin");
+        when(user.isMemberOf(group)).thenReturn(false); // User is not a member of the group
+
+        authenticator.authenticate(context);
+
+        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    }
+
+    @Test
+    public void testShouldAcceptEmptyGroups() {
+        when(client.getAttribute("uds.core.groups")).thenReturn(""); // Empty groups attribute
+
+        authenticator.authenticate(context);
+
+        verify(context).success();
+    }
+
+    @Test
+    public void testShouldAcceptUserInGroup() throws Exception {
+        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"httpbin\"]}");
+        when(group.getName()).thenReturn("httpbin");
+        when(user.isMemberOf(group)).thenReturn(true); // User is a member of the group
+
+        authenticator.authenticate(context);
+
+        verify(context).success();
+    }
+
+    @Test
+    public void testShouldRejectNullUser() {
+        when(context.getUser()).thenReturn(null); // Simulating null user
+
+        authenticator.authenticate(context);
+
+        verify(context).failure(AuthenticationFlowError.INVALID_USER);
+    }
+
+    @Test
+    public void testShouldRejectFailedJsonParse() {
+        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [invalid-json]}"); // Invalid JSON
+
+        authenticator.authenticate(context);
+
+        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    }
+
+    @Test
+    public void testShouldRejectNoGroupsArray() {
+        when(client.getAttribute("uds.core.groups")).thenReturn("{}"); // JSON without 'anyOf' array
+
+        authenticator.authenticate(context);
+
+        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    }
+
+    @Test
+    public void testShouldRejectMemberGroupNull() {
+        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [null]}"); // JSON with null group
+
+        authenticator.authenticate(context);
+
+        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+    }
+}

--- a/src/realm.json
+++ b/src/realm.json
@@ -2370,6 +2370,14 @@
                     "priority": 30,
                     "autheticatorFlow": false,
                     "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 40,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
                 }
             ]
         },

--- a/src/realm.json
+++ b/src/realm.json
@@ -2328,6 +2328,14 @@
                     "autheticatorFlow": true,
                     "flowAlias": "UDS registration form",
                     "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
                 }
             ]
         },

--- a/src/realm.json
+++ b/src/realm.json
@@ -1723,7 +1723,7 @@
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,
           "linkOnly": false,
-          "postBrokerLoginFlowAlias": "Authorization",
+          "postBrokerLoginFlowAlias": "Group Protection Authorization",
           "config": {
             "postBindingLogout": "false",
             "postBindingResponse": "true",
@@ -2268,7 +2268,7 @@
         },
         {
             "id": "7d53187d-13f4-4ec6-ade0-20b7d88d9aa4",
-            "alias": "Authorization",
+            "alias": "Group Protection Authorization",
             "description": "",
             "providerId": "basic-flow",
             "topLevel": true,

--- a/src/realm.json
+++ b/src/realm.json
@@ -2257,14 +2257,13 @@
                     "userSetupAllowed": false
                 },
                 {
-                    "authenticatorFlow": true,
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
                     "requirement": "REQUIRED",
                     "priority": 1,
-                    "flowAlias": "Authorization",
                     "userSetupAllowed": false,
-                    "autheticatorFlow": true
-                  }
-          
+                    "autheticatorFlow": false
+                }
             ]
         },
         {
@@ -2330,13 +2329,13 @@
                     "userSetupAllowed": false
                 },
                 {
-                    "authenticatorFlow": true,
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
                     "requirement": "REQUIRED",
                     "priority": 20,
-                    "flowAlias": "Authorization",
                     "userSetupAllowed": false,
-                    "autheticatorFlow": true
-                }
+                    "autheticatorFlow": false
+                  }
             ]
         },
         {
@@ -2372,13 +2371,13 @@
                     "userSetupAllowed": false
                 },
                 {
-                    "authenticatorFlow": true,
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
                     "requirement": "REQUIRED",
                     "priority": 40,
-                    "flowAlias": "Authorization",
                     "userSetupAllowed": false,
-                    "autheticatorFlow": true
-                }
+                    "autheticatorFlow": false
+                  }
             ]
         },
         {

--- a/src/realm.json
+++ b/src/realm.json
@@ -1723,6 +1723,7 @@
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,
           "linkOnly": false,
+          "postBrokerLoginFlowAlias": "Authorization",
           "config": {
             "postBindingLogout": "false",
             "postBindingResponse": "true",
@@ -2250,13 +2251,41 @@
                 {
                     "authenticatorFlow": true,
                     "requirement": "REQUIRED",
-                    "priority": 31,
+                    "priority": 0,
                     "autheticatorFlow": true,
                     "flowAlias": "Authentication",
                     "userSetupAllowed": false
-                }
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 1,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
+                  }
+          
             ]
         },
+        {
+            "id": "7d53187d-13f4-4ec6-ade0-20b7d88d9aa4",
+            "alias": "Authorization",
+            "description": "",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": false,
+            "authenticationExecutions": [
+              {
+                "authenticator": "uds-group-restriction",
+                "authenticatorFlow": false,
+                "requirement": "REQUIRED",
+                "priority": 0,
+                "userSetupAllowed": false,
+                "autheticatorFlow": false
+              }
+            ]
+          },
+      
         {
             "id": "5603fb4e-050a-48d5-9ffc-14fa0bba25e8",
             "alias": "UDS Authentication Browser - Conditional OTP",

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2142,6 +2142,14 @@
                     "priority": 30,
                     "autheticatorFlow": false,
                     "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 40,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
                 }
             ]
         },

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -61,7 +61,25 @@
             "lastName": "User",
             "email": "testinguser@gmail.com",
             "emailVerified": true,
-            "realmRoles": ["default-roles-uds"]
+            "realmRoles": ["default-roles-uds"],
+            "groups": ["/UDS Core/Auditor"]
+        },
+        {
+            "id": "123456",
+            "username": "testing_admin",
+            "enabled": "true",
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "testingpassword1!!"
+                }
+            ],
+            "firstName": "Testing",
+            "lastName": "Admin",
+            "email": "testingadmin@gmail.com",
+            "emailVerified": true,
+            "realmRoles": ["default-roles-uds"],
+            "groups": ["/UDS Core/Admin"]
         }
     ],
     "roles": {
@@ -1488,6 +1506,7 @@
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,
           "linkOnly": false,
+          "postBrokerLoginFlowAlias": "Authorization",
           "config": {
             "postBindingLogout": "false",
             "postBindingResponse": "true",
@@ -2006,10 +2025,36 @@
                 {
                     "authenticatorFlow": true,
                     "requirement": "REQUIRED",
-                    "priority": 31,
+                    "priority": 0,
                     "autheticatorFlow": true,
                     "flowAlias": "Authentication",
                     "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 1,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
+                }
+            ]
+        },
+        {
+            "id": "7d53187d-13f4-4ec6-ade0-20b7d88d9aa4",
+            "alias": "Authorization",
+            "description": "",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": false,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 0,
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": false
                 }
             ]
         },

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2100,6 +2100,14 @@
                     "autheticatorFlow": true,
                     "flowAlias": "UDS registration form",
                     "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "flowAlias": "Authorization",
+                    "userSetupAllowed": false,
+                    "autheticatorFlow": true
                 }
             ]
         },

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2031,12 +2031,12 @@
                     "userSetupAllowed": false
                 },
                 {
-                    "authenticatorFlow": true,
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
                     "requirement": "REQUIRED",
-                    "priority": 1,
-                    "flowAlias": "Authorization",
+                    "priority": 2,
                     "userSetupAllowed": false,
-                    "autheticatorFlow": true
+                    "autheticatorFlow": false
                 }
             ]
         },
@@ -2102,12 +2102,12 @@
                     "userSetupAllowed": false
                 },
                 {
-                    "authenticatorFlow": true,
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
                     "requirement": "REQUIRED",
                     "priority": 20,
-                    "flowAlias": "Authorization",
                     "userSetupAllowed": false,
-                    "autheticatorFlow": true
+                    "autheticatorFlow": false
                 }
             ]
         },
@@ -2144,12 +2144,12 @@
                     "userSetupAllowed": false
                 },
                 {
-                    "authenticatorFlow": true,
+                    "authenticator": "uds-group-restriction",
+                    "authenticatorFlow": false,
                     "requirement": "REQUIRED",
                     "priority": 40,
-                    "flowAlias": "Authorization",
                     "userSetupAllowed": false,
-                    "autheticatorFlow": true
+                    "autheticatorFlow": false
                 }
             ]
         },

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -1506,7 +1506,7 @@
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,
           "linkOnly": false,
-          "postBrokerLoginFlowAlias": "Authorization",
+          "postBrokerLoginFlowAlias": "Group Protection Authorization",
           "config": {
             "postBindingLogout": "false",
             "postBindingResponse": "true",
@@ -2042,7 +2042,7 @@
         },
         {
             "id": "7d53187d-13f4-4ec6-ade0-20b7d88d9aa4",
-            "alias": "Authorization",
+            "alias": "Group Protection Authorization",
             "description": "",
             "providerId": "basic-flow",
             "topLevel": true,


### PR DESCRIPTION
## Description
* Adds authenticator that enforces client.attribute.groups membership
* Denies access if group does not exist
* Adds group authenticator to default realm configuration
* Adds group authenticator for IDP flow
* Unit Testing all the things

### Example Package definition to require group authentication for an application
```yaml
apiVersion: uds.dev/v1alpha1
kind: Package
metadata:
  name: grafana
  namespace: {{ .Release.Namespace }}
spec:
  sso:
    - name: Grafana Dashboard
      clientId: uds-core-admin-grafana
      redirectUris:
        - "https://grafana.admin.{{ .Values.domain }}/login/generic_oauth"
      groups:
        anyOf:
          - /UDS Core/Admin
```

## Related Issue
This is related / has a sister PR in the [uds-core repo ](https://github.com/defenseunicorns/uds-core/pull/497)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed