### PR TITLE
fix: admin ui login theme bug fix

### DIFF
--- a/src/theme/login/template.ftl
+++ b/src/theme/login/template.ftl
@@ -55,6 +55,10 @@ ${msg("loginTitle",(realm.displayName!''))}
                                     <h2 class="client-unique-name">
                                         My Account
                                     </h2>
+                                <#elseif client.name == "${" + "client_security-admin-console" + "}">
+                                    <h2 class="client-unique-name">
+                                        Admin Account
+                                    </h2>
                                 <#else>
                                     <h2 class="client-unique-name">
                                         ${kcSanitize(client.name)?no_esc}


### PR DESCRIPTION
## Description
When enabling the admin ui to use a specific type of auth flow, there is a bug that doesnt show the correct client in the login theme. We've never ( add rarely will) use a custom theme for the admin ui however this will be value add with the new authentication configurations.

## Testing
1. Modify the identity-config bundle to be only x509 enable auth flow
2. deploy identity-config with uds core  `uds run uds-core-integration-tests`
3. log into Admin UI
4. change login theme to be `Theme`
5. logout
6. verify that login page has change to the login theme and the title says `Admin Account` not `${client_security-admin-console}`

![Screenshot from 2024-12-20 08-52-11](https://github.com/user-attachments/assets/0a64cc31-652f-4cb6-9625-6194c6ef4c01)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed