### PR TITLE
fix: update cypress tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ uds-core/**
 ./tls_cacert.yaml
 ./test.pfx
 src/extra-jars/
-src/test/cypress/node_modules/**
+**/node_modules/**
 src/plugin/target/**
 uds-docs/
 uds-docs/**

--- a/bundles/uds-bundle.yaml
+++ b/bundles/uds-bundle.yaml
@@ -16,7 +16,7 @@ packages:
   - name: init
     repository: ghcr.io/zarf-dev/packages/init
     # renovate: datasource=github-tags depName=zarf-dev/zarf versioning=semver
-    ref: v0.48.1
+    ref: v0.49.0
 
   - name: keycloak-identity-config
     path: ../
@@ -25,7 +25,7 @@ packages:
   - name: core-base
     path: ../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.35.0
+    ref: 0.36.2
     overrides:
       istio-admin-gateway:
         uds-istio-config:
@@ -55,7 +55,7 @@ packages:
   - name: core-identity-authorization
     path: ../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.35.0
+    ref: 0.36.2
     overrides:
       keycloak:
         keycloak:
@@ -83,4 +83,4 @@ packages:
   - name: core-monitoring
     path: ../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.35.0
+    ref: 0.36.2

--- a/src/test/cypress/cypress.config.ts
+++ b/src/test/cypress/cypress.config.ts
@@ -5,19 +5,23 @@
 
 import { defineConfig } from "cypress";
 
+const useCAC = process.env.USE_CAC === "true";
+
 module.exports = defineConfig({
-  clientCertificates: [
-    {
-      url: "https://sso.uds.dev/**",
-      ca: [],
-      certs: [
-        {
-          pfx: "certs/test.pfx",
-          passphrase: "certs/pfx_passphrase.txt",
-        },
-      ],
-    },
-  ],
+  clientCertificates: useCAC
+    ? [
+      {
+        url: "https://sso.uds.dev/**",
+        ca: [],
+        certs: [
+          {
+            pfx: "certs/test.pfx",
+            passphrase: "certs/pfx_passphrase.txt",
+          },
+        ],
+      },
+    ]
+    : [],
 
   e2e: {
     setupNodeEvents(on, config) {
@@ -31,6 +35,5 @@ module.exports = defineConfig({
     video: false,
     injectDocumentDomain: true,
   },
-
   pageLoadTimeout: 12000,
 });

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -8,6 +8,7 @@
       "name": "uds-identity-config",
       "version": "1.0.0",
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "cypress": "^14.0.0",
         "prettier": "^3.2.5",
         "typescript": "^5.4.3"
@@ -538,6 +539,24 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.3.tgz",
-      "integrity": "sha512-yIdvobANw3kS+KF/t5vwjjPNufBA8ux7iQHaWxPTkUw2yCKI72m9mKM24eOwE84Wk4ALPsSvEcGbDrwgmhr4RA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.1.0.tgz",
+      "integrity": "sha512-pPPj8Uu9NwjaaiXAEcjYZZmgsq6v9Zs1Nw6a+zRF+ANgYSNhH4S32SjFRsvMcuOHR/8dp4GBJhBPqIPSs+TxaA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -572,7 +572,7 @@
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
-        "ci-info": "^4.0.0",
+        "ci-info": "^4.1.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
         "commander": "^6.2.1",
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -5,11 +5,14 @@
   "scripts": {
     "cy.open": "cypress open",
     "cy.run": "cypress run",
+    "cy.run:registration": "cross-env USE_CAC=true cypress run --spec 'e2e/registration.cy.ts'",
+    "cy.run:others": "cross-env USE_CAC=false cypress run --spec 'e2e/login.cy.ts,e2e/group-authz.cy.ts'",
     "prettier": "prettier --write **/*.ts"
   },
   "devDependencies": {
     "cypress": "^14.0.0",
     "prettier": "^3.2.5",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.3",
+    "cross-env": "^7.0.3"
   }
 }

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -146,7 +146,8 @@ tasks:
     actions:
       - cmd: |
           npm --prefix src/test/cypress install
-          npm --prefix src/test/cypress run cy.run
+          npm --prefix src/test/cypress run cy.run:others
+          npm --prefix src/test/cypress run cy.run:registration
 
   - name: license
     actions:

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
-  - remote: https://raw.githubusercontent.com/defenseunicorns/uds-common/v1.8.0/tasks/lint.yaml
+  - remote: https://raw.githubusercontent.com/defenseunicorns/uds-common/v1.9.1/tasks/lint.yaml
 
 variables:
   - name: VERSION
@@ -18,7 +18,7 @@ variables:
   - name: CORE_VERSION
     description: UDS Core Version for Releases and Clone
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    default: "v0.35.0"
+    default: "v0.36.2"
 
 tasks:
   - name: build-and-publish


### PR DESCRIPTION
## Description

It appears that in the latest version of cypress (14.1+) there was some optimizations made to the tests that has exposed a race condition that was undetected in the tests. ( could also be that the cypress tests are now synchronous by default whereas previous to the new cypress version they were asynchronous, however the release notes don't mention this).

The way that cypress manages injected CAC browser certs, means that it's there for all tests. Previously the registration test that actually uses that cert always got to it first, now the login user test gets there first and causes cypress to fail because it wasn't expecting to get a CAC pop up.



There is two avenues to fix this, i went with the 2nd option so that we could guarantee the outcome of tests now and in the future where there are additional tests added:

1. combine test into a single file, rather than three individual ones
     - simplest solution, only 9 tests total across the three files
     - does mean the tests need to be ordered correctly ( fragile in the long term )
     - can maintain the npm run command that gets all cypress tests regardless of name
     
2. add some logic so that the cac is only present in the browser for the registration tests.
     - this would allow us to keep individual files for the different test
     - also means the tests are truly individual from one another
     - requires that an ENV be passed in to the registration test


## Test locally:
`uds run uds-core-integration-tests` - run cypress tests against latest release of uds-core, should result in successful e2e tests.


## Related Issue

Fixes #348 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed