### PR TITLE
fix: exclude fips jars boolean

### DIFF
--- a/src/sync.sh
+++ b/src/sync.sh
@@ -19,8 +19,8 @@ cp -fv *.jar /opt/keycloak/providers/
 cp -fv certs/* /opt/keycloak/conf/truststores
 
 # if USE_FIPS is true
-if [ "${FIPS_ENABLED}" = "true" ]; then
-    echo "FIPS mode enabled, copying FIPS libraries"
+if [ "${FIPS_ENABLED}" = "true" ] && [ "${INSTALL_FIPS_PROVIDERS:-true}" = "true" ]; then
+    echo "FIPS mode enabled and INSTALL_FIPS_PROVIDERS=true, copying FIPS libraries"
     cp -fv ./fips/libs/*.jar /opt/keycloak/providers/
 fi
 


### PR DESCRIPTION
## Description
Specifically for new unicorn images, we want to be able to disable the jars from being added since unicorn images provide the jars as well. When they both are present we get duplicate jar errors.

## Related Issue
Relates to [UDS Core keycloak renovate PR](https://github.com/defenseunicorns/uds-core/pull/2061)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed