### PR TITLE
chore(docs): update air gapped limitations for x509

### DIFF
--- a/docs/reference/UDS Core/IdAM/authentication-flows.md
+++ b/docs/reference/UDS Core/IdAM/authentication-flows.md
@@ -26,6 +26,8 @@ UDS Core comes equipped with a robust authentication framework that supports mul
 
     x509 certificates provide a way to authenticate using digital certificates. It is commonly used in environments that require higher security, such as corporate or governmental networks. This method uses public key infrastructure (PKI) to verify the user's identity through a trusted certificate authority.
 
+    > **Air-Gapped Note**: In environments without reliable internet access, **OCSP revocation checks** may fail if the designated OCSP responder cannot be reached. As a short-term workaround, you can configure “fail-open” or disable OCSP checks entirely. However, these approaches carry **security risks** (e.g., potentially allowing revoked certificates).
+
 ---
 
 ![Authentication Flow Options](https://github.com/defenseunicorns/uds-identity-config/blob/main/docs/.images/diagrams/uds-core-auth-flows-options.svg?raw=true)

--- a/docs/reference/UDS Core/IdAM/customization.md
+++ b/docs/reference/UDS Core/IdAM/customization.md
@@ -147,6 +147,12 @@ overrides:
 
 > These environment variables can be found in the [realm.json](https://github.com/defenseunicorns/uds-identity-config/blob/main/src/realm.json).
 
+:::note
+**Important**: By allowing certificates to pass when no revocation check is performed, you accept the **risk** of potentially allowing revoked certificates to authenticate. This can pose a significant security threat depending on your organization’s compliance requirements and threat model.
+- **Fail-Closed (`X509_OCSP_FAIL_OPEN:false`)**: More secure (no unchecked certificates) but can disrupt logins if the OCSP responder is unreachable.
+- **Fail-Open (`X509_OCSP_FAIL_OPEN:true`)**: More forgiving (users still log in if checks fail) but can allow revoked certificates if the OCSP server is down.
+:::
+
 ### Customizing Session and Access Token Timeouts
 The `SSO_SESSION_IDLE_TIMEOUT` specifies how long a session remains active without user activity, while the `ACCESS_TOKEN_LIFESPAN` defines the validity duration of an access token before it requires refreshing. The `SSO_SESSION_MAX_LIFESPAN` determines the maximum duration a session can remain active, regardless of user activity.
 

--- a/docs/reference/UDS Core/IdAM/uds-identity-config-overview.md
+++ b/docs/reference/UDS Core/IdAM/uds-identity-config-overview.md
@@ -20,6 +20,11 @@ UDS Identity Config is responsible for managing several key aspects of Keycloak�
 3. Truststore Management – Ensures secure communication by handling trusted certificates and keys.
 4. Custom Plugins – Supports additional functionality through custom Keycloak extensions and providers.
 
+### Air-Gapped Limitations
+When Keycloak is configured for X.509 certificate authentication and OCSP checking (x509-cert-auth.ocsp-checking-enabled) is enabled, it attempts to contact the OCSP responder specified in the certificate or a manually configured URL. In air-gapped or otherwise restricted environments, this external endpoint may be unreachable.
+
+See this [bundle override](https://uds.defenseunicorns.com/reference/uds-core/idam/customization/#templated-realm-values) for an example of disabling OCSP checking but note the risks of doing so. By allowing certificates to pass when the revocation check fails, the door is open to revoked certificates being considered valid, which can pose a serious security threat depending on your organization’s compliance requirements and threat model.
+
 ### Upgrading UDS Identity Config
 When upgrading UDS Identity Config, changes to the realm configuration do not propagate automatically. This is because Keycloak persists its realm settings across upgrades to prevent breaking existing functionality. To apply updates to the realm configuration, follow the manual steps outlined in [Upgrading Identity Config Versions](https://uds.defenseunicorns.com/reference/uds-core/idam/upgrading-versions/) .
 


### PR DESCRIPTION
## Description
We’ve encountered issues in air-gapped environments where Keycloak’s X.509 authentication flow fails due to unreachable OCSP responders. Currently, there is no official documentation guiding users on how to configure Keycloak for such environments or what the trade-offs are between different options (fail-open vs. fail-closed, disabling OCSP, hosting an internal responder, etc.). We need clear guidance in the documentation for administrators who must configure Keycloak X.509 authentication in offline or restricted environments.

## Related Issue

Fixes #412 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed