### PR TITLE
fix: add grouplist to default allowed mappers

### DIFF
--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
@@ -19,7 +19,6 @@ import org.keycloak.protocol.oidc.mappers.*;
 import org.keycloak.protocol.saml.mappers.RoleListMapper;
 import org.keycloak.protocol.saml.mappers.UserAttributeStatementMapper;
 import org.keycloak.protocol.saml.mappers.UserPropertyAttributeStatementMapper;
-import org.keycloak.protocol.saml.mappers.GroupMembershipMapper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/clientpolicy/executor/UDSClientPolicyPermissionsExecutor.java
@@ -19,6 +19,7 @@ import org.keycloak.protocol.oidc.mappers.*;
 import org.keycloak.protocol.saml.mappers.RoleListMapper;
 import org.keycloak.protocol.saml.mappers.UserAttributeStatementMapper;
 import org.keycloak.protocol.saml.mappers.UserPropertyAttributeStatementMapper;
+import org.keycloak.protocol.saml.mappers.GroupMembershipMapper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -55,6 +56,8 @@ public class UDSClientPolicyPermissionsExecutor implements ClientPolicyExecutorP
             UserAttributeStatementMapper.PROVIDER_ID,
             UserAttributeMapper.PROVIDER_ID,
             UserPropertyAttributeStatementMapper.PROVIDER_ID,
+            org.keycloak.protocol.saml.mappers.GroupMembershipMapper.PROVIDER_ID, // tbd: what is the best way to use, imports may collide with https://www.keycloak.org/docs-api/26.2.0/javadocs/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.html
+            AudienceProtocolMapper.PROVIDER_ID, // tbd: should we add this by default to support https://github.com/uds-packages/argo-workflows/blob/5257c03814a9f6b3925e26aaaea914918344dc37/chart/templates/uds-package.yaml#L26
             UserPropertyMapper.PROVIDER_ID,
             FullNameMapper.PROVIDER_ID,
             AddressMapper.PROVIDER_ID,


### PR DESCRIPTION
## Description

Adds grouplist and `AudienceProtocolMapper` (tbd) to the default list of allowed mappers based on current package usage.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-identity-config/issues/460

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed