### PR TITLE
fix: use newer release-please-action

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -18,9 +18,7 @@ jobs:
     steps:
       - name: Create release tag
         id: tag
-        uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
-        with:
-          command: manifest # use configs in release-please-config.json
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
       - id: release-flag
         run: echo "release_created=${{ steps.tag.outputs.release_created || false }}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

The release-please-action moved to https://github.com/googleapis/release-please-action but we were referencing the older version. `command: manifest` was also removed in 4.0.0 (see https://github.com/googleapis/release-please-action/releases/tag/v4.0.0 and the warnings on https://github.com/defenseunicorns/uds-identity-config/actions/runs/19085470554).

## Related Issue

Renovate erroring on updates.