### PR TITLE
fix: hide the 'Or sign in with' in social login block when password login is disabled

### DIFF
--- a/src/theme/login/login.ftl
+++ b/src/theme/login/login.ftl
@@ -50,8 +50,10 @@
             </#if>
             <#if realm.password && social?? && social.providers?has_content && properties["SOCIAL_LOGIN_ENABLED"] == "true">
                 <div id="kc-social-providers" class="kc-social-section kc-social">
+                    <#if properties["USERNAME_PASSWORD_AUTH_ENABLED"] != "true">
                     <hr/>
                     <h2>${msg("doLogInWith")}</h2>
+                    </#if>
 
                     <ul class="social-ul kc-social-links <#if social.providers?size gt 3>pf-l-grid kc-social-grid</#if>">
                         <#list social.providers as p>


### PR DESCRIPTION
## Description

Removes the "Or sign in with" login text when Password login is disabled but Social login is enabled

from this:
<img width="1702" height="536" alt="image" src="https://github.com/user-attachments/assets/1c801ccc-f9be-4404-80dc-04387236a2e6" />

to this:
<img width="1702" height="536" alt="image" src="https://github.com/user-attachments/assets/d9f5ee49-4250-46fd-8a8e-00bdbdb88d77" />

## Related Issue

Fixes #622

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed