### PR TITLE
fix: escape client name

### DIFF
--- a/src/theme/login/template.ftl
+++ b/src/theme/login/template.ftl
@@ -50,7 +50,7 @@ ${msg("loginTitle",(realm.displayName!''))}
                                     </h2>
                                 <#else>
                                     <h2 class="client-unique-name">
-                                        ${client.name?no_esc}
+                                        ${kcSanitize(client.name)?no_esc}
                                     </h2>
                                 </#if>
                             <#else>


### PR DESCRIPTION
## Description
Currently a client name is not escaped allowing for a potential XSS. Wrap client name in Keycloak's `kcSanitize` function to make sure that value is escaped properly.

## Related Issue

Fixes #128 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed