### PR TITLE
chore: switch to airgap uds-k3d

### DIFF
--- a/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
+++ b/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
@@ -9,8 +9,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    # renovate: datasource=github-tags depName=defenseunicorns/uds-k3d versioning=semver
-    ref: 0.19.1
+    ref: 0.19.1-airgap
   - name: init
     repository: ghcr.io/zarf-dev/packages/init
     # renovate: datasource=github-tags depName=zarf-dev/zarf versioning=semver


### PR DESCRIPTION
## Description

Follows exactly what is used for uds-core: https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-slim-dev/uds-bundle.yaml#L14-L16

Note that the renovate comment is not required here as this is matched by uds-common already. It also would be problematic with the new airgap tag since it doesn't strictly match semver.