### PR TITLE
chore: remove grafana group auth task

### DIFF
--- a/bundles/external-loadbalancer/uds-bundle.yaml
+++ b/bundles/external-loadbalancer/uds-bundle.yaml
@@ -11,7 +11,7 @@ packages:
   - name: core-base
     path: ../../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.48.0
+    ref: 0.48.1
     overrides:
       pepr-uds-core:
         module:
@@ -34,7 +34,7 @@ packages:
   - name: core-identity-authorization
     path: ../../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.48.0
+    ref: 0.48.1
     overrides:
       keycloak:
         keycloak:

--- a/bundles/k3d-core-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-core-slim-dev/uds-bundle.yaml
@@ -25,7 +25,7 @@ packages:
   - name: core-base
     path: ../../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.48.0
+    ref: 0.48.1
     overrides:
       pepr-uds-core:
         module:
@@ -61,7 +61,7 @@ packages:
   - name: core-identity-authorization
     path: ../../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.48.0
+    ref: 0.48.1
     overrides:
       keycloak:
         keycloak:
@@ -96,4 +96,4 @@ packages:
   - name: core-monitoring
     path: ../../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.48.0
+    ref: 0.48.1

--- a/bundles/theme-customizations/uds-bundle.yaml
+++ b/bundles/theme-customizations/uds-bundle.yaml
@@ -11,7 +11,7 @@ packages:
   - name: core-identity-authorization
     path: ../../uds-core/build/
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    ref: 0.48.0
+    ref: 0.48.1
     overrides:
       keycloak:
         keycloak:

--- a/src/test/cypress/e2e/group-authz.cy.ts
+++ b/src/test/cypress/e2e/group-authz.cy.ts
@@ -25,9 +25,25 @@ describe('Group Authorization', () => {
     cy.url().should('include', 'https://grafana.admin.uds.dev');
   });
 
-  it('Grafana Auditor User - Failure', () => {
+  it('Grafana Auditor User - Success', () => {
     const formData: RegistrationFormData = {
       username: "testing_user",
+      password: "Testingpassword1!!",
+    };
+
+    // navigate to grafana dashboard
+    cy.accessGrafana();
+
+    // login user
+    cy.loginUser(formData.username, formData.password);
+
+    // Assert that auditor user was able to access grafana dashboard
+    cy.url().should('include', 'https://grafana.admin.uds.dev');
+  });
+
+  it('Grafana No Groups User - Failure', () => {
+    const formData: RegistrationFormData = {
+      username: "testing_user_no_groups",
       password: "Testingpassword1!!",
     };
 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -161,6 +161,11 @@ tasks:
           group: "/UDS Core/Admin"
           username: "testing_admin"
           password: "Testingpassword1!!"
+      - description: "Create a User with no groups"
+        task: common-setup:keycloak-user
+        with:
+          username: "testing_user_no_groups"
+          password: "Testingpassword1!!"
 
   - name: cypress-tests
     description: "Run all cypress tests ( requires an existing deployed UDS Core Identity )"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -129,19 +129,6 @@ tasks:
       - task: theme-customization-tests
       - task: external-loadbalancer-tests
 
-  - name: grafana-group-auth-build-deploy
-    description: Configure existing uds-core/grafana package for group authz, build, deploy grafana
-    actions:
-      - cmd: |
-          sed -i '/^\s*sso:/,/^\s*-\s*name:/ {
-            /groups:/d
-            /^\s*-\s*name:/a \ \ \ \ \ \ groups:\n\ \ \ \ \ \ \ \ anyOf:\n\ \ \ \ \ \ \ \ \ - \/UDS Core\/Admin
-          }' uds-core/src/grafana/chart/templates/uds-package.yaml
-
-      - cmd: |
-          cd uds-core
-          uds run create:single-layer-callable --set LAYER=monitoring
-
   - name: clone-core
     description: "Clone UDS Core for integration testing"
     actions:
@@ -153,7 +140,7 @@ tasks:
     actions:
       - cmd: uds zarf package create . --confirm --set=IDENTITY_CONFIG_IMG=uds-core-config:keycloak --no-progress
       - cmd: cd uds-core && mkdir -p build && uds run create:single-layer && uds run create:single-layer-callable --set LAYER=identity-authorization
-      - task: grafana-group-auth-build-deploy
+      - cmd: cd uds-core && uds run create:single-layer-callable --set LAYER=monitoring
       - cmd: uds create bundles/k3d-core-slim-dev --confirm --no-progress
       - cmd: uds deploy bundles/k3d-core-slim-dev/uds-bundle-k3d-core-slim-dev-*.tar.zst --set=core-identity-authorization.KEYCLOAK_CONFIG_IMAGE=uds-core-config:keycloak --confirm --no-progress
       - task: create-users

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -20,7 +20,7 @@ variables:
   - name: CORE_VERSION
     description: UDS Core Version for Releases and Clone
     # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-    default: "v0.48.0"
+    default: "v0.48.1"
 
 tasks:
   - name: build-and-publish
@@ -139,8 +139,7 @@ tasks:
     description: "Build/Deploy custom slim dev bundle for integration testing"
     actions:
       - cmd: uds zarf package create . --confirm --set=IDENTITY_CONFIG_IMG=uds-core-config:keycloak --no-progress
-      - cmd: cd uds-core && mkdir -p build && uds run create:single-layer && uds run create:single-layer-callable --set LAYER=identity-authorization
-      - cmd: cd uds-core && uds run create:single-layer-callable --set LAYER=monitoring
+      - cmd: cd uds-core && mkdir -p build && uds run create:single-layer && uds run create:single-layer-callable --set LAYER=identity-authorization && uds run create:single-layer-callable --set LAYER=monitoring
       - cmd: uds create bundles/k3d-core-slim-dev --confirm --no-progress
       - cmd: uds deploy bundles/k3d-core-slim-dev/uds-bundle-k3d-core-slim-dev-*.tar.zst --set=core-identity-authorization.KEYCLOAK_CONFIG_IMAGE=uds-core-config:keycloak --confirm --no-progress
       - task: create-users


### PR DESCRIPTION
## Description

Remove unnecessary task to add group auth to Grafana.  Group auth is now added by default in core via: https://github.com/defenseunicorns/uds-core/pull/1809. Also bumps core references in bundles to `0.48.1` and updates the group auth tests.

## Related Issue

Fixes #372 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed