### PR TITLE
fix: cac detection when using bcustom back button

### DIFF
--- a/src/theme/login/register.ftl
+++ b/src/theme/login/register.ftl
@@ -4,7 +4,7 @@
             <form action="/chuck-norris-calendar-goes-straight-from-march-31st-to-april-2nd-because-no-one-fools-chuck-norris"
                 id="unicorn-registration-form" method="post">
                 <div class="back-button-container">
-                    <a href="${url.loginUrl}" class="back-button">
+                    <a href="${(url.loginRestartFlowUrl)!url.loginUrl}" class="back-button">
                         <img src="${url.resourcesPath}/img/icon_back.svg" alt=""/>
                         <span>${msg("backToLogin")}</span>
                     </a>


### PR DESCRIPTION
## Description
When using the custom back button (not the browser back button) with a cac from the registration page, the login prompt to use the cac wouldn't present. This fix uses the correct url parameter from the FreeMarker `UrlBean` that Keycloak injects into the login and registration templates. The result is that it properly goes backwards to the existing auth session that was started when originally landing on the login page. For context the problem was that the built in back button removed the session id from the URL and resulted in the cac not being detected because there was no auth session attached.

## To test this
use the `uds run uds-core-integration-setup` command and load test cac into browser and click on the register button and then the built in back button. should see the cac register here button again (without these changes that cac alert header would be missing).

## Related Issue

Fixes #709 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed