### PR TITLE
fix: add new client scope

### DIFF
--- a/src/realm.json
+++ b/src/realm.json
@@ -1252,6 +1252,35 @@
             ]
         },
         {
+            "id": "1962f32a-2c09-4ce0-8677-6f6776768d24",
+            "name": "bare-groups",
+            "description": "A client scope providing only the simplified, non-hierarchical group names.",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "Please use this scope only if you understand the implications of excluding full path information from group data."
+            },
+            "protocolMappers": [
+                {
+                    "id": "62009bb0-75d1-46a8-b207-f39a0c3c0e2d",
+                    "name": "bare_groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-group-membership-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "full.path": "false",
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "id.token.claim": "true",
+                        "lightweight.claim": "false",
+                        "access.token.claim": "true",
+                        "claim.name": "bare_groups"
+                    }
+                }
+            ]
+        },
+        {
             "id": "80bca4fb-c991-4f47-b941-90033d417619",
             "name": "web-origins",
             "description": "OpenID Connect scope for add allowed web origins to the access token",
@@ -1618,7 +1647,8 @@
         "offline_access",
         "address",
         "phone",
-        "microprofile-jwt"
+        "microprofile-jwt",
+        "bare-groups"
     ],
     "browserSecurityHeaders": {
         "contentSecurityPolicyReportOnly": "",
@@ -1828,6 +1858,7 @@
                     ],
                     "allowed-client-scopes": [
                         "openid",
+                        "bare-groups",
                         "mapper-saml-username-name",
                         "mapper-saml-email-email",
                         "mapper-saml-username-login",
@@ -1836,7 +1867,7 @@
                         "mapper-saml-grouplist-groups",
                         "mapper-oidc-username-username",
                         "mapper-oidc-mattermostid-id",
-                        "mapper-oidc-email-email"                     
+                        "mapper-oidc-email-email"
                     ]
                 }
             },

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -1288,6 +1288,36 @@
             ]
         },
         {
+            "id": "1962f32a-2c09-4ce0-8677-6f6776768d24",
+            "name": "bare-groups",
+            "description": "A client scope providing only the simplified, non-hierarchical group names.",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "gui.order": "",
+                "consent.screen.text": "Please use this scope only if you understand the implications of excluding full path information from group data."
+            },
+            "protocolMappers": [
+                {
+                    "id": "62009bb0-75d1-46a8-b207-f39a0c3c0e2d",
+                    "name": "bare_groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-group-membership-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "full.path": "false",
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "id.token.claim": "true",
+                        "lightweight.claim": "false",
+                        "access.token.claim": "true",
+                        "claim.name": "bare_groups"
+                    }
+                }
+            ]
+        },
+        {
             "id": "80bca4fb-c991-4f47-b941-90033d417619",
             "name": "web-origins",
             "description": "OpenID Connect scope for add allowed web origins to the access token",
@@ -1401,7 +1431,8 @@
         "offline_access",
         "address",
         "phone",
-        "microprofile-jwt"
+        "microprofile-jwt",
+        "bare-groups"
     ],
     "browserSecurityHeaders": {
         "contentSecurityPolicyReportOnly": "",
@@ -1610,7 +1641,17 @@
                         "true"
                     ],
                     "allowed-client-scopes": [
-                        "openid"
+                        "openid",
+                        "bare-groups",
+                        "mapper-saml-username-name",
+                        "mapper-saml-email-email",
+                        "mapper-saml-username-login",
+                        "mapper-saml-firstname-first_name",
+                        "mapper-saml-lastname-last_name",
+                        "mapper-saml-grouplist-groups",
+                        "mapper-oidc-username-username",
+                        "mapper-oidc-mattermostid-id",
+                        "mapper-oidc-email-email"
                     ]
                 }
             },


### PR DESCRIPTION
## Description
Create an optional Client Scope for including only the child group name and excluding all hierarchical group paths. 

The new client scope is called `bare-groups` and it creates a token claim called `bare_groups`. This scope is optional, meaning it will not come default with clients, we still want to encourage the use of the full.path group called `groups` that is in the `profile` client scope. 

There is a potential risk if using only the new `bare_groups` for user authorization because there can technically be two different child groups called `ADMIN` and by removing the parent group structure those two child groups would be identical. An easy solution for this is to implement the use of [group authorization](https://uds.defenseunicorns.com/core/configuration/uds-operator/#package) that uses the `group` full.path to verify a user has access to the given application.

## Related Issue

Fixes [#603](https://github.com/defenseunicorns/uds-core/issues/603)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed