### PR TITLE
chore: renovate unlimited PRs and case on group name

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
     "replacements:all",
     "workarounds:all"
   ],
+  "branchConcurrentLimit": 0,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "packageRules": [
     {
       "matchDatasources": [
@@ -102,7 +105,7 @@
         ".github/**",
         ".vscode/settings.json"
       ],
-      "groupName": "GHA-DEPS"
+      "groupName": "gha-deps"
     },
     {
       "description": "Group updates in src/plugin files into plugin-deps group.",


### PR DESCRIPTION
## Description

Small renovate config changes. Unlimited PRs matches what we do for core: https://github.com/defenseunicorns/uds-core/blob/main/renovate.json#L8-L10