### PR TITLE
feat: inactive user disabled account workflow

### DIFF
--- a/src/realm.json5
+++ b/src/realm.json5
@@ -2209,7 +2209,7 @@
                             "subComponents": {},
                             "config": {
                                 "uses": ["disable-user"],
-                                "after": ["${REALM_ACCOUNT_INACTIVITY_DAYS:35}d"],
+                                "after": ["${ACCOUNT_INACTIVITY_DAYS:35}d"],
                                 "priority": ["0"]
                             }
                         }
@@ -2218,9 +2218,10 @@
                 "config": {
                     "name": ["disable-inactive-users"],
                     "on": ["user-authenticated"],
-                    "enabled": ["${REALM_ACCOUNT_INACTIVITY_DAYS_ENABLED:false}"],
+                    "enabled": ["${ACCOUNT_INACTIVITY_DAYS_ENABLED:false}"],
                     "restart-in-progress": ["true"],
-                    "supports": ["USERS"]
+                    "supports": ["USERS"],
+                    "conditions": ["NOT has-role(\"realm-management/realm-admin\")"]
                 }
             }
         ]

--- a/src/realm.json5
+++ b/src/realm.json5
@@ -2209,7 +2209,7 @@
                             "subComponents": {},
                             "config": {
                                 "uses": ["disable-user"],
-                                "after": ["${ACCOUNT_INACTIVITY_DAYS:35}d"],
+                                "after": ["${REALM_ACCOUNT_INACTIVITY_DAYS:35}d"],
                                 "priority": ["0"]
                             }
                         }
@@ -2218,7 +2218,7 @@
                 "config": {
                     "name": ["disable-inactive-users"],
                     "on": ["user-authenticated"],
-                    "enabled": ["${ACCOUNT_INACTIVITY_DAYS_ENABLED:false}"],
+                    "enabled": ["${REALM_ACCOUNT_INACTIVITY_DAYS_ENABLED:false}"],
                     "restart-in-progress": ["true"],
                     "supports": ["USERS"],
                     "conditions": ["NOT has-role(\"realm-management/realm-admin\")"]

--- a/src/realm.json5
+++ b/src/realm.json5
@@ -2194,6 +2194,35 @@
                     ]
                 }
             }
+        ],
+        "org.keycloak.models.workflow.WorkflowProvider": [
+            {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "name": "disable-inactive-users",
+                "providerId": "default",
+                "subComponents": {
+                    "org.keycloak.models.workflow.WorkflowStepProvider": [
+                        {
+                            "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                            "name": "disable-user-step",
+                            "providerId": "disable-user",
+                            "subComponents": {},
+                            "config": {
+                                "uses": ["disable-user"],
+                                "after": ["${REALM_ACCOUNT_INACTIVITY_DAYS:35}d"],
+                                "priority": ["0"]
+                            }
+                        }
+                    ]
+                },
+                "config": {
+                    "name": ["disable-inactive-users"],
+                    "on": ["user-authenticated"],
+                    "enabled": ["${REALM_ACCOUNT_INACTIVITY_DAYS_ENABLED:false}"],
+                    "restart-in-progress": ["true"],
+                    "supports": ["USERS"]
+                }
+            }
         ]
     },
     "internationalizationEnabled": false,

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -130,7 +130,7 @@ tasks:
     description: "Clone UDS Core for integration testing"
     actions:
       - cmd: rm -rf uds-core
-      - cmd: git clone --branch main https://github.com/defenseunicorns/uds-core.git
+      - cmd: git clone --branch chance/core-432-address-apsc-dv-000320-account-inactivity-disable https://github.com/defenseunicorns/uds-core.git
 
   - name: build-deploy-custom-slim
     description: "Build/Deploy custom slim dev bundle for integration testing"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -130,7 +130,7 @@ tasks:
     description: "Clone UDS Core for integration testing"
     actions:
       - cmd: rm -rf uds-core
-      - cmd: git clone --branch chance/core-432-address-apsc-dv-000320-account-inactivity-disable https://github.com/defenseunicorns/uds-core.git
+      - cmd: git clone --branch main https://github.com/defenseunicorns/uds-core.git
 
   - name: build-deploy-custom-slim
     description: "Build/Deploy custom slim dev bundle for integration testing"


### PR DESCRIPTION
## Description
Configure a workflow that disables users accounts after x number of days of inactivity. This workflow can also be enabled/disabled.

Two new config items that enable this are number of days of inactivity and enabled/disabled workflow that are set in the uds-core bundle overrides.

## Related Issue

Fixes [core-432](https://linear.app/defense-unicorns/issue/CORE-432/address-apsc-dv-000320-account-inactivity-disable-requirement)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed