### PR TITLE
fix: rename auth flow

### DIFF
--- a/src/realm.json
+++ b/src/realm.json
@@ -2194,7 +2194,7 @@
         },
         {
             "id": "6ba27e4e-b569-4531-857b-2e6a10077f02",
-            "alias": "Conditional Username/Password 2FA",
+            "alias": "Conditional OTP",
             "description": "",
             "providerId": "basic-flow",
             "topLevel": false,
@@ -2385,7 +2385,7 @@
                     "requirement": "${MFA_FLOW_ENABLED:DISABLED}",
                     "priority": 2,
                     "autheticatorFlow": true,
-                    "flowAlias": "Conditional Username/Password 2FA",
+                    "flowAlias": "Conditional OTP",
                     "userSetupAllowed": false
                 }
             ]

--- a/src/test/cypress/realm.json
+++ b/src/test/cypress/realm.json
@@ -2227,7 +2227,7 @@
         },
         {
             "id": "6ba27e4e-b569-4531-857b-2e6a10077f02",
-            "alias": "Conditional Username/Password 2FA",
+            "alias": "Conditional OTP",
             "description": "",
             "providerId": "basic-flow",
             "topLevel": false,
@@ -2418,7 +2418,7 @@
                     "requirement": "${MFA_FLOW_ENABLED:DISABLED}",
                     "priority": 2,
                     "autheticatorFlow": true,
-                    "flowAlias": "Conditional Username/Password 2FA",
+                    "flowAlias": "Conditional OTP",
                     "userSetupAllowed": false
                 }
             ]


### PR DESCRIPTION
## Description
In previous PR, renamed the authentication flows and this resulted in the doug user breaking because it depends on the authentication flow to disable the OTP. this resulted in OTP being present on playwright tests, which resulted in failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)


- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed