### PR TITLE
chore: cleanup cacert tasks in identity-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo builds the UDS Identity (Keycloak) Config image used by UDS Identity. 
    | dev-update-image    | Build the image and import locally into k3d |
    | dev-theme           | Copy theme to Keycloak in dev cluster       |
    | dev-plugin          | Build and run unit tests for keycloak plugin|
-   | cacert              | Get the CA cert value for the Istio Gateway |
+   | dev-cacert          | Get the CA cert value for the Istio Gateway from your local build |
    | debug-istio-traffic | Debug Istio traffic on keycloak             |
    | regenerate-test-pki | Generate a PKI cert for testing             |
    | uds-core-integration-test | Create cluster and deploy uds-core identity using local uds-identity-config image |

--- a/docs/reference/UDS Core/IdAM/truststore-customization.md
+++ b/docs/reference/UDS Core/IdAM/truststore-customization.md
@@ -76,15 +76,13 @@ If you're getting errors from the ca-to-jks.sh script, verify your zip folder is
 
 ### Configure Istio Gateways CACERT in UDS Core
 
-```bash
-# In `uds-core` create cacert from the new identity-config image
-uds run -f src/keycloak/tasks.yaml cacert --set IMAGE_NAME=<identity config image> --set VERSION=<identity config image version>
-```
+In order to ensure your client certs are requested when deploying UDS Core you will need to override the `tls.cacert` value for the gateway(s) where you expect client certs to be provided. A values file can be generated from your local image build using the `dev-cacert` task:
 
 ```bash
-# Update tenant and admin gateway with generated cacerts
-uds run -f src/keycloak/tasks.yaml dev-cacert
+uds run dev-cacert
 ```
+
+This task can also be modified locally to point to a different image if you have published a custom build somewhere else. The output of this task will be a values file locally, `tls_cacert.yaml`, that can be used in your bundle or copied out as needed.
 
 ### Deploy UDS Core with new uds-identity-config
 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -5,7 +5,6 @@ includes:
   - remote: https://raw.githubusercontent.com/defenseunicorns/uds-common/v1.14.2/tasks/lint.yaml
   - common-setup: https://raw.githubusercontent.com/defenseunicorns/uds-common/v1.14.2/tasks/setup.yaml
 
-
 variables:
   - name: VERSION
     description: "The image tag"
@@ -64,8 +63,8 @@ tasks:
           cd src/plugin
           mvn clean verify | egrep ".*"
 
-  - name: cacert
-    description: "Get the CA cert value for the Istio Gateway"
+  - name: dev-cacert
+    description: "Get the CA cert value for the Istio Gateway from your local build"
     actions:
       # This is written to a file rather than printed because it is a massive value to copy out of the terminal
       - cmd: |
@@ -73,7 +72,7 @@ tasks:
           tls:
             cacert: "$(docker run --rm --entrypoint sh uds-core-config:keycloak -c 'cat /home/nonroot/authorized_certs.pem | base64 -w 0')"
           EOF
-          echo "Base64 encoded CA Cert value is in cacert.b64, this can be passed to your Istio tenant gateway for Keycloak OPTIONAL_MUTUAL"
+          echo "CA Cert values are in tls_cacert.yaml, this can be provided to your Istio gateway(s) for Keycloak OPTIONAL_MUTUAL"
 
   - name: debug-istio-traffic
     description: "Debug Istio traffic on keycloak"
@@ -183,9 +182,9 @@ tasks:
         cmd: uds deploy bundles/theme-customizations/uds-bundle-theme-customization-tests-*.tar.zst --set=core-identity-authorization.KEYCLOAK_CONFIG_IMAGE=uds-core-config:keycloak --confirm --no-progress
       - description: "Run the theme customization tests"
         cmd: |
-         # Should already be done... but just in case
-         npm --prefix src/test/cypress install
-         npm --prefix src/test/cypress run cy.run:theme-customization
+          # Should already be done... but just in case
+          npm --prefix src/test/cypress install
+          npm --prefix src/test/cypress run cy.run:theme-customization
 
   - name: license
     actions:


### PR DESCRIPTION
## Description

The cacert task in this repo was not being used, except as consumed by uds-core. An updated task is being added to core in https://github.com/defenseunicorns/uds-core/pull/1567, and this PR changes the identity-config `cacert` task to explicitly focus on local dev builds of custom identity-config (specifically custom CAs).

Documentation was also updated to reference this task and explain usage.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed