### PR TITLE
fix: group authenticator doesn't count towards failure attempts

### DIFF
--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticator.java
@@ -3,200 +3,224 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
-package com.defenseunicorns.uds.keycloak.plugin.authentication;
+ package com.defenseunicorns.uds.keycloak.plugin.authentication;
 
-import java.util.Arrays;
-import java.util.Optional;
-import org.jboss.logging.Logger;
-import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.authentication.AuthenticationFlowError;
-import org.keycloak.authentication.Authenticator;
-import org.keycloak.models.*;
-import com.defenseunicorns.uds.keycloak.plugin.Common;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-/**
- * Simple {@link Authenticator} that checks if a user is a member of a given {@link GroupModel Group}.
- */
-public class RequireGroupAuthenticator implements Authenticator {
-
-    private static final Logger LOGGER = Logger.getLogger(RequireGroupAuthenticator.class.getName());
-
-    public static final String TAC_USER_ATTRIBUTE = "uds.tac.session.id";
-
-    @Override
-    public void authenticate(final AuthenticationFlowContext context) {
-        UserModel user = context.getUser();
-        if (user == null) {
-            LOGGER.warn("Invalid user");
-            context.failure(AuthenticationFlowError.INVALID_USER);
-            return;
-        }
-
-        ClientModel client = context.getAuthenticationSession().getClient();
-
-        // if client is in ignore list, automatic success and finish
-        if(Common.GROUP_PROTECTION_IGNORE_CLIENTS.contains(client.getClientId())){
-            context.success();
-            return;
-        }
-
-        String groupsAttribute = client.getAttribute("uds.core.groups");
-
-        if (groupsAttribute == null || groupsAttribute.isEmpty()) {
-            LOGGER.infof("No groups detected for client %s", client.getName());
-            success(context, user);
-            return;
-        }
-
-        Groups groups = parseGroupsAttribute(groupsAttribute);
-        if (groups == null) {
-            LOGGER.warn("Failed to parse groups JSON");
-            context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-            return;
-        }
-
-        RealmModel realm = context.getRealm();
-        boolean foundGroup = false;
-
-        for (String groupName : groups.anyOf) {
-            Optional<GroupModel> group = getGroupByPath(groupName, realm);
-
-            if (group.isPresent()) {
-                if (isMemberOfExactGroup(user, group.get())) {
-                    LOGGER.infof("User %s is authorized for group %s", user.getUsername(), groupName);
-                    success(context, user);
-                    return;
-                }
-                foundGroup = true;
-            }
-        }
-
-        if (foundGroup) {
-            LOGGER.warn("User is not a member of the required group(s)");
-            context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-            return;
-        }
-
-        LOGGER.warnf("Required group(s) %s do not exist in realm", Arrays.toString(groups.anyOf));
-        context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    private Groups parseGroupsAttribute(String groupsAttribute) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            Groups groups = objectMapper.readValue(groupsAttribute, Groups.class);
-            if (groups.anyOf.length == 0) {
-                LOGGER.errorf("Groups attribute does not contain a valid anyOf array");
-                return null;
-            }
-            return groups;
-        } catch (Exception e) {
-            LOGGER.errorf("Failed to parse groups JSON: %s", e.getMessage());
-            return null;
-        }
-    }
-
-    private Optional<GroupModel> getGroupByPath(final String groupPath, final RealmModel realm) {
-        return realm.getGroupsStream()
-            .filter(group -> buildGroupPath(group).equals(groupPath))
-            .findFirst();
-    }
-
-    private String buildGroupPath(GroupModel group) {
-        StringBuilder path = new StringBuilder();
-        GroupModel currentGroup = group;
-        while (currentGroup != null) {
-            String groupName = currentGroup.getName();
-            // Disallow slashes in the group unless they are prefixed by a tilde ~
-            // See https://www.keycloak.org/docs/latest/upgrading/index.html#escaping-slashes-in-group-paths
-            // Regexp tester: https://regex101.com/r/BgkuuO/1
-            if (groupName.matches(".*(?<!~)/.*")) {
-                LOGGER.errorf("Group name '%s' contains a disallowed slash", groupName);
-                throw new IllegalArgumentException("Group names cannot contain slashes unless prefixed with '~'");
-            }
-            path.insert(0, "/" + groupName);
-            currentGroup = currentGroup.getParent();
-        }
-        return path.toString();
-    }
-
-    protected void success(final AuthenticationFlowContext context, final UserModel user) {
-        boolean shouldAddTAC = true;
-
-        if (isConditionalTACActive(context)) {
-            String parentSessionId = context.getAuthenticationSession().getParentSession().getId();
-            if (user.getAttributes().get(TAC_USER_ATTRIBUTE) != null) {
-                String userSessionId = user.getAttributes().get(TAC_USER_ATTRIBUTE).get(0);
-                if (parentSessionId.equals(userSessionId)) {
-                    shouldAddTAC = false;
-                    LOGGER.trace("User already accepted Terms and Conditions for this session. Skipping...");
-                } else {
-                    LOGGER.trace("Stale session detected, asking user to accept Terms and Conditions again");
-                }
-            } else {
-                LOGGER.trace("User hasn't accepted Terms and Conditions. Requesting user accept them.");
-            }
-            user.setAttribute(TAC_USER_ATTRIBUTE, Arrays.asList(parentSessionId));
-        } else {
-            // Keycloak admins configured the plugin to ask for TAC every time
-            shouldAddTAC = true;
-        }
-
-        if (shouldAddTAC) {
-            user.addRequiredAction("TERMS_AND_CONDITIONS");
-        }
-        context.success();
-    }
-
-    protected boolean isConditionalTACActive(AuthenticationFlowContext context) {
-        LOGGER.trace("Evaluating conditional TAC");
-        AuthenticatorConfigModel authConfig = context.getAuthenticatorConfig();
-        if (authConfig != null && authConfig.getConfig() != null) {
-            String tocPerSession = authConfig.getConfig().get(RequireGroupAuthenticatorFactory.TOC_PER_SESSION_CONFIG_NAME);
-            LOGGER.tracef("Custom Authentication Config is configured, TAC per session setting: %s", tocPerSession);
-            return Boolean.valueOf(tocPerSession);
-        } else {
-            LOGGER.trace("No AuthenticatorConfig is configured, using default (true) value");
-        }
-        return true;
-    }
-
-    private boolean isMemberOfExactGroup(UserModel user, GroupModel group) {
-        return user.getGroupsStream()
-            .anyMatch(userGroup -> buildGroupPath(userGroup).equals(buildGroupPath(group)));
-    }
-
-    @Override
-    public void action(final AuthenticationFlowContext authenticationFlowContext) {
-        // no implementation needed here
-    }
-
-    @Override
-    public boolean requiresUser() {
-        return true;
-    }
-
-    @Override
-    public boolean configuredFor(
-        final KeycloakSession keycloakSession,
-        final RealmModel realmModel,
-        final UserModel userModel) {
-
-        return true;
-    }
-
-    @Override
-    public void setRequiredActions(
-        final KeycloakSession keycloakSession,
-        final RealmModel realmModel,
-        final UserModel userModel) {
-
-        // no implementation needed here
-    }
-
-    @Override
-    public void close() {
-        // no implementation needed here
-    }
-}
+ import java.util.Arrays;
+ import java.util.Optional;
+ import org.jboss.logging.Logger;
+ import org.keycloak.authentication.AuthenticationFlowContext;
+ import org.keycloak.authentication.AuthenticationFlowError;
+ import org.keycloak.authentication.Authenticator;
+ import org.keycloak.models.*;
+ import com.defenseunicorns.uds.keycloak.plugin.Common;
+ import com.fasterxml.jackson.databind.ObjectMapper;
+ import jakarta.ws.rs.core.Response;
+ import org.keycloak.forms.login.LoginFormsProvider;
+ 
+ /**
+  * Simple {@link Authenticator} that checks if a user is a member of a given {@link GroupModel Group}.
+  */
+ public class RequireGroupAuthenticator implements Authenticator {
+ 
+     private static final Logger LOGGER = Logger.getLogger(RequireGroupAuthenticator.class.getName());
+ 
+     public static final String TAC_USER_ATTRIBUTE = "uds.tac.session.id";
+ 
+     @Override
+     public void authenticate(final AuthenticationFlowContext context) {
+         UserModel user = context.getUser();
+         if (user == null) {
+             LOGGER.warn("Invalid user");
+             context.failure(AuthenticationFlowError.INVALID_USER);
+             return;
+         }
+ 
+         ClientModel client = context.getAuthenticationSession().getClient();
+ 
+         // if client is in ignore list, automatic success and finish
+         if(Common.GROUP_PROTECTION_IGNORE_CLIENTS.contains(client.getClientId())){
+             context.success();
+             return;
+         }
+ 
+         String groupsAttribute = client.getAttribute("uds.core.groups");
+ 
+         if (groupsAttribute == null || groupsAttribute.isEmpty()) {
+             LOGGER.infof("No groups detected for client %s", client.getName());
+             success(context, user);
+             return;
+         }
+ 
+         Groups groups = parseGroupsAttribute(groupsAttribute);
+         if (groups == null) {
+             LOGGER.warn("Failed to parse groups JSON for client groups attribute, denying access (403)");
+             accessDenied(context, "accessDenied");
+             return;
+         }
+ 
+         RealmModel realm = context.getRealm();
+         boolean foundGroup = false;
+ 
+         for (String groupName : groups.anyOf) {
+             Optional<GroupModel> group = getGroupByPath(groupName, realm);
+ 
+             if (group.isPresent()) {
+                 if (isMemberOfExactGroup(user, group.get())) {
+                     LOGGER.infof("User %s is authorized for group %s", user.getUsername(), groupName);
+                     success(context, user);
+                     return;
+                 }
+                 foundGroup = true;
+             }
+         }
+ 
+         if (foundGroup) {
+             LOGGER.warn("User is not a member of the required group(s), denying access (403)");
+             accessDenied(context, "accessDenied");
+             return;
+         }
+ 
+         LOGGER.warnf("Required group(s) %s do not exist in realm, denying access (403)", Arrays.toString(groups.anyOf));
+         accessDenied(context, "accessDenied");
+     }
+ 
+     private Groups parseGroupsAttribute(String groupsAttribute) {
+         ObjectMapper objectMapper = new ObjectMapper();
+         try {
+             Groups groups = objectMapper.readValue(groupsAttribute, Groups.class);
+             if (groups.anyOf.length == 0) {
+                 LOGGER.errorf("Groups attribute does not contain a valid anyOf array");
+                 return null;
+             }
+             return groups;
+         } catch (Exception e) {
+             LOGGER.errorf("Failed to parse groups JSON: %s", e.getMessage());
+             return null;
+         }
+     }
+ 
+     private Optional<GroupModel> getGroupByPath(final String groupPath, final RealmModel realm) {
+         return realm.getGroupsStream()
+             .filter(group -> buildGroupPath(group).equals(groupPath))
+             .findFirst();
+     }
+ 
+     private String buildGroupPath(GroupModel group) {
+         StringBuilder path = new StringBuilder();
+         GroupModel currentGroup = group;
+         while (currentGroup != null) {
+             String groupName = currentGroup.getName();
+             // Disallow slashes in the group unless they are prefixed by a tilde ~
+             // See https://www.keycloak.org/docs/latest/upgrading/index.html#escaping-slashes-in-group-paths
+             // Regexp tester: https://regex101.com/r/BgkuuO/1
+             if (groupName.matches(".*(?<!~)/.*")) {
+                 LOGGER.errorf("Group name '%s' contains a disallowed slash", groupName);
+                 throw new IllegalArgumentException("Group names cannot contain slashes unless prefixed with '~'");
+             }
+             path.insert(0, "/" + groupName);
+             currentGroup = currentGroup.getParent();
+         }
+         return path.toString();
+     }
+ 
+     private void accessDenied(final AuthenticationFlowContext context, final String messageKey) {
+         LoginFormsProvider form = context.form();
+         if (form != null) {
+             String clientDisplay = "<unknown>";
+             if (context.getAuthenticationSession() != null && context.getAuthenticationSession().getClient() != null) {
+                 ClientModel c = context.getAuthenticationSession().getClient();
+                 String name = c.getName();
+                 clientDisplay = (name != null && !name.isBlank()) ? name : c.getClientId();
+             }
+             // Set the error first, then create the page (avoid relying on chained return value)
+             form.setError("uds_access_denied_client", clientDisplay);
+             Response challenge = form.createErrorPage(Response.Status.FORBIDDEN);
+             // Force a 403 challenge without marking the flow as a failure to avoid brute-force increments
+             context.forceChallenge(challenge);
+         } else {
+             // Fallback: build a minimal 403 response and force the challenge
+             Response challenge = Response.status(Response.Status.FORBIDDEN).build();
+             context.forceChallenge(challenge);
+         }
+     }
+ 
+     protected void success(final AuthenticationFlowContext context, final UserModel user) {
+         boolean shouldAddTAC = true;
+ 
+         if (isConditionalTACActive(context)) {
+             String parentSessionId = context.getAuthenticationSession().getParentSession().getId();
+             if (user.getAttributes().get(TAC_USER_ATTRIBUTE) != null) {
+                 String userSessionId = user.getAttributes().get(TAC_USER_ATTRIBUTE).get(0);
+                 if (parentSessionId.equals(userSessionId)) {
+                     shouldAddTAC = false;
+                     LOGGER.trace("User already accepted Terms and Conditions for this session. Skipping...");
+                 } else {
+                     LOGGER.trace("Stale session detected, asking user to accept Terms and Conditions again");
+                 }
+             } else {
+                 LOGGER.trace("User hasn't accepted Terms and Conditions. Requesting user accept them.");
+             }
+             user.setAttribute(TAC_USER_ATTRIBUTE, Arrays.asList(parentSessionId));
+         } else {
+             // Keycloak admins configured the plugin to ask for TAC every time
+             shouldAddTAC = true;
+         }
+ 
+         if (shouldAddTAC) {
+             user.addRequiredAction("TERMS_AND_CONDITIONS");
+         }
+         context.success();
+     }
+ 
+     protected boolean isConditionalTACActive(AuthenticationFlowContext context) {
+         LOGGER.trace("Evaluating conditional TAC");
+         AuthenticatorConfigModel authConfig = context.getAuthenticatorConfig();
+         if (authConfig != null && authConfig.getConfig() != null) {
+             String tocPerSession = authConfig.getConfig().get(RequireGroupAuthenticatorFactory.TOC_PER_SESSION_CONFIG_NAME);
+             LOGGER.tracef("Custom Authentication Config is configured, TAC per session setting: %s", tocPerSession);
+             return Boolean.valueOf(tocPerSession);
+         } else {
+             LOGGER.trace("No AuthenticatorConfig is configured, using default (true) value");
+         }
+         return true;
+     }
+ 
+     private boolean isMemberOfExactGroup(UserModel user, GroupModel group) {
+         return user.getGroupsStream()
+             .anyMatch(userGroup -> buildGroupPath(userGroup).equals(buildGroupPath(group)));
+     }
+ 
+     @Override
+     public void action(final AuthenticationFlowContext authenticationFlowContext) {
+         // no implementation needed here
+     }
+ 
+     @Override
+     public boolean requiresUser() {
+         return true;
+     }
+ 
+     @Override
+     public boolean configuredFor(
+         final KeycloakSession keycloakSession,
+         final RealmModel realmModel,
+         final UserModel userModel) {
+ 
+         return true;
+     }
+ 
+     @Override
+     public void setRequiredActions(
+         final KeycloakSession keycloakSession,
+         final RealmModel realmModel,
+         final UserModel userModel) {
+ 
+         // no implementation needed here
+     }
+ 
+     @Override
+     public void close() {
+         // no implementation needed here
+     }
+ }
+ 

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/RequireGroupAuthenticatorTest.java
@@ -3,299 +3,312 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
-package com.defenseunicorns.uds.keycloak.plugin.authentication;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.authentication.AuthenticationFlowError;
-import org.keycloak.models.*;
-import org.keycloak.sessions.AuthenticationSessionModel;
-import org.keycloak.sessions.RootAuthenticationSessionModel;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.util.Collections;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
-
-@RunWith(MockitoJUnitRunner.class)
-public class RequireGroupAuthenticatorTest {
-
-    @InjectMocks
-    @Spy
-    private RequireGroupAuthenticator authenticator;
-
-    @Mock
-    private AuthenticationFlowContext context;
-
-    @Mock
-    private RealmModel realm;
-
-    @Mock
-    private UserModel user;
-
-    @Mock
-    private GroupModel group;
-
-    @Mock
-    private GroupModel parentGroup;
-
-    @Mock
-    private AuthenticationSessionModel authenticationSession;
-
-    @Mock
-    private RootAuthenticationSessionModel parentAuthenticationSession;
-
-    @Mock
-    private ClientModel client;
-
-    @Mock
-    private GroupProvider groupProvider;
-
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-
-        when(parentAuthenticationSession.getId()).thenReturn("test-id");
-
-        when(context.getRealm()).thenReturn(realm);
-        when(context.getUser()).thenReturn(user);
-        when(context.getAuthenticationSession()).thenReturn(authenticationSession);
-        when(authenticationSession.getClient()).thenReturn(client);
-        when(authenticationSession.getParentSession()).thenReturn(parentAuthenticationSession);
-
-        when(group.getName()).thenReturn("Admin");
-        when(group.getParent()).thenReturn(parentGroup);
-        when(parentGroup.getName()).thenReturn("UDS Core");
-
-        when(realm.getGroupsStream()).thenReturn(Stream.of(group, parentGroup));
-    }
-
-    @Test
-    public void testShouldRejectUnknownGroups() throws Exception {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/unknown-group\"]}");
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    @Test
-    public void testShouldRejectNonGroupMembers() throws Exception {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/Admin\"]}");
-        when(group.getName()).thenReturn("Admin");
-        when(user.getGroupsStream()).thenReturn(Stream.of()); // User is not a member of any group
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    @Test
-    public void testShouldAcceptEmptyGroupsAttribute() {
-        when(client.getAttribute("uds.core.groups")).thenReturn(""); // Empty groups attribute
-
-        authenticator.authenticate(context);
-
-        verify(context).success();
-    }
-
-    @Test
-    public void testShouldAcceptUserInGroup() throws Exception {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/Admin\"]}");
-        when(user.getGroupsStream()).thenReturn(Stream.of(group)); // User is a member of the group
-
-        authenticator.authenticate(context);
-
-        verify(context).success();
-    }
-
-    @Test
-    public void testShouldAcceptUserInParentGroup() throws Exception {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core\"]}");
-        when(user.getGroupsStream()).thenReturn(Stream.of(parentGroup)); // User is a member of the parent group
-
-        authenticator.authenticate(context);
-
-        verify(context).success();
-    }
-
-    @Test
-    public void testShouldRejectUserNotInParentGroup() {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core\"]}");
-        when(user.getGroupsStream()).thenReturn(Stream.of(group)); // User is a member of the admin group
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    @Test
-    public void testShouldRejectNullUser() {
-        when(context.getUser()).thenReturn(null); // Simulating null user
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_USER);
-    }
-
-    @Test
-    public void testShouldRejectFailedJsonParse() {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [invalid-json]}"); // Invalid JSON
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    @Test
-    public void testShouldRejectNoGroupsArray() {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{}"); // JSON without 'anyOf' array
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    @Test
-    public void testShouldRejectNullGroupInAnyOf() {
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [null]}"); // JSON with null group
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    @Test
-    public void testShouldRejectUserInDifferentGroup() throws Exception {
-        GroupModel differentGroup = mock(GroupModel.class);
-        when(differentGroup.getName()).thenReturn("DifferentGroup");
-        when(differentGroup.getParent()).thenReturn(null);
-
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/Admin\"]}");
-        when(user.getGroupsStream()).thenReturn(Stream.of(differentGroup)); // User is a member of a different group
-
-        authenticator.authenticate(context);
-
-        verify(context).failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testShouldThrowExceptionForInvalidGroupNameWithSlash() {
-        GroupModel invalidGroup = mock(GroupModel.class);
-        when(invalidGroup.getName()).thenReturn("Invalid/Group");
-
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"Invalid/Group\"]}");
-        when(realm.getGroupsStream()).thenReturn(Stream.of(invalidGroup));
-
-        authenticator.authenticate(context);
-    }
-
-    @Test
-    public void testShouldNotThrowExceptionForValidGroupNameWithEscapedSlash() {
-        GroupModel validGroup = mock(GroupModel.class);
-        when(validGroup.getName()).thenReturn("Invalid~/Group");
-
-        when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"Invalid/Group\"]}");
-        when(realm.getGroupsStream()).thenReturn(Stream.of(validGroup));
-
-        authenticator.authenticate(context);
-    }
-
-    @Test
-    public void testShouldAcceptClientInIgnoreList() {
-        when(client.getClientId()).thenReturn("account-console");
-
-        authenticator.authenticate(context);
-
-        verify(context).success();
-    }
-
-    @Test
-    public void testConditionalTACWhenThePluginIsNotConfigured() {
-        when(context.getAuthenticatorConfig()).thenReturn(null);
-
-        boolean result = authenticator.isConditionalTACActive(context);
-
-        assertTrue(result);
-    }
-
-    @Test
-    public void testConditionalTACWhenPluginConfigurationIsDisabled() {
-        AuthenticatorConfigModel authConfig = mock(AuthenticatorConfigModel.class);
-        when(context.getAuthenticatorConfig()).thenReturn(authConfig);
-        when(authConfig.getConfig()).thenReturn(Collections.singletonMap(RequireGroupAuthenticatorFactory.TOC_PER_SESSION_CONFIG_NAME, "false"));
-
-        boolean result = authenticator.isConditionalTACActive(context);
-
-        assertFalse(result);
-    }
-
-    @Test
-    public void testConditionalTACWhenPluginConfigurationIsEnabled() {
-        AuthenticatorConfigModel authConfig = mock(AuthenticatorConfigModel.class);
-        when(context.getAuthenticatorConfig()).thenReturn(authConfig);
-        when(authConfig.getConfig()).thenReturn(Collections.singletonMap(RequireGroupAuthenticatorFactory.TOC_PER_SESSION_CONFIG_NAME, "true"));
-
-        boolean result = authenticator.isConditionalTACActive(context);
-
-        assertTrue(result);
-    }
-
-    @Test
-    public void testAddingTACWhenSessionIDsMismatch() {
-        doReturn(true).when(authenticator).isConditionalTACActive(context);
-
-        when(context.getAuthenticationSession().getParentSession().getId()).thenReturn("test-session-id");
-        when(user.getAttributes()).thenReturn(Collections.singletonMap(RequireGroupAuthenticator.TAC_USER_ATTRIBUTE, Collections.singletonList("doesn't match")));
-
-        authenticator.success(context, user);
-
-        verify(user).addRequiredAction("TERMS_AND_CONDITIONS");
-        verify(context).success();
-    }
-
-    @Test
-    public void testNotAddingTACWhenSessionIDsMatch() {
-        doReturn(true).when(authenticator).isConditionalTACActive(context);
-
-        when(context.getAuthenticationSession().getParentSession().getId()).thenReturn("test-session-id");
-        when(user.getAttributes()).thenReturn(Collections.singletonMap(RequireGroupAuthenticator.TAC_USER_ATTRIBUTE, Collections.singletonList("test-session-id")));
-
-        authenticator.success(context, user);
-
-        verify(user, never()).addRequiredAction("TERMS_AND_CONDITIONS");
-        verify(context).success();
-    }
-
-    @Test
-    public void testAddingTACWhenUserHasNoAttribute() {
-        doReturn(true).when(authenticator).isConditionalTACActive(context);
-
-        when(context.getAuthenticationSession().getParentSession().getId()).thenReturn("test-session-id");
-        when(user.getAttributes()).thenReturn(Collections.emptyMap());
-
-        authenticator.success(context, user);
-
-        verify(user).addRequiredAction("TERMS_AND_CONDITIONS");
-        verify(context).success();
-    }
-
-    @Test
-    public void testAddingTACWhenConditionalTACIsDisabled() {
-        doReturn(false).when(authenticator).isConditionalTACActive(context);
-
-        authenticator.success(context, user);
-
-        verify(user).addRequiredAction("TERMS_AND_CONDITIONS");
-        verify(context).success();
-    }
-}
+ package com.defenseunicorns.uds.keycloak.plugin.authentication;
+
+ import org.junit.Before;
+ import org.junit.Test;
+ import org.junit.runner.RunWith;
+ import org.keycloak.authentication.AuthenticationFlowContext;
+ import org.keycloak.authentication.AuthenticationFlowError;
+ import org.keycloak.models.*;
+ import org.keycloak.sessions.AuthenticationSessionModel;
+ import org.keycloak.sessions.RootAuthenticationSessionModel;
+ import org.keycloak.forms.login.LoginFormsProvider;
+ import jakarta.ws.rs.core.Response;
+ import org.mockito.Spy;
+ import org.mockito.junit.MockitoJUnitRunner;
+ import org.mockito.InjectMocks;
+ import org.mockito.Mock;
+ import org.mockito.MockitoAnnotations;
+ 
+ import java.util.Collections;
+ import java.util.stream.Stream;
+ 
+ import static org.junit.Assert.assertFalse;
+ import static org.junit.Assert.assertTrue;
+ import static org.mockito.Mockito.*;
+ 
+ @RunWith(MockitoJUnitRunner.class)
+ public class RequireGroupAuthenticatorTest {
+ 
+     @InjectMocks
+     @Spy
+     private RequireGroupAuthenticator authenticator;
+ 
+     @Mock
+     private AuthenticationFlowContext context;
+ 
+     @Mock
+     private RealmModel realm;
+ 
+     @Mock
+     private UserModel user;
+ 
+     @Mock
+     private GroupModel group;
+ 
+     @Mock
+     private GroupModel parentGroup;
+ 
+     @Mock
+     private AuthenticationSessionModel authenticationSession;
+ 
+     @Mock
+     private RootAuthenticationSessionModel parentAuthenticationSession;
+ 
+     @Mock
+     private ClientModel client;
+ 
+     @Mock
+     private GroupProvider groupProvider;
+ 
+     @Mock
+     private LoginFormsProvider formProvider;
+ 
+     @Mock
+     private Response response;
+ 
+     @Before
+     public void setup() {
+         MockitoAnnotations.initMocks(this);
+ 
+         when(parentAuthenticationSession.getId()).thenReturn("test-id");
+ 
+         when(context.getRealm()).thenReturn(realm);
+         when(context.getUser()).thenReturn(user);
+         when(context.getAuthenticationSession()).thenReturn(authenticationSession);
+         when(authenticationSession.getClient()).thenReturn(client);
+         when(authenticationSession.getParentSession()).thenReturn(parentAuthenticationSession);
+ 
+         // default form provider mocks for error page path
+         when(context.form()).thenReturn(formProvider);
+         when(formProvider.createErrorPage(Response.Status.FORBIDDEN)).thenReturn(response);
+ 
+         when(group.getName()).thenReturn("Admin");
+         when(group.getParent()).thenReturn(parentGroup);
+         when(parentGroup.getName()).thenReturn("UDS Core");
+ 
+         when(realm.getGroupsStream()).thenReturn(Stream.of(group, parentGroup));
+     }
+ 
+     @Test
+     public void testShouldRejectUnknownGroups() throws Exception {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/unknown-group\"]}");
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).forceChallenge(any(Response.class));
+     }
+ 
+     @Test
+     public void testShouldRejectNonGroupMembers() throws Exception {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/Admin\"]}");
+         when(group.getName()).thenReturn("Admin");
+         when(user.getGroupsStream()).thenReturn(Stream.of()); // User is not a member of any group
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).forceChallenge(any(Response.class));
+     }
+ 
+     @Test
+     public void testShouldAcceptEmptyGroupsAttribute() {
+         when(client.getAttribute("uds.core.groups")).thenReturn(""); // Empty groups attribute
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).success();
+     }
+ 
+     @Test
+     public void testShouldAcceptUserInGroup() throws Exception {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/Admin\"]}");
+         when(user.getGroupsStream()).thenReturn(Stream.of(group)); // User is a member of the group
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).success();
+     }
+ 
+     @Test
+     public void testShouldAcceptUserInParentGroup() throws Exception {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core\"]}");
+         when(user.getGroupsStream()).thenReturn(Stream.of(parentGroup)); // User is a member of the parent group
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).success();
+     }
+ 
+     @Test
+     public void testShouldRejectUserNotInParentGroup() {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core\"]}");
+         when(user.getGroupsStream()).thenReturn(Stream.of(group)); // User is a member of the admin group
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).forceChallenge(any(Response.class));
+     }
+ 
+     @Test
+     public void testShouldRejectNullUser() {
+         when(context.getUser()).thenReturn(null); // Simulating null user
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).failure(AuthenticationFlowError.INVALID_USER);
+     }
+ 
+     @Test
+     public void testShouldRejectFailedJsonParse() {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [invalid-json]}"); // Invalid JSON
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).forceChallenge(any(Response.class));
+     }
+ 
+     @Test
+     public void testShouldRejectNoGroupsArray() {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{}"); // JSON without 'anyOf' array
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).forceChallenge(any(Response.class));
+     }
+ 
+     @Test
+     public void testShouldRejectNullGroupInAnyOf() {
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [null]}"); // JSON with null group
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).forceChallenge(any(Response.class));
+     }
+ 
+     @Test
+     public void testShouldRejectUserInDifferentGroup() throws Exception {
+         GroupModel differentGroup = mock(GroupModel.class);
+         when(differentGroup.getName()).thenReturn("DifferentGroup");
+         when(differentGroup.getParent()).thenReturn(null);
+ 
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"/UDS Core/Admin\"]}");
+         when(user.getGroupsStream()).thenReturn(Stream.of(differentGroup)); // User is a member of a different group
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).forceChallenge(any(Response.class));
+     }
+ 
+     @Test(expected = IllegalArgumentException.class)
+     public void testShouldThrowExceptionForInvalidGroupNameWithSlash() {
+         GroupModel invalidGroup = mock(GroupModel.class);
+         when(invalidGroup.getName()).thenReturn("Invalid/Group");
+ 
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"Invalid/Group\"]}");
+         when(realm.getGroupsStream()).thenReturn(Stream.of(invalidGroup));
+ 
+         authenticator.authenticate(context);
+     }
+ 
+     @Test
+     public void testShouldNotThrowExceptionForValidGroupNameWithEscapedSlash() {
+         GroupModel validGroup = mock(GroupModel.class);
+         when(validGroup.getName()).thenReturn("Invalid~/Group");
+ 
+         when(client.getAttribute("uds.core.groups")).thenReturn("{\"anyOf\": [\"Invalid/Group\"]}");
+         when(realm.getGroupsStream()).thenReturn(Stream.of(validGroup));
+ 
+         authenticator.authenticate(context);
+     }
+ 
+     @Test
+     public void testShouldAcceptClientInIgnoreList() {
+         when(client.getClientId()).thenReturn("account-console");
+ 
+         authenticator.authenticate(context);
+ 
+         verify(context).success();
+     }
+ 
+     @Test
+     public void testConditionalTACWhenThePluginIsNotConfigured() {
+         when(context.getAuthenticatorConfig()).thenReturn(null);
+ 
+         boolean result = authenticator.isConditionalTACActive(context);
+ 
+         assertTrue(result);
+     }
+ 
+     @Test
+     public void testConditionalTACWhenPluginConfigurationIsDisabled() {
+         AuthenticatorConfigModel authConfig = mock(AuthenticatorConfigModel.class);
+         when(context.getAuthenticatorConfig()).thenReturn(authConfig);
+         when(authConfig.getConfig()).thenReturn(Collections.singletonMap(RequireGroupAuthenticatorFactory.TOC_PER_SESSION_CONFIG_NAME, "false"));
+ 
+         boolean result = authenticator.isConditionalTACActive(context);
+ 
+         assertFalse(result);
+     }
+ 
+     @Test
+     public void testConditionalTACWhenPluginConfigurationIsEnabled() {
+         AuthenticatorConfigModel authConfig = mock(AuthenticatorConfigModel.class);
+         when(context.getAuthenticatorConfig()).thenReturn(authConfig);
+         when(authConfig.getConfig()).thenReturn(Collections.singletonMap(RequireGroupAuthenticatorFactory.TOC_PER_SESSION_CONFIG_NAME, "true"));
+ 
+         boolean result = authenticator.isConditionalTACActive(context);
+ 
+         assertTrue(result);
+     }
+ 
+     @Test
+     public void testAddingTACWhenSessionIDsMismatch() {
+         doReturn(true).when(authenticator).isConditionalTACActive(context);
+ 
+         when(context.getAuthenticationSession().getParentSession().getId()).thenReturn("test-session-id");
+         when(user.getAttributes()).thenReturn(Collections.singletonMap(RequireGroupAuthenticator.TAC_USER_ATTRIBUTE, Collections.singletonList("doesn't match")));
+ 
+         authenticator.success(context, user);
+ 
+         verify(user).addRequiredAction("TERMS_AND_CONDITIONS");
+         verify(context).success();
+     }
+ 
+     @Test
+     public void testNotAddingTACWhenSessionIDsMatch() {
+         doReturn(true).when(authenticator).isConditionalTACActive(context);
+ 
+         when(context.getAuthenticationSession().getParentSession().getId()).thenReturn("test-session-id");
+         when(user.getAttributes()).thenReturn(Collections.singletonMap(RequireGroupAuthenticator.TAC_USER_ATTRIBUTE, Collections.singletonList("test-session-id")));
+ 
+         authenticator.success(context, user);
+ 
+         verify(user, never()).addRequiredAction("TERMS_AND_CONDITIONS");
+         verify(context).success();
+     }
+ 
+     @Test
+     public void testAddingTACWhenUserHasNoAttribute() {
+         doReturn(true).when(authenticator).isConditionalTACActive(context);
+ 
+         when(context.getAuthenticationSession().getParentSession().getId()).thenReturn("test-session-id");
+         when(user.getAttributes()).thenReturn(Collections.emptyMap());
+ 
+         authenticator.success(context, user);
+ 
+         verify(user).addRequiredAction("TERMS_AND_CONDITIONS");
+         verify(context).success();
+     }
+ 
+     @Test
+     public void testAddingTACWhenConditionalTACIsDisabled() {
+         doReturn(false).when(authenticator).isConditionalTACActive(context);
+ 
+         authenticator.success(context, user);
+ 
+         verify(user).addRequiredAction("TERMS_AND_CONDITIONS");
+         verify(context).success();
+     }
+ }
+ 

--- a/src/theme/login/messages/messages_en.properties
+++ b/src/theme/login/messages/messages_en.properties
@@ -339,3 +339,4 @@ identity-provider-redirector=Connect with another Identity Provider
 registerNow=Register now
 registerNewAccount=Register New Account
 noAccountYet=Don''t have an account?
+uds_access_denied_client=You do not have access to this application. Please contact your administrator.


### PR DESCRIPTION
## Description
Users who fail the Group Protection Authorization check three times are permanently locked out due to realm brute-force settings, even though these failures are authorization/eligibility checks (group membership), not credential failures.

### Expected behavior
- Failing the Group Protection Authorization check should block access to the client but should not increment the brute-force counter or contribute to account lockout.
- Users should only be locked out after repeated invalid credential attempts (e.g., bad password), not group membership mismatches

<img width="1429" height="826" alt="Screenshot from 2025-11-05 11-06-59" src="https://github.com/user-attachments/assets/b1ecfe6c-2dff-4275-aff6-6121071a0d8b" />

## Related Issue

Fixes #690 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed