### PR TITLE
feat: uds policy hardening

### DIFF
--- a/docs/reference/UDS Core/IdAM/plugin.md
+++ b/docs/reference/UDS Core/IdAM/plugin.md
@@ -17,6 +17,14 @@ A Keycloak plugin provides additional custom logic to our Keycloak deployment. B
 | [ClientIdAndKubernetesSecretAuthenticator](https://github.com/defenseunicorns/uds-identity-config/blob/main/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/ClientIdAndKubernetesSecretAuthenticator.java) | [ClientAuthenticator](https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/authentication/ClientAuthenticator.html)                          | Authenticates a client using a Kubernetes secret. Used in the `ClientIdAndKubernetesSecret` authentication flow.                                                                                                                                                                                                                                                   |
 | [UDSClientPolicyPermissionsExecutor](https://github.com/defenseunicorns/uds-identity-config/blob/main/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java)                            | [ClientPolicyExecutorProvider](https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/clientpolicy/executor/ClientPolicyExecutorProvider.html) | Checks if a client has the necessary permissions to access a resource. Used in the `UDSClientPolicyPermissions` client policy.                                                                                                                                                                                                                                     |
 
+### Security hardening
+
+The UDS Keycloak Plugin leverages [Keycloak Client Policies](https://www.keycloak.org/docs/latest/server_admin/index.html#_client_policies) to enforce security hardening for clients created by the UDS Operator. The configuration can be accessed under "Realm Settings" > "Client Policies" > "UDS Client Profile" > "uds-operator-permissions" and includes the following options:
+
+* `Additional Allowed Protocol Mappers` - Specifies additional Protocol Mappers permitted for use by the packages.
+* `Use UDS Default Allowed Protocol Mappers` - When enabled, applies a predefined list of Protocol Mappers. Additional Protocol Mappers can be added using the `Additional Allowed Protocol Mappers` option.
+* `Additional Allowed Client Scopes` - Specifies additional Client Scopes permitted for use by the packages.
+* `Use UDS Default Client Scopes` - When enabled, applies a predefined list of Client Scopes. Additional Client Scopes can be added using the `Additional Allowed Client Scopes` option.
 
 ### Terms and Conditions behavior
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/CustomGroupPathMapper.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/CustomGroupPathMapper.java
@@ -25,8 +25,8 @@ public class CustomGroupPathMapper extends AbstractOIDCProtocolMapper implements
         OIDCIDTokenMapper, UserInfoTokenMapper {
 
     public static final String PROVIDER_ID = "bare-group-path-mapper";
-    private static final String GROUPS_CLAIM = "groups";
-    private static final String BARE_GROUPS_CLAIM = "bare-groups";
+    public static final String GROUPS_CLAIM = "groups";
+    public static final String BARE_GROUPS_CLAIM = "bare-groups";
 
     @Override
     public String getDisplayCategory() {

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
@@ -5,9 +5,18 @@
 
 package com.defenseunicorns.uds.keycloak.plugin.clientpolicy.executor;
 
+import com.defenseunicorns.uds.keycloak.plugin.CustomAWSSAMLGroupMapper;
+import com.defenseunicorns.uds.keycloak.plugin.CustomGroupPathMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.events.Errors;
 import org.keycloak.models.ClientModel;
-import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.*;
+import org.keycloak.protocol.saml.mappers.RoleListMapper;
+import org.keycloak.protocol.saml.mappers.UserAttributeStatementMapper;
+import org.keycloak.protocol.saml.mappers.UserPropertyAttributeStatementMapper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -18,6 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Keycloak Client Policy Executor for the UDS Operator.
@@ -26,26 +38,69 @@ import java.lang.invoke.MethodHandles;
  * * The Client is marked as created by the UDS Operator by setting the attribute "created-by=uds-operator".
  * * The UDS Operator's Token is checked if it can access particular Client (the client need to contain "created-by=uds-operator" attribute).
  * * The Client can't use the Full Scope Allowed feature.
- * * The Client can use all potential Client Scopes. This will be restricted in the future and is tracked with https://github.com/defenseunicorns/uds-identity-config/issues/385
+ * * The Client can only use the Protocol Mappers that are whitelisted in the configuration. The default, opinionated configuration uses OIDC nad UDS Protocol Mappers.
+ * * The Client can only use the Custom Client Scopes that are whitelisted in the configuration. The default, opinionated configuration uses UDS Provided Client Scopes, Client Scopes configured at the Realm level as well as SAML defaults.
  */
-public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorProvider<ClientPolicyExecutorConfigurationRepresentation> {
+public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorProvider<UDSClientPolicyPermissionsExecutorConfiguration> {
 
     public static final String UDS_OPERATOR_CLIENT_ID = "uds-operator";
     public static final String ATTRIBUTE_UDS_OPERATOR = "created-by";
     public static final String ATTRIBUTE_UDS_OPERATOR_VALUE = "uds-operator";
 
-    private final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    public static final List<String> DEFAULT_ALLOWED_PROTOCOL_MAPPERS = List.of(
+            UserAttributeStatementMapper.PROVIDER_ID,
+            UserAttributeMapper.PROVIDER_ID,
+            UserPropertyAttributeStatementMapper.PROVIDER_ID,
+            UserPropertyMapper.PROVIDER_ID,
+            FullNameMapper.PROVIDER_ID,
+            AddressMapper.PROVIDER_ID,
+            new SHA256PairwiseSubMapper().getId(),
+            RoleListMapper.PROVIDER_ID,
+            CustomAWSSAMLGroupMapper.PROVIDER_ID
+    );
+
+    public static final List<String> DEFAULT_ALLOWED_CLIENT_SCOPES = List.of(
+            "openid",
+            "aws-groups",
+            CustomGroupPathMapper.GROUPS_CLAIM,
+            CustomGroupPathMapper.BARE_GROUPS_CLAIM,
+            "mapper-saml-username-name",
+            "mapper-saml-email-email",
+            "mapper-saml-username-login",
+            "mapper-saml-firstname-first_name",
+            "mapper-saml-lastname-last_name",
+            "mapper-saml-grouplist-groups",
+            "mapper-oidc-username-username",
+            "mapper-oidc-mattermostid-id",
+            "mapper-oidc-email-email"
+    );
+
+    protected final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    protected final KeycloakSession keycloakSession;
+    protected UDSClientPolicyPermissionsExecutorConfiguration configuration;
+
+    public UDSClientPolicyPermissionsExecutor(KeycloakSession session) {
+        this.keycloakSession = session;
+    }
+
+    private static String toString(ClientRepresentation rep) {
+        try {
+            return new ObjectMapper().writeValueAsString(rep);
+        } catch (Exception e) {
+            return "Failed to convert ClientRepresentation to JSON, " + e.getMessage();
+        }
+    }
 
     @Override
     public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
         if ((context instanceof ClientCRUDContext clientCRUDContext)) {
-
             logger.debug("Executing UDSClientPolicyPermissionsExecutor, authenticated to Client ID: {}, ", getAuthenticatedClientId(clientCRUDContext));
 
             if (clientCRUDContext.getAuthenticatedClient() != null && UDS_OPERATOR_CLIENT_ID.equals(getAuthenticatedClientId(clientCRUDContext))) {
                 switch (context.getEvent()) {
                     case UPDATE:
-                        logger.debug("Updating existing Client with Client ID: {}", clientCRUDContext.getTargetClient().getClientId());
+                        logger.trace("Updating existing Client with Client ID: {}", clientCRUDContext.getTargetClient().getClientId());
                         if (!isOwnedByUDSOperator(clientCRUDContext.getTargetClient())) {
                             throw new ClientPolicyException(Errors.UNAUTHORIZED_CLIENT, "The Client doesn't have the " + ATTRIBUTE_UDS_OPERATOR + "=" + ATTRIBUTE_UDS_OPERATOR_VALUE + " attribute. Rejecting request.");
                         }
@@ -53,13 +108,13 @@ public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorP
                         break;
 
                     case REGISTER:
-                        logger.debug("Creating new Client with Client ID: {}", clientCRUDContext.getProposedClientRepresentation().getClientId());
+                        logger.trace("Creating new Client with Client ID: {}", clientCRUDContext.getProposedClientRepresentation().getClientId());
                         enforceClientSettings(clientCRUDContext.getProposedClientRepresentation());
                         break;
 
                     case VIEW:
                     case UNREGISTER:
-                        logger.debug("Viewing or deleting Client with Client ID: {}", clientCRUDContext.getTargetClient().getClientId());
+                        logger.trace("Viewing or deleting Client with Client ID: {}", clientCRUDContext.getTargetClient().getClientId());
                         if (!isOwnedByUDSOperator(clientCRUDContext.getTargetClient())) {
                             throw new ClientPolicyException(Errors.UNAUTHORIZED_CLIENT, "The Client doesn't have the " + ATTRIBUTE_UDS_OPERATOR + "=" + ATTRIBUTE_UDS_OPERATOR_VALUE + " attribute. Rejecting request.");
                         }
@@ -82,13 +137,58 @@ public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorP
         return ATTRIBUTE_UDS_OPERATOR_VALUE.equals(client.getAttribute(ATTRIBUTE_UDS_OPERATOR));
     }
 
-    @Override
-    public void setupConfiguration(ClientPolicyExecutorConfigurationRepresentation config) {
+    void setAllowedProtocolMappers(ClientRepresentation rep) {
+        if (rep.getProtocolMappers() != null && !rep.getProtocolMappers().isEmpty()) {
+            rep.getProtocolMappers()
+                    .removeIf(mapper -> !configuration.getAllowedProtocolMappers().contains(mapper.getProtocolMapper()));
+        }
+    }
+
+    void setAllowedCustomClientScopes(ClientRepresentation rep) {
+        if (rep.getDefaultClientScopes() != null && !rep.getDefaultClientScopes().isEmpty()) {
+            rep.getDefaultClientScopes()
+                    .removeIf(scope -> !configuration.getAllowedClientScopes().contains(scope));
+        }
+        if (rep.getOptionalClientScopes() != null && !rep.getOptionalClientScopes().isEmpty()) {
+            rep.getOptionalClientScopes()
+                    .removeIf(scope -> !configuration.getAllowedClientScopes().contains(scope));
+        }
     }
 
     @Override
-    public Class<ClientPolicyExecutorConfigurationRepresentation> getExecutorConfigurationClass() {
-        return ClientPolicyExecutorConfigurationRepresentation.class;
+    public void setupConfiguration(UDSClientPolicyPermissionsExecutorConfiguration config) {
+        if (config.isUseDefaultAllowedProtocolMappers()) {
+            List<String> defenseUnicornsProtocolMappers = this.keycloakSession.getKeycloakSessionFactory().
+                    getProviderFactoriesStream(ProtocolMapper.class)
+                    .filter(o -> o.getClass().getPackageName().startsWith("com.defenseunicorns.uds.keycloak"))
+                    .map(o -> o.getId())
+                    .toList();
+
+            List<String> allowedProtocolMappers = new ArrayList<>();
+            allowedProtocolMappers.addAll(DEFAULT_ALLOWED_PROTOCOL_MAPPERS);
+            allowedProtocolMappers.addAll(defenseUnicornsProtocolMappers);
+            if (config.getAllowedProtocolMappers() != null)
+                allowedProtocolMappers.addAll(config.getAllowedProtocolMappers());
+            config.setAllowedProtocolMappers(allowedProtocolMappers);
+        }
+
+        if (config.isUseDefaultAllowedClientScopes()) {
+            List<String> allowedClientScopes = new ArrayList<>();
+            allowedClientScopes.addAll(DEFAULT_ALLOWED_CLIENT_SCOPES);
+            // Add Realm defaults
+            allowedClientScopes.addAll(this.keycloakSession.getContext().getRealm().getDefaultClientScopesStream(true).map(ClientScopeModel::getName).collect(Collectors.toList()));
+            if (config.getAllowedClientScopes() != null)
+                allowedClientScopes.addAll(config.getAllowedClientScopes());
+            config.setAllowedClientScopes(allowedClientScopes);
+        }
+
+        logger.trace("Initializing with configuration: {}", config);
+        this.configuration = config;
+    }
+
+    @Override
+    public Class<UDSClientPolicyPermissionsExecutorConfiguration> getExecutorConfigurationClass() {
+        return UDSClientPolicyPermissionsExecutorConfiguration.class;
     }
 
     @Override
@@ -97,8 +197,14 @@ public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorP
     }
 
     void enforceClientSettings(ClientRepresentation rep) {
+        logger.trace("Client Representation before enforcements: {}", toString(rep));
+
         setUDSOperatorAsOwner(rep);
         setFullScopeDisabled(rep);
+        setAllowedProtocolMappers(rep);
+        setAllowedCustomClientScopes(rep);
+
+        logger.trace("Client Representation after enforcements: {}", toString(rep));
     }
 
     private void setUDSOperatorAsOwner(ClientRepresentation rep) {

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
@@ -182,7 +182,7 @@ public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorP
             config.setAllowedClientScopes(allowedClientScopes);
         }
 
-        logger.trace("Initializing with configuration: {}", config);
+        logger.debug("Initializing with configuration: {}", config);
         this.configuration = config;
     }
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
@@ -8,6 +8,8 @@ package com.defenseunicorns.uds.keycloak.plugin.clientpolicy.executor;
 import com.defenseunicorns.uds.keycloak.plugin.CustomAWSSAMLGroupMapper;
 import com.defenseunicorns.uds.keycloak.plugin.CustomGroupPathMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.events.Errors;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
@@ -30,6 +32,8 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.keycloak.common.util.CollectionUtil.*;
 
 /**
  * Keycloak Client Policy Executor for the UDS Operator.
@@ -138,20 +142,22 @@ public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorP
     }
 
     void setAllowedProtocolMappers(ClientRepresentation rep) {
-        if (rep.getProtocolMappers() != null && !rep.getProtocolMappers().isEmpty()) {
+        if (isNotEmpty(rep.getProtocolMappers()) && configuration.getAllowedProtocolMappers() != null) {
             rep.getProtocolMappers()
                     .removeIf(mapper -> !configuration.getAllowedProtocolMappers().contains(mapper.getProtocolMapper()));
         }
     }
 
     void setAllowedCustomClientScopes(ClientRepresentation rep) {
-        if (rep.getDefaultClientScopes() != null && !rep.getDefaultClientScopes().isEmpty()) {
-            rep.getDefaultClientScopes()
-                    .removeIf(scope -> !configuration.getAllowedClientScopes().contains(scope));
-        }
-        if (rep.getOptionalClientScopes() != null && !rep.getOptionalClientScopes().isEmpty()) {
-            rep.getOptionalClientScopes()
-                    .removeIf(scope -> !configuration.getAllowedClientScopes().contains(scope));
+        if (configuration.getAllowedClientScopes() != null) {
+            if (isNotEmpty(rep.getDefaultClientScopes())) {
+                rep.getDefaultClientScopes()
+                        .removeIf(scope -> !configuration.getAllowedClientScopes().contains(scope));
+            }
+            if (isNotEmpty(rep.getOptionalClientScopes())) {
+                rep.getOptionalClientScopes()
+                        .removeIf(scope -> !configuration.getAllowedClientScopes().contains(scope));
+            }
         }
     }
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorConfiguration.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorConfiguration.java
@@ -16,13 +16,13 @@ public class UDSClientPolicyPermissionsExecutorConfiguration extends ClientPolic
     private List<String> allowedProtocolMappers;
 
     @JsonProperty(value = UDSClientPolicyPermissionsExecutorFactory.USE_DEFAULT_ALLOWED_PROTOCOL_MAPPER_TYPES, defaultValue = "true")
-    private boolean useDefaultAllowedProtocolMappers;
+    private boolean useDefaultAllowedProtocolMappers = true;
 
     @JsonProperty(UDSClientPolicyPermissionsExecutorFactory.ADDITIONAL_ALLOWED_CLIENT_SCOPES)
     private List<String> allowedClientScopes;
 
     @JsonProperty(value = UDSClientPolicyPermissionsExecutorFactory.USE_DEFAULT_ALLOWED_CLIENT_SCOPES, defaultValue = "true")
-    private boolean useDefaultAllowedClientScopes;
+    private boolean useDefaultAllowedClientScopes = true;
 
     public List<String> getAllowedProtocolMappers() {
         return allowedProtocolMappers;

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorConfiguration.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.clientpolicy.executor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+
+import java.util.List;
+
+public class UDSClientPolicyPermissionsExecutorConfiguration extends ClientPolicyExecutorConfigurationRepresentation {
+
+    @JsonProperty(UDSClientPolicyPermissionsExecutorFactory.ADDITIONAL_ALLOWED_PROTOCOL_MAPPER_TYPES)
+    private List<String> allowedProtocolMappers;
+
+    @JsonProperty(value = UDSClientPolicyPermissionsExecutorFactory.USE_DEFAULT_ALLOWED_PROTOCOL_MAPPER_TYPES, defaultValue = "true")
+    private boolean useDefaultAllowedProtocolMappers;
+
+    @JsonProperty(UDSClientPolicyPermissionsExecutorFactory.ADDITIONAL_ALLOWED_CLIENT_SCOPES)
+    private List<String> allowedClientScopes;
+
+    @JsonProperty(value = UDSClientPolicyPermissionsExecutorFactory.USE_DEFAULT_ALLOWED_CLIENT_SCOPES, defaultValue = "true")
+    private boolean useDefaultAllowedClientScopes;
+
+    public List<String> getAllowedProtocolMappers() {
+        return allowedProtocolMappers;
+    }
+
+    public void setAllowedProtocolMappers(List<String> allowedProtocolMappers) {
+        this.allowedProtocolMappers = allowedProtocolMappers;
+    }
+
+    public boolean isUseDefaultAllowedProtocolMappers() {
+        return useDefaultAllowedProtocolMappers;
+    }
+
+    public void setUseDefaultAllowedProtocolMappers(boolean useDefaultAllowedProtocolMappers) {
+        this.useDefaultAllowedProtocolMappers = useDefaultAllowedProtocolMappers;
+    }
+
+    public List<String> getAllowedClientScopes() {
+        return allowedClientScopes;
+    }
+
+    public void setAllowedClientScopes(List<String> allowedClientScopes) {
+        this.allowedClientScopes = allowedClientScopes;
+    }
+
+    public boolean isUseDefaultAllowedClientScopes() {
+        return useDefaultAllowedClientScopes;
+    }
+
+    public void setUseDefaultAllowedClientScopes(boolean useDefaultAllowedClientScopes) {
+        this.useDefaultAllowedClientScopes = useDefaultAllowedClientScopes;
+    }
+
+    @Override
+    public String toString() {
+        return "UDSClientPolicyPermissionsExecutorConfiguration{" +
+                "allowedProtocolMappers=" + allowedProtocolMappers +
+                ", useDefaultAllowedProtocolMappers=" + useDefaultAllowedProtocolMappers +
+                ", allowedClientScopes=" + allowedClientScopes +
+                ", useDefaultAllowedClientScopes=" + useDefaultAllowedClientScopes +
+                '}';
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorFactory.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorFactory.java
@@ -8,22 +8,25 @@ package com.defenseunicorns.uds.keycloak.plugin.clientpolicy.executor;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderFactory;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Factory for creating and registering the UDS Client Policy Executor with Keycloak.
- *
+ * <p>
  * This class is needed to integrate the custom UDS security hardening logic into Keycloak's
  * client management process. It creates instances of UDSClientPolicyPermissionsExecutor, which
  * enforce policies such as:
  * - Marking clients as created by the UDS Operator by setting the "created-by=uds-operator" attribute.
  * - Restricting operations on clients not owned by the UDS Operator or not following the naming convention.
  * - Disabling the "Full Scope Allowed" feature and limiting client scopes to an allowed set.
- *
+ * <p>
  * Without this factory, Keycloak would not be able to instantiate and manage the custom policy
  * executor, and the UDS-specific client policies would not be enforced.
  */
@@ -31,9 +34,52 @@ public class UDSClientPolicyPermissionsExecutorFactory implements ClientPolicyEx
 
     public static final String PROVIDER_ID = "uds-operator-permissions";
 
+    public static final String ADDITIONAL_ALLOWED_PROTOCOL_MAPPER_TYPES = "allowed-protocol-mappers";
+    public static final String ADDITIONAL_ALLOWED_CLIENT_SCOPES = "allowed-client-scopes";
+    public static final String USE_DEFAULT_ALLOWED_PROTOCOL_MAPPER_TYPES = "use-default-allowed-protocol-mappers";
+    public static final String USE_DEFAULT_ALLOWED_CLIENT_SCOPES = "use-default-allowed-client-scopes";
+
+    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    ProviderConfigProperty additionalAllowedProtocolMappers = new ProviderConfigProperty();
+    ProviderConfigProperty useDefaultAllowedProtocolMappers = new ProviderConfigProperty();
+    ProviderConfigProperty additionalAllowedClientScopes = new ProviderConfigProperty();
+    ProviderConfigProperty useDefaultAllowedClientScopes = new ProviderConfigProperty();
+
+    {
+        additionalAllowedProtocolMappers.setName(ADDITIONAL_ALLOWED_PROTOCOL_MAPPER_TYPES);
+        additionalAllowedProtocolMappers.setLabel("Additional Allowed Protocol Mappers");
+        additionalAllowedProtocolMappers.setHelpText("Additional Allowed Protocol Mappers");
+        additionalAllowedProtocolMappers.setType(ProviderConfigProperty.MULTIVALUED_LIST_TYPE);
+        configProperties.add(additionalAllowedProtocolMappers);
+
+        useDefaultAllowedProtocolMappers.setName(USE_DEFAULT_ALLOWED_PROTOCOL_MAPPER_TYPES);
+        useDefaultAllowedProtocolMappers.setLabel("Use UDS Default Allowed Protocol Mappers");
+        useDefaultAllowedProtocolMappers.setHelpText("Setting this to true results in default OIDC and UDS Protocol Mappers to be whitelisted");
+        useDefaultAllowedProtocolMappers.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        useDefaultAllowedProtocolMappers.setDefaultValue(Boolean.TRUE.toString());
+        configProperties.add(useDefaultAllowedProtocolMappers);
+
+        additionalAllowedClientScopes.setName(ADDITIONAL_ALLOWED_CLIENT_SCOPES);
+        additionalAllowedClientScopes.setLabel("Additional Allowed Client Scopes");
+        additionalAllowedClientScopes.setHelpText("Additional Allowed Client Scopes");
+        additionalAllowedClientScopes.setType(ProviderConfigProperty.MULTIVALUED_STRING_TYPE);
+        // Unfortunately, when we're creating a Client Policy we don't have access to Client Scopes yet.
+        // This is different in
+//            additionalAllowedClientScopes.setOptions(getClientScopes());
+        configProperties.add(additionalAllowedClientScopes);
+
+        useDefaultAllowedClientScopes.setName(USE_DEFAULT_ALLOWED_CLIENT_SCOPES);
+        useDefaultAllowedClientScopes.setLabel("Use UDS Default Client Scopes");
+        useDefaultAllowedClientScopes.setHelpText("Setting this to true results in default OIDC and UDS Client Scopes to be whitelisted");
+        useDefaultAllowedClientScopes.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        useDefaultAllowedClientScopes.setDefaultValue(Boolean.TRUE.toString());
+        configProperties.add(useDefaultAllowedClientScopes);
+    }
+
     @Override
     public UDSClientPolicyPermissionsExecutor create(KeycloakSession session) {
-        return new UDSClientPolicyPermissionsExecutor();
+        return new UDSClientPolicyPermissionsExecutor(session);
     }
 
     @Override
@@ -41,7 +87,16 @@ public class UDSClientPolicyPermissionsExecutorFactory implements ClientPolicyEx
     }
 
     @Override
-    public void postInit(KeycloakSessionFactory factory) {
+    public synchronized void postInit(KeycloakSessionFactory factory) {
+        // Factory init is tricky and might be called multiple times.
+        // We initialize everything at the instance construction time and keep updating the options.
+        additionalAllowedProtocolMappers.setOptions(getProtocolMapperFactoryIds(factory));
+    }
+
+    private List<String> getProtocolMapperFactoryIds(KeycloakSessionFactory sessionFactory) {
+        return sessionFactory.getProviderFactoriesStream(ProtocolMapper.class)
+                .map(ProviderFactory::getId)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -60,6 +115,9 @@ public class UDSClientPolicyPermissionsExecutorFactory implements ClientPolicyEx
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return Collections.emptyList();
+        return List.of(additionalAllowedProtocolMappers,
+                useDefaultAllowedProtocolMappers,
+                additionalAllowedClientScopes,
+                useDefaultAllowedClientScopes);
     }
 }

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorFactory.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorFactory.java
@@ -64,9 +64,6 @@ public class UDSClientPolicyPermissionsExecutorFactory implements ClientPolicyEx
         additionalAllowedClientScopes.setLabel("Additional Allowed Client Scopes");
         additionalAllowedClientScopes.setHelpText("Additional Allowed Client Scopes");
         additionalAllowedClientScopes.setType(ProviderConfigProperty.MULTIVALUED_STRING_TYPE);
-        // Unfortunately, when we're creating a Client Policy we don't have access to Client Scopes yet.
-        // This is different in
-//            additionalAllowedClientScopes.setOptions(getClientScopes());
         configProperties.add(additionalAllowedClientScopes);
 
         useDefaultAllowedClientScopes.setName(USE_DEFAULT_ALLOWED_CLIENT_SCOPES);

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorTest.java
@@ -5,24 +5,54 @@
 
 package com.defenseunicorns.uds.keycloak.plugin.clientpolicy.executor;
 
+import com.defenseunicorns.uds.keycloak.plugin.CustomGroupPathMapper;
 import junit.framework.TestCase;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.keycloak.models.ClientModel;
+import org.keycloak.models.*;
+import org.keycloak.protocol.saml.mappers.UserAttributeStatementMapper;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UDSClientPolicyPermissionsExecutorTest extends TestCase {
 
-    private final UDSClientPolicyPermissionsExecutor executor = new UDSClientPolicyPermissionsExecutor();
+    final UDSClientPolicyPermissionsExecutor executor = new UDSClientPolicyPermissionsExecutor(null);
+
     @Mock
-    private ClientModel client;
+    KeycloakSession session;
+
+    @Mock
+    KeycloakContext keycloakContext;
+
+    @Mock
+    RealmModel realm;
+
+    @Mock
+    KeycloakSessionFactory factory;
+
+    @Mock
+    ClientModel client;
+
+    @Before
+    public void before() {
+        UDSClientPolicyPermissionsExecutorConfiguration config = new UDSClientPolicyPermissionsExecutorConfiguration();
+        config.setUseDefaultAllowedProtocolMappers(false);
+        config.setAllowedProtocolMappers(UDSClientPolicyPermissionsExecutor.DEFAULT_ALLOWED_PROTOCOL_MAPPERS);
+        config.setUseDefaultAllowedClientScopes(false);
+        config.setAllowedClientScopes(UDSClientPolicyPermissionsExecutor.DEFAULT_ALLOWED_CLIENT_SCOPES);
+        executor.setupConfiguration(config);
+    }
 
     @Test
     public void shouldReportAsOwnedByUDS() {
@@ -74,4 +104,79 @@ public class UDSClientPolicyPermissionsExecutorTest extends TestCase {
         assertFalse(rep.isFullScopeAllowed());
     }
 
+    @Test
+    public void shouldEnforceWhitelistedProtocolMappers() {
+        // given
+        ProtocolMapperRepresentation allowedProtocolMapper = new ProtocolMapperRepresentation() {{
+            setProtocolMapper(UserAttributeStatementMapper.PROVIDER_ID);
+        }};
+
+        ProtocolMapperRepresentation disallowedProtocolMapper = new ProtocolMapperRepresentation() {{
+            setProtocolMapper("invalid");
+        }};
+
+        ClientRepresentation rep = new ClientRepresentation();
+        // We need a modifiable List implementation here - that's why it's wrapped with an ArrayList
+        rep.setProtocolMappers(new ArrayList<>(List.of(allowedProtocolMapper, disallowedProtocolMapper)));
+
+        // when
+        executor.enforceClientSettings(rep);
+
+        // then
+        assertEquals(1, rep.getProtocolMappers().size());
+        assertEquals(allowedProtocolMapper.getId(), rep.getProtocolMappers().get(0).getId());
+    }
+
+    @Test
+    public void shouldEnforceWhitelistedCustomClaims() {
+        // given
+        ClientRepresentation rep = new ClientRepresentation();
+        // We need a modifiable List implementation here - that's why it's wrapped with an ArrayList
+        rep.setDefaultClientScopes(new ArrayList<>(List.of(CustomGroupPathMapper.GROUPS_CLAIM, "invalid")));
+        rep.setOptionalClientScopes(new ArrayList<>(List.of(CustomGroupPathMapper.GROUPS_CLAIM, "invalid")));
+
+        // when
+        executor.enforceClientSettings(rep);
+
+        // then
+        assertEquals(1, rep.getOptionalClientScopes().size());
+        assertEquals(1, rep.getDefaultClientScopes().size());
+        assertEquals(CustomGroupPathMapper.GROUPS_CLAIM, rep.getOptionalClientScopes().get(0));
+        assertEquals(CustomGroupPathMapper.GROUPS_CLAIM, rep.getDefaultClientScopes().get(0));
+    }
+
+    @Test
+    public void shouldConfigureWithDefaults() {
+        // given
+        UDSClientPolicyPermissionsExecutor executor = new UDSClientPolicyPermissionsExecutor(session);
+        UDSClientPolicyPermissionsExecutorConfiguration config = new UDSClientPolicyPermissionsExecutorConfiguration();
+        config.setUseDefaultAllowedProtocolMappers(true);
+        config.setUseDefaultAllowedClientScopes(true);
+
+        {
+            doReturn(factory).when(session).getKeycloakSessionFactory();
+            doReturn(Stream.of(new CustomGroupPathMapper())).when(factory).getProviderFactoriesStream(any());
+        }
+
+        {
+            doReturn(keycloakContext).when(session).getContext();
+            doReturn(realm).when(keycloakContext).getRealm();
+
+            ClientScopeModel additionalScope = mock(ClientScopeModel.class);
+            doReturn(CustomGroupPathMapper.GROUPS_CLAIM).when(additionalScope).getName();
+
+            doReturn(Stream.of(additionalScope)).when(realm).getDefaultClientScopesStream(anyBoolean());
+        }
+
+        // when
+        executor.setupConfiguration(config);
+        UDSClientPolicyPermissionsExecutorConfiguration resultingConfiguration = executor.configuration;
+
+        // then
+        assertTrue(resultingConfiguration.isUseDefaultAllowedProtocolMappers());
+        assertEquals(UDSClientPolicyPermissionsExecutor.DEFAULT_ALLOWED_PROTOCOL_MAPPERS.size() + 1, resultingConfiguration.getAllowedProtocolMappers().size());
+
+        assertTrue(resultingConfiguration.isUseDefaultAllowedClientScopes());
+        assertEquals(UDSClientPolicyPermissionsExecutor.DEFAULT_ALLOWED_CLIENT_SCOPES.size() + 1, resultingConfiguration.getAllowedClientScopes().size());
+    }
 }

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutorTest.java
@@ -123,6 +123,7 @@ public class UDSClientPolicyPermissionsExecutorTest extends TestCase {
         executor.enforceClientSettings(rep);
 
         // then
+        assertFalse(rep.getProtocolMappers().stream().anyMatch(mapper -> "invalid".equals(mapper.getProtocolMapper())));
         assertEquals(1, rep.getProtocolMappers().size());
         assertEquals(allowedProtocolMapper.getId(), rep.getProtocolMappers().get(0).getId());
     }

--- a/src/test/cypress/e2e/client-credentials.cy.ts
+++ b/src/test/cypress/e2e/client-credentials.cy.ts
@@ -45,8 +45,6 @@ describe("UDS Operator Client Credentials", () => {
         });
 
         it("UDS Operator can't delete a built-in Client", () => {
-            const randomClientId = `client-${Math.random().toString(36).substring(2, 15)}`;
-
             cy.getAccessToken().then((accessToken: string) => {
                 cy.request({
                     method: 'GET',
@@ -73,6 +71,47 @@ describe("UDS Operator Client Credentials", () => {
                             error: "unauthorized_client",
                             error_description: "The Client doesn't have the created-by=uds-operator attribute. Rejecting request."
                         });
+                    });
+                });
+            });
+        });
+
+        it("UDSClientPolicyPermissionsExecutor removes non-whitelisted mappers and claims", () => {
+            cy.exec("uds zarf tools kubectl apply -f ./resources/test-package.yaml").its('code').should('eq', 0);
+            cy.exec("uds zarf tools kubectl wait --for=condition=Ready package/test-package -n test-package --timeout=300s").its('code').should('eq', 0);
+
+            cy.getAccessToken().then((accessToken: string) => {
+                cy.request({
+                    method: 'GET',
+                    url: 'https://keycloak.admin.uds.dev/admin/realms/uds/clients',
+                    headers: {
+                        'Authorization': `Bearer ${accessToken}`,
+                        'Content-Type': 'application/json'
+                    },
+                }).then((response) => {
+                    expect(response.status).to.eq(200);
+                    const testClient = response.body.find((client: any) => client.clientId === "uds-core-admin-test");
+                    const protocolMappersUrl = `https://keycloak.admin.uds.dev/admin/realms/uds/clients/${testClient.id}/protocol-mappers/models`;
+                    cy.request({
+                        method: 'GET',
+                        url: protocolMappersUrl,
+                        headers: {
+                            'Authorization': `Bearer ${accessToken}`,
+                            'Content-Type': 'application/json'
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(200);
+
+                        interface ProtocolMapper {
+                            name: string;
+                        }
+                        const protocolMappers = response.body as ProtocolMapper[];
+                        expect(protocolMappers).to.have.length(3);
+                        expect(protocolMappers.map((mapper) => mapper.name)).to.include.members([
+                            "valid-protocol-mapper-1",
+                            "valid-protocol-mapper-2",
+                            "valid-protocol-mapper-3",
+                        ]);
                     });
                 });
             });

--- a/src/test/cypress/resources/test-package.yaml
+++ b/src/test/cypress/resources/test-package.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-package
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: test-package
+  namespace: test-package
+spec:
+  sso:
+    - name: Test
+      clientId: uds-core-admin-test
+      redirectUris:
+        - "https://test-package.admin.uds.dev/openId_auth"
+      protocolMappers:
+        - name: valid-protocol-mapper-1
+          protocol: "openid-connect"
+          protocolMapper: "bare-group-path-mapper"
+        - name: valid-protocol-mapper-2
+          protocol: "openid-connect"
+          protocolMapper: "oidc-full-name-mapper"
+        - name: valid-protocol-mapper-3
+          protocol: "saml"
+          protocolMapper: "aws-saml-group-mapper"
+        # This one is expected to be rejected by the Policy
+        - name: invalid-protocol-mapper
+          protocol: "openid-connect"
+          protocolMapper: "non-whitelisted-protocol-mapper"


### PR DESCRIPTION
## Description

This Pull Request introduces new configuration options for the `UDSClientPolicyPermissionsExecutor` that limit what the UDS Operator can do in Keycloak. 

## Related Issue

Fixes: https://github.com/defenseunicorns/uds-identity-config/issues/385

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed