### PR TITLE
fix: authentication flow rename after breaking doug user

### DIFF
--- a/src/realm.json
+++ b/src/realm.json
@@ -2227,7 +2227,7 @@
             ]
         },
         {
-            "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
+            "id": "6ba27e4e-b569-4531-857b-2e6a10077f02",
             "alias": "Conditional X509 2FA",
             "description": "",
             "providerId": "basic-flow",

--- a/src/realm.json
+++ b/src/realm.json
@@ -2127,7 +2127,7 @@
                     "requirement": "ALTERNATIVE",
                     "priority": 3,
                     "autheticatorFlow": true,
-                    "flowAlias": "Username/Password Authentication",
+                    "flowAlias": "Conditional OTP",
                     "userSetupAllowed": false
                 }
             ]
@@ -2357,8 +2357,8 @@
             ]
         },
         {
-            "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
-            "alias": "Username/Password Authentication",
+            "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
+            "alias": "Conditional OTP",
             "description": "",
             "providerId": "basic-flow",
             "topLevel": false,

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2260,7 +2260,7 @@
             ]
         },
         {
-            "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
+            "id": "6ba27e4e-b569-4531-857b-2e6a10077f02",
             "alias": "Conditional X509 2FA",
             "description": "",
             "providerId": "basic-flow",

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2160,7 +2160,7 @@
                     "requirement": "ALTERNATIVE",
                     "priority": 3,
                     "autheticatorFlow": true,
-                    "flowAlias": "Username/Password Authentication",
+                    "flowAlias": "Conditional OTP",
                     "userSetupAllowed": false
                 }
             ]
@@ -2390,8 +2390,8 @@
             ]
         },
         {
-            "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
-            "alias": "Username/Password Authentication",
+            "id": "ae089c5c-0424-4fb7-9768-2346b32bb1b2",
+            "alias": "Conditional OTP",
             "description": "",
             "providerId": "basic-flow",
             "topLevel": false,


### PR DESCRIPTION
## Description
In previous PR I renamed the authentication flows and this resulted in the doug user breaking because it depends on the authentication flow to disable the OTP. this resulted in OTP being present on playwright tests, which resulted in failures.

## Related Issue

Fixes #402

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed