### PR TITLE
chore: small doc change

### DIFF
--- a/docs/reference/UDS Core/IdAM/truststore-customization.md
+++ b/docs/reference/UDS Core/IdAM/truststore-customization.md
@@ -20,7 +20,7 @@ To use the `regenerate-test-pki` task:
 
 * Create `csr.conf`
 
-   ```conf
+   ```bash
    [req]
    default_bits       = 2048
    default_keyfile    = key.pem


### PR DESCRIPTION
## Description

UDS Docs site doesn't like the use of `conf` as a type of code block. This fix removes a warning when building the site.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed