### PR TITLE
fix: login image not loading

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,7 +3,7 @@
 # Build the Keycloak java plugin and copy any extra-jars                          #
 #                                                                                 #
 ###################################################################################
-FROM cgr.dev/chainguard/maven:openjdk-17 as plugin
+FROM cgr.dev/chainguard/maven:openjdk-17 AS plugin
 
 WORKDIR /home/build
 
@@ -21,7 +21,7 @@ COPY extra-jars/* ./target/
 # Build the Java truststore from DOD CAs                                          #
 #                                                                                 #
 ###################################################################################
-FROM amazoncorretto:21-alpine-jdk as truststore
+FROM amazoncorretto:21-alpine-jdk AS truststore
 USER root
 RUN apk add openssl coreutils sed bash findutils
 

--- a/src/theme/login/template.ftl
+++ b/src/theme/login/template.ftl
@@ -38,9 +38,7 @@ ${msg("loginTitle",(realm.displayName!''))}
                 <div class="card">
                     <div class="card-header branding row">
                         <div class="col-sm-5 p-0">
-                            <#if client??>
-                                <img src="${url.resourcesPath}/img/uds-logo.svg"/>
-                            </#if>
+                            <img src="${url.resourcesPath}/img/uds-logo.svg"/>
                         </div>
                         <div class="col-sm-1">&nbsp;</div>
                         <div class="col-sm-6 my-auto">

--- a/src/theme/login/template.ftl
+++ b/src/theme/login/template.ftl
@@ -38,9 +38,7 @@ ${msg("loginTitle",(realm.displayName!''))}
                 <div class="card">
                     <div class="card-header branding row">
                         <div class="col-sm-5 p-0">
-                            <#if client?? && client.description?has_content>
-                                <img src="${client.description}"/>
-                            <#else>
+                            <#if client??>
                                 <img src="${url.resourcesPath}/img/uds-logo.svg"/>
                             </#if>
                         </div>


### PR DESCRIPTION
## Description
Login theme logo had some weird logic that is no longer being used. Removing the usecase of defining the login logo from the description that we override with our package definition. Now depends solely on the uds-logo in the identity config.

Maybe this removes the ability to override the default logo and that's something we want to enable, in which case we need to rework the use of description field.

Also noticed a small warning when building the uds-identity image dockerfile, fixed that as well.

## Related Issue

Fixes #124 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed