### PR TITLE
chore: add action to check readiness on renovate PRs before running CI

### DIFF
--- a/.github/actions/renovate-readiness/action.yaml
+++ b/.github/actions/renovate-readiness/action.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+name: renovate-readiness
+description: "Check if Renovate PRs are ready for testing"
+
+runs:
+  using: composite
+  steps:
+    # This is current a stub for future logic that would auto-detect readiness
+    # In lieu of that, we require an engineer to review changes and manually add the `renovate-ready` label
+    - name: Check if PR has the ready label
+      if: ${{ ! contains(github.event.pull_request.labels.*.name, 'renovate-ready') }}
+      run: |
+        echo "This PR is not ready to run CI. Failing job."
+        exit 1
+      shell: bash

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -7,7 +7,8 @@ on:
   pull_request:
     branches: [main]
     # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
-    types: [milestoned, opened, edited, synchronize]
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
 
 jobs:
   title_check:
@@ -22,6 +23,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
 
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,8 @@ name: Test
 on:
   pull_request:
     branches: [main]
-    types: [milestoned, opened, reopened, synchronize]
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
 
 # Abort prior jobs in the same workflow / PR
 concurrency:
@@ -24,6 +25,10 @@ jobs:
     steps:
       - name: Github Actions Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
 
       - name: Environment setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Description
Not absolutely necessary since there is minimal renovate churn in the repo but to be as similar to uds-core possible.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed