### PR TITLE
chore: stabilize tests

### DIFF
--- a/src/test/cypress/cypress.config.ts
+++ b/src/test/cypress/cypress.config.ts
@@ -29,6 +29,7 @@ module.exports = defineConfig({
     supportFile: "support/e2e.ts",
     screenshotOnRunFailure: false,
     video: false,
+    injectDocumentDomain: true,
   },
 
   pageLoadTimeout: 12000,


### PR DESCRIPTION
## Description

This Pull Request stabilizes tests that try to obtain `cy.document` object. Depending on the exact moment in the redirect flow, calling this may or may not end up with cross-origin call. These cross-origin calls end up with an error in Cypress 14 and the behavior will be permanently changed in Cypress 15 (see the [docs](https://docs.cypress.io/api/commands/origin)).

The easiest approach for the time-bing is to include the `injectDocumentDomain` option in the configuration. This ensures all calls to the `cy.document` pass regardless to the origin. A larger test restructure task has been scheduled in
#341

## Related Issue

Fixes #338

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
