### PR TITLE
chore: add support for configurable admin domain

### DIFF
--- a/src/realm.json
+++ b/src/realm.json
@@ -1925,7 +1925,7 @@
                     "trusted-hosts": [
                         "127.0.0.6",
                         "*.${UDS_DOMAIN}",
-                        "*.${UDS_ADMIN_DOMAIN:cluster.local}"
+                        "*.${UDS_ADMIN_DOMAIN}"
                     ],
                     "client-uris-must-match": [
                         "true"

--- a/src/realm.json
+++ b/src/realm.json
@@ -1925,7 +1925,7 @@
                     "trusted-hosts": [
                         "127.0.0.6",
                         "*.${UDS_DOMAIN}",
-                        "*.${UDS_ADMIN_DOMAIN}"
+                        "*.${UDS_ADMIN_DOMAIN:cluster.local}"
                     ],
                     "client-uris-must-match": [
                         "true"

--- a/src/realm.json
+++ b/src/realm.json
@@ -1925,7 +1925,7 @@
                     "trusted-hosts": [
                         "127.0.0.6",
                         "*.${UDS_DOMAIN}",
-                        "*.admin.${UDS_DOMAIN}"
+                        "*.${UDS_ADMIN_DOMAIN}"
                     ],
                     "client-uris-must-match": [
                         "true"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -18,7 +18,7 @@ variables:
   - name: CORE_VERSION
     description: UDS Core Version for Releases and Clone
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    default: "configurable-admin"
+    default: "v0.32.1"
 
 tasks:
   - name: build-and-publish

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -18,7 +18,7 @@ variables:
   - name: CORE_VERSION
     description: UDS Core Version for Releases and Clone
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    default: "v0.32.1"
+    default: "configurable-admin"
 
 tasks:
   - name: build-and-publish
@@ -117,7 +117,7 @@ tasks:
     description: Configure existing uds-core/grafana package for group authz, build, deploy grafana
     actions:
       - cmd: |
-          sed -i '/^\s*sso:/,/^\s*-\s*name:/ { 
+          sed -i '/^\s*sso:/,/^\s*-\s*name:/ {
             /groups:/d
             /^\s*-\s*name:/a \ \ \ \ \ \ groups:\n\ \ \ \ \ \ \ \ anyOf:\n\ \ \ \ \ \ \ \ \ - \/UDS Core\/Admin
           }' uds-core/src/grafana/chart/templates/uds-package.yaml


### PR DESCRIPTION
## Description

Modifies the trusted hosts policy to match `"*.${UDS_ADMIN_DOMAIN}"` instead of `"*.admin.${UDS_DOMAIN}"`. Note that `*.${UDS_DOMAIN}` will also match `*.admin.${UDS_DOMAIN}` due to how Keycloak interprets these. In some cases both list items may be identical, but Keycloak allows this without issue.

This should wait on the related PR in uds-core: https://github.com/defenseunicorns/uds-core/pull/1114

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed