### PR TITLE
fix: logic to display 'or sign in with'

### DIFF
--- a/src/theme/login/login.ftl
+++ b/src/theme/login/login.ftl
@@ -50,7 +50,7 @@
             </#if>
             <#if realm.password && social?? && social.providers?has_content && properties["SOCIAL_LOGIN_ENABLED"] == "true">
                 <div id="kc-social-providers" class="kc-social-section kc-social">
-                    <#if properties["USERNAME_PASSWORD_AUTH_ENABLED"] != "true">
+                    <#if properties["USERNAME_PASSWORD_AUTH_ENABLED"] == "true">
                     <hr/>
                     <h2>${msg("doLogInWith")}</h2>
                     </#if>


### PR DESCRIPTION
## Description

Fixes the logic introduced in https://github.com/defenseunicorns/uds-identity-config/pull/621.  

When `USERNAME_PASSWORD_AUTH_ENABLED` is `"true"` we should display the `Or sign in with` text above the social providers.

## Related Issue

Fixes #649 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed