### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -61,10 +61,15 @@
       "updateTypes": ["patch"],
       "labels": ["renovate/helm-release", "dependency/patch"]
     },
-    {   
+    {
       "description": "Group Github Actions and vscode/settings.json updates.",
       "matchPaths": [".github/**", ".vscode/settings.json"],
       "groupName": "GHA-DEPS"
+    },
+    {
+      "description": "Group updates in src/plugin files into plugin-deps group.",
+      "matchPaths": ["src/plugin/pom.xml"],
+      "groupName": "plugin-deps"
     }
   ],
   "regexManagers":[
@@ -75,6 +80,6 @@
       ],
       "versioningTemplate": "semver-coerced",
       "datasourceTemplate": "github-tags"
-    }  
+    }
   ]
 }


### PR DESCRIPTION
## Description
There is a current problem where we are unable to move to keycloak v25 which creates a renovate problem where some dependencies are grouped with those updates and we have to get two people to create and approve individual PR's for that. 

Tested these changes in a personal repo here: https://github.com/UnicornChance/uds-identity-config/pulls

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed