### PR TITLE
feat: force re-login after changing credentials

### DIFF
--- a/docs/reference/UDS Core/IdAM/upgrading-versions.md
+++ b/docs/reference/UDS Core/IdAM/upgrading-versions.md
@@ -4,7 +4,7 @@ title: Upgrading Versions
 
 This doc contains important information for upgrading uds-identity-config versions. It is not meant to be an exhaustive list of changes between versions, rather information and steps required to manually upgrade versions without a full redeploy of keycloak.
 
-## v0.9.1 to v0.9.2
+## v0.9.1 to v0.10.0
 
 <details open>
 <summary>Upgrade Details</summary>
@@ -13,6 +13,10 @@ This doc contains important information for upgrading uds-identity-config versio
   - Click `Clients` > `Client registration` > `Client details`
   - Add `*.pepr-uds-core-watcher.pepr-system.svc.cluster.local` and `*.keycloak.svc.cluster.local` to the `Trusted Hosts` list
   - Click `Save`
+* Keycloak 26.1.1 introduces a new option to force re-login after resetting credentials ([Keycloak Release Notes](https://www.keycloak.org/docs/latest/release_notes/index.html#new-option-in-send-reset-email-to-force-a-login-after-reset-credentials)). This option has been enabled for new deployments but the existing ones, it needs to be turned on manually:
+    - Click `Authentication` > `UDS Reset Credentials` and find `Send Reset Email` Step of the Authentication Flow.
+    - Click `Settings`, enter a new alias name, for example `reset-credentials-email` and turn the `Force login after reset` option on.
+    - Click `Save`
 </details>
 
 ## v0.5.1 to v0.5.2

--- a/src/realm.json
+++ b/src/realm.json
@@ -2417,6 +2417,7 @@
                     "userSetupAllowed": false
                 },
                 {
+                    "authenticatorConfig": "reset-credentials-email",
                     "authenticator": "reset-credential-email",
                     "authenticatorFlow": false,
                     "requirement": "REQUIRED",
@@ -2897,6 +2898,13 @@
             "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
             "alias": "main",
             "config": {}
+        },
+        {
+            "id": "b5d3d1bc-14b0-407f-8057-d72451a34013",
+            "alias": "reset-credentials-email",
+            "config": {
+              "force-login": "true"
+            }
         },
         {
             "id": "d20d218e-9109-455d-9b03-bb453e209e81",

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2190,6 +2190,7 @@
                     "userSetupAllowed": false
                 },
                 {
+                    "authenticatorConfig": "reset-credentials-email",
                     "authenticator": "reset-credential-email",
                     "authenticatorFlow": false,
                     "requirement": "REQUIRED",
@@ -2670,6 +2671,13 @@
             "id": "5afe735f-ceba-4390-8ad4-63de03c294cc",
             "alias": "main",
             "config": {}
+        },
+        {
+            "id": "b5d3d1bc-14b0-407f-8057-d72451a34013",
+            "alias": "reset-credentials-email",
+            "config": {
+              "force-login": "true"
+            }
         },
         {
             "id": "d20d218e-9109-455d-9b03-bb453e209e81",


### PR DESCRIPTION
## Description

This Pull Request forces users to re-login after they change their credentials. 

More info: https://www.keycloak.org/docs/latest/release_notes/index.html#new-option-in-send-reset-email-to-force-a-login-after-reset-credentials

Since this is a low-priority hardening change, I skipped writing automated tests for it. 

## Related Issue

Fixes #329

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed