### PR TITLE
feat(CORE-152): re-introduce the Signed JWTs to the UDS Operator

### DIFF
--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
@@ -18,6 +18,7 @@ import org.keycloak.models.IdentityProviderModel;
 import com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes.UDSKubernetesIdentityProviderFactory;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.jboss.logging.Logger;
@@ -91,8 +92,9 @@ public class UDSClientAssertionStrategy implements ClientAssertionStrategy {
         }
         var idpStorage = context.getSession().identityProviders();
 
-        List<LookupResult> matches = context.getRealm().getClientsStream()
-            .filter(c -> subject.equals(c.getAttribute(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_SUBJECT_KEY)))
+        List<LookupResult> matches = context.getSession().clients()
+            .searchClientsByAttributes(context.getRealm(),
+                Map.of(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_SUBJECT_KEY, subject), null, null)
             .map(matchingClient -> {
                 String idpAlias = matchingClient.getAttribute(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_ISSUER_KEY);
                 if (idpAlias == null) {

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
@@ -106,7 +106,7 @@ public class UDSClientAssertionStrategy implements ClientAssertionStrategy {
                 }
                 return null;
             })
-            .filter(r -> r != null)
+            .filter(Objects::nonNull)
             .findFirst()
             .orElse(null);
     }

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.ClientAuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.client.ClientAssertionState;
+import org.keycloak.authentication.authenticators.client.DefaultClientAssertionStrategy;
+import org.keycloak.authentication.authenticators.client.FederatedJWTClientAuthenticator;
+import org.keycloak.broker.provider.ClientAssertionIdentityProviderFactory.ClientAssertionStrategy;
+import org.keycloak.broker.provider.ClientAssertionIdentityProviderFactory.LookupResult;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.IdentityProviderModel;
+
+import com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes.UDSKubernetesIdentityProviderFactory;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Issuer-agnostic client assertion strategy for managed Kubernetes clusters.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * The upstream {@link DefaultClientAssertionStrategy} looks up identity providers by matching
+ * the JWT assertion's {@code iss} claim against configured IdP issuer URLs. On self-hosted
+ * clusters (e.g. k3d), the SA token issuer is {@code https://kubernetes.default.svc.cluster.local}
+ * which matches the configured IdP — so the default strategy works.
+ *
+ * On managed Kubernetes clusters (EKS, AKS, GKE), the SA token issuer is a cloud-specific URL
+ * (e.g. {@code https://oidc.eks.us-gov-west-1.amazonaws.com/id/...}) that does NOT match the
+ * configured IdP issuer. The default strategy returns null, and authentication fails with
+ * {@code client_not_found} before our custom IdP's {@code verifyClientAssertion} is ever called.
+ *
+ * <h2>How the fallback works</h2>
+ *
+ * When the default issuer-based lookup fails, this strategy uses a client-first approach:
+ * <ol>
+ *   <li>Scan realm clients for one whose {@code jwt.credential.sub} matches the JWT subject</li>
+ *   <li>Read that client's {@code jwt.credential.issuer} attribute (which is the IdP alias)</li>
+ *   <li>Look up the IdP by alias via {@code IdentityProviderStorageProvider.getByAlias()}</li>
+ *   <li>Verify the IdP uses our {@code uds-kubernetes} provider type and is enabled</li>
+ * </ol>
+ *
+ * <h2>Why we don't use {@code getIdentityProvidersStream()}</h2>
+ *
+ * In Keycloak 26.5, {@code RealmModel.getIdentityProvidersStream()} delegates to
+ * {@code IdentityProviderStorageProvider.getAllStream(IdentityProviderQuery.userAuthentication())},
+ * which only returns {@code USER_AUTHENTICATION} type IdPs. Our {@code uds-kubernetes} IdP has
+ * type {@code CLIENT_ASSERTION}, so it is excluded from that stream. Using
+ * {@code getByAlias()} bypasses this filter entirely.
+ *
+ * @see DefaultClientAssertionStrategy
+ * @see UDSKubernetesIdentityProvider
+ */
+public class UDSClientAssertionStrategy implements ClientAssertionStrategy {
+
+    private static final Logger LOGGER = Logger.getLogger(UDSClientAssertionStrategy.class);
+
+    private final DefaultClientAssertionStrategy defaultStrategy = new DefaultClientAssertionStrategy();
+
+    @Override
+    public boolean isSupportedAssertionType(String assertionType) {
+        return OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT.equals(assertionType);
+    }
+
+    @Override
+    public LookupResult lookup(ClientAuthenticationFlowContext context) throws Exception {
+        // 1. Try standard issuer-based lookup (handles k3d and matching-issuer cases)
+        LookupResult defaultResult = defaultStrategy.lookup(context);
+        if (defaultResult != null
+                && defaultResult.identityProviderModel() != null
+                && defaultResult.identityProviderModel().isEnabled()
+                && defaultResult.clientModel() != null) {
+            LOGGER.debug("Standard issuer-based lookup succeeded");
+            return defaultResult;
+        }
+
+        // 2. Fallback: client-first lookup for managed K8s clusters where issuer doesn't match
+        LOGGER.debug("Standard issuer-based lookup failed, falling back to client-first lookup");
+        ClientAssertionState state = context.getState(ClientAssertionState.class, ClientAssertionState.supplier());
+        String subject = state != null && state.getToken() != null ? state.getToken().getSubject() : null;
+        if (subject == null) {
+            LOGGER.debug("Fallback lookup skipped because client assertion subject is missing");
+            return null;
+        }
+        var idpStorage = context.getSession().identityProviders();
+
+        return context.getRealm().getClientsStream()
+            .filter(c -> subject.equals(c.getAttribute(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_SUBJECT_KEY)))
+            .map(matchingClient -> {
+                String idpAlias = matchingClient.getAttribute(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_ISSUER_KEY);
+                if (idpAlias == null) {
+                    return null;
+                }
+
+                IdentityProviderModel idp = idpStorage.getByAlias(idpAlias);
+                if (idp != null
+                        && UDSKubernetesIdentityProviderFactory.PROVIDER_ID.equals(idp.getProviderId())
+                        && idp.isEnabled()) {
+                    LOGGER.debugf("Fallback lookup matched client '%s' to IdP '%s'",
+                        matchingClient.getClientId(), idpAlias);
+                    return new LookupResult(matchingClient, idp);
+                }
+                return null;
+            })
+            .filter(r -> r != null)
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
@@ -17,6 +17,8 @@ import org.keycloak.models.IdentityProviderModel;
 
 import com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes.UDSKubernetesIdentityProviderFactory;
 
+import java.util.Objects;
+
 import org.jboss.logging.Logger;
 
 /**

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategy.java
@@ -17,6 +17,7 @@ import org.keycloak.models.IdentityProviderModel;
 
 import com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes.UDSKubernetesIdentityProviderFactory;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.jboss.logging.Logger;
@@ -90,7 +91,7 @@ public class UDSClientAssertionStrategy implements ClientAssertionStrategy {
         }
         var idpStorage = context.getSession().identityProviders();
 
-        return context.getRealm().getClientsStream()
+        List<LookupResult> matches = context.getRealm().getClientsStream()
             .filter(c -> subject.equals(c.getAttribute(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_SUBJECT_KEY)))
             .map(matchingClient -> {
                 String idpAlias = matchingClient.getAttribute(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_ISSUER_KEY);
@@ -109,7 +110,14 @@ public class UDSClientAssertionStrategy implements ClientAssertionStrategy {
                 return null;
             })
             .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+            .toList();
+
+        if (matches.size() > 1) {
+            throw new IllegalStateException(String.format(
+                "Ambiguous client assertion: subject '%s' matched %d clients. "
+                + "Each service account subject must map to exactly one client.", subject, matches.size()));
+        }
+
+        return matches.isEmpty() ? null : matches.get(0);
     }
 }

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidator.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.ClientAuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.client.FederatedJWTClientValidator;
+import org.keycloak.models.ClientModel;
+import org.keycloak.representations.JsonWebToken;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Custom JWT client validator that relaxes the {@code client_id} form parameter check.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * The upstream {@link FederatedJWTClientValidator} inherits from {@code AbstractJWTClientValidator}
+ * which has a {@code private} method {@code validateClient()} that rejects requests where the
+ * {@code client_id} form parameter doesn't match the JWT {@code sub} claim. In the Kubernetes
+ * service account flow, the JWT subject is the SA identity
+ * (e.g. {@code system:serviceaccount:pepr-system:pepr-uds-core}) while the {@code client_id}
+ * parameter is the Keycloak client name (e.g. {@code uds-operator}). These intentionally differ.
+ *
+ * <p>Because {@code validateClient()} is private, we cannot override just that method. We must
+ * override {@code validate()} entirely and copy the private helper methods, modifying only the
+ * client_id check to log a debug message instead of failing.
+ *
+ * <p>This is a stop-gap solution until
+ * <a href="https://github.com/keycloak/keycloak/pull/48026">https://github.com/keycloak/keycloak/pull/48026</a>
+ * is merged upstream, which will make validation methods extensible.
+ *
+ * <h2>What changed vs upstream</h2>
+ *
+ * Only one behavioral change in {@code validateClientInternal()}:
+ * <pre>
+ * // Upstream (fails):
+ * if (clientIdParam != null &amp;&amp; !clientIdParam.equals(clientId)) {
+ *     return failure("client_id parameter does not match sub claim");
+ * }
+ *
+ * // UDS (logs and continues):
+ * if (clientIdParam != null &amp;&amp; !clientIdParam.equals(clientId)) {
+ *     LOGGER.debugf("client_id parameter '%s' does not match JWT subject '%s', ignoring", ...);
+ * }
+ * </pre>
+ *
+ * All other validation steps (assertion parameters, issuer, signature, audience, expiry,
+ * reuse detection) are unchanged from the upstream implementation.
+ *
+ * @see com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes.UDSKubernetesIdentityProvider
+ */
+public class UDSFederatedJWTClientValidator extends FederatedJWTClientValidator {
+
+    private static final Logger LOGGER = Logger.getLogger(UDSFederatedJWTClientValidator.class);
+
+    public UDSFederatedJWTClientValidator(ClientAuthenticationFlowContext context,
+            SignatureValidator signatureValidator, String expectedTokenIssuer,
+            int allowedClockSkew, boolean reusePermitted) throws Exception {
+        super(context, signatureValidator, expectedTokenIssuer, allowedClockSkew, reusePermitted);
+    }
+
+    @Override
+    public boolean validate() {
+        return validateClientAssertionParametersInternal() &&
+                validateClientInternal() &&
+                validateSignatureAlgorithm(getExpectedSignatureAlgorithm()) &&
+                validateSignatureInternal() &&
+                validateTokenAudience(getExpectedAudiences(), isMultipleAudienceAllowed()) &&
+                validateTokenActive(getAllowedClockSkew(), getMaximumExpirationTime(), isReusePermitted());
+    }
+
+    /**
+     * Copied from {@code AbstractJWTClientValidator.validateClientAssertionParameters()} (private).
+     */
+    private boolean validateClientAssertionParametersInternal() {
+        String clientAssertionType = clientAssertionState.getClientAssertionType();
+        String clientAssertion = clientAssertionState.getClientAssertion();
+
+        if (clientAssertionType == null) {
+            return failure("Parameter client_assertion_type is missing");
+        }
+
+        if (!expectedClientAssertionType.equals(clientAssertionType)) {
+            return failure("Parameter client_assertion_type has value '"
+                    + clientAssertionType + "' but expected is '" + expectedClientAssertionType + "'");
+        }
+
+        if (clientAssertion == null) {
+            return failure("client_assertion parameter missing");
+        }
+
+        return true;
+    }
+
+    /**
+     * Modified from {@code AbstractJWTClientValidator.validateClient()} (private).
+     *
+     * <p>The only change: when {@code client_id} form parameter doesn't match the JWT subject,
+     * this logs a debug message instead of returning a failure. The {@code client_id} parameter
+     * is optional in the {@code client_credentials} grant with JWT assertion per RFC 7523.
+     */
+    private boolean validateClientInternal() {
+        JsonWebToken token = clientAssertionState.getToken();
+
+        String clientId = token.getSubject();
+        if (clientId == null) {
+            return failure("Token sub claim is required");
+        }
+
+        // Relaxed check: log instead of fail when client_id doesn't match JWT subject.
+        // In the K8s SA flow, client_id is "uds-operator" but sub is the SA identity.
+        String clientIdParam = context.getHttpRequest().getDecodedFormParameters().getFirst(OAuth2Constants.CLIENT_ID);
+        if (clientIdParam != null && !clientIdParam.equals(clientId)) {
+            LOGGER.debugf("client_id parameter '%s' does not match JWT subject '%s', ignoring mismatch",
+                clientIdParam, clientId);
+        }
+
+        String expectedTokenIssuer = getExpectedTokenIssuer();
+        if (expectedTokenIssuer != null && !expectedTokenIssuer.equals(token.getIssuer())) {
+            LOGGER.debugf("Expected token issuer '%s' does not match actual issuer '%s'",
+                expectedTokenIssuer, token.getIssuer());
+            return false;
+        }
+
+        ClientModel client = clientAssertionState.getClient();
+
+        if (client == null) {
+            context.failure(AuthenticationFlowError.CLIENT_NOT_FOUND, null);
+            return false;
+        } else {
+            context.getEvent().client(client.getClientId());
+            context.setClient(client);
+        }
+
+        if (!client.isEnabled()) {
+            context.failure(AuthenticationFlowError.CLIENT_DISABLED, null);
+            return false;
+        }
+
+        if (clientAuthenticatorProviderId != null && !clientAuthenticatorProviderId.equals(client.getClientAuthenticatorType())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Copied from {@code AbstractJWTClientValidator.validateSignature()} (private).
+     */
+    private boolean validateSignatureInternal() {
+        return signatureValidator.verifySignature(this);
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidator.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -107,17 +107,17 @@ public class UDSFederatedJWTClientValidator extends FederatedJWTClientValidator 
     private boolean validateClientInternal() {
         JsonWebToken token = clientAssertionState.getToken();
 
-        String clientId = token.getSubject();
-        if (clientId == null) {
+        String jwtSubject = token.getSubject();
+        if (jwtSubject == null) {
             return failure("Token sub claim is required");
         }
 
         // Relaxed check: log instead of fail when client_id doesn't match JWT subject.
         // In the K8s SA flow, client_id is "uds-operator" but sub is the SA identity.
         String clientIdParam = context.getHttpRequest().getDecodedFormParameters().getFirst(OAuth2Constants.CLIENT_ID);
-        if (clientIdParam != null && !clientIdParam.equals(clientId)) {
+        if (clientIdParam != null && !clientIdParam.equals(jwtSubject)) {
             LOGGER.debugf("client_id parameter '%s' does not match JWT subject '%s', ignoring mismatch",
-                clientIdParam, clientId);
+                clientIdParam, jwtSubject);
         }
 
         String expectedTokenIssuer = getExpectedTokenIssuer();

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/KubernetesUtils.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/KubernetesUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.jboss.logging.Logger;
+
+import static org.keycloak.broker.kubernetes.KubernetesConstants.SERVICE_ACCOUNT_TOKEN_PATH;
+
+/**
+ * Shared utilities for Kubernetes identity provider classes.
+ */
+final class KubernetesUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(KubernetesUtils.class);
+
+    private KubernetesUtils() {
+    }
+
+    /**
+     * Reads the Kubernetes service account token from the standard mounted path.
+     *
+     * <p>On managed Kubernetes clusters (EKS, AKS, GKE), the SA token must be included in
+     * requests to the K8s API server's OIDC discovery and JWKS endpoints. The upstream Keycloak
+     * code conditionally includes this token based on an issuer match, which fails on managed
+     * clusters. Our custom classes use this method to always include the token.
+     *
+     * @return the SA token string, or {@code null} if the file doesn't exist or can't be read
+     */
+    static String readServiceAccountToken() {
+        try {
+            var path = Paths.get(SERVICE_ACCOUNT_TOKEN_PATH);
+            if (!Files.exists(path)) {
+                return null;
+            }
+            return new String(Files.readAllBytes(path), StandardCharsets.UTF_8).trim();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to read service account token", e);
+            return null;
+        }
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/KubernetesUtils.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/KubernetesUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -8,6 +8,10 @@ package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.util.JsonSerialization;
 
 import org.jboss.logging.Logger;
 
@@ -24,14 +28,46 @@ final class KubernetesUtils {
     }
 
     /**
+     * Executes the request, checks for a 2xx status, and deserializes the response body.
+     *
+     * @throws IllegalStateException if the response status is not 2xx
+     */
+    static <T> T executeAndParse(SimpleHttpRequest request, String url, Class<T> type) throws Exception {
+        try (SimpleHttpResponse response = request.asResponse()) {
+            int status = response.getStatus();
+            if (status < 200 || status >= 300) {
+                throw new IllegalStateException("Request to " + url + " returned HTTP " + status);
+            }
+            return JsonSerialization.readValue(response.asString(), type);
+        }
+    }
+
+    /**
      * Reads the Kubernetes service account token from the standard mounted path.
      *
-     * <p>On managed Kubernetes clusters (EKS, AKS, GKE), the SA token must be included in
-     * requests to the K8s API server's OIDC discovery and JWKS endpoints. The upstream Keycloak
-     * code conditionally includes this token based on an issuer match, which fails on managed
-     * clusters. Our custom classes use this method to always include the token.
+     * <h2>Why this exists instead of upstream {@code KubernetesJwksEndpointLoader.getToken()}</h2>
+     *
+     * The upstream {@code getToken()} parses the SA token and only returns it when its
+     * {@code iss} claim matches the configured IdP issuer:
+     * <pre>
+     * if (jwt.getIssuer().equals(issuer)) {
+     *     return token;
+     * } else {
+     *     return null;  // "issuer mismatch"
+     * }
+     * </pre>
+     *
+     * On managed Kubernetes clusters (EKS, AKS, GKE), the SA token issuer is a cloud-specific
+     * URL (e.g. {@code https://oidc.eks.*.amazonaws.com/id/...}) while the configured issuer
+     * is {@code https://kubernetes.default.svc.cluster.local}. These never match, so upstream
+     * always excludes the token, causing 401 errors on OIDC discovery and JWKS requests.
+     *
+     * <p>This method returns the raw token unconditionally. The caller
+     * ({@link UDSKubernetesJwksEndpointLoader}) decides whether to forward it based on the
+     * OIDC discovery response's {@code issuer} field instead.
      *
      * @return the SA token string, or {@code null} if the file doesn't exist or can't be read
+     * @see UDSKubernetesJwksEndpointLoader#shouldIncludeToken(String, String)
      */
     static String readServiceAccountToken() {
         try {

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProvider.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProvider.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.keycloak.authentication.ClientAuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.client.AbstractJWTClientValidator;
+import org.keycloak.broker.kubernetes.KubernetesIdentityProvider;
+import org.keycloak.broker.kubernetes.KubernetesIdentityProviderConfig;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.keys.PublicKeyStorageProvider;
+import org.keycloak.keys.PublicKeyStorageUtils;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.util.JsonSerialization;
+
+import com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client.UDSFederatedJWTClientValidator;
+
+import org.keycloak.http.simple.SimpleHttp;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Custom Kubernetes Identity Provider that discovers the real OIDC issuer at runtime.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * The upstream {@link KubernetesIdentityProvider} has its {@code verifyClientAssertion} method
+ * tightly coupled to the configured issuer URL. On managed Kubernetes clusters (EKS, AKS, GKE),
+ * three things break:
+ *
+ * <ol>
+ *   <li><b>Issuer validation fails:</b> The upstream validator compares the JWT's issuer claim
+ *       against the configured IdP issuer. On EKS, the JWT issuer is a cloud-specific URL
+ *       (e.g. {@code https://oidc.eks.us-gov-west-1.amazonaws.com/id/...}) while the configured
+ *       issuer is {@code https://kubernetes.default.svc.cluster.local}.</li>
+ *
+ *   <li><b>OIDC discovery requires authentication:</b> On managed clusters, the API server's
+ *       {@code /.well-known/openid-configuration} endpoint returns 401 Unauthorized unless
+ *       a valid service account token is presented. The upstream code does not always include
+ *       the SA token (see {@link UDSKubernetesJwksEndpointLoader} for details).</li>
+ *
+ *   <li><b>JWKS loading fails:</b> The upstream {@code KubernetesJwksEndpointLoader} only
+ *       includes the SA token when its issuer matches the configured issuer. On managed clusters
+ *       they don't match, so the token is excluded, and JWKS requests fail with 401.</li>
+ * </ol>
+ *
+ * <h2>How this provider fixes it</h2>
+ *
+ * <ul>
+ *   <li>{@link #discoverIssuer} calls the K8s API server's OIDC discovery endpoint
+ *       (with the SA token for auth) and extracts the real issuer URL. This discovered issuer
+ *       is passed to the validator so the issuer check passes naturally.</li>
+ *   <li>{@link #verifySignature(AbstractJWTClientValidator)} uses {@link UDSKubernetesJwksEndpointLoader} which always
+ *       attaches the SA token, so JWKS loading works on managed clusters.</li>
+ *   <li>The discovered issuer is cached in a static {@link ConcurrentHashMap} because the
+ *       OIDC issuer URL never changes during a cluster's lifetime.</li>
+ * </ul>
+ *
+ * <h2>Why verifySignature is copied</h2>
+ *
+ * The upstream {@code KubernetesIdentityProvider.verifySignature()} is {@code private},
+ * so it cannot be overridden or called via {@code super}. We copy it here and swap in
+ * {@link UDSKubernetesJwksEndpointLoader} to fix the SA token inclusion issue.
+ *
+ * @see UDSKubernetesJwksEndpointLoader
+ * @see UDSFederatedJWTClientValidator
+ * @see com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client.UDSClientAssertionStrategy
+ */
+public class UDSKubernetesIdentityProvider extends KubernetesIdentityProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(UDSKubernetesIdentityProvider.class);
+
+    // Static cache: OIDC issuer URL never changes during a cluster's lifetime.
+    // Keyed by configured issuer URL to support multiple IdP instances.
+    private static final ConcurrentHashMap<String, String> ISSUER_CACHE = new ConcurrentHashMap<>();
+
+    private final KeycloakSession session;
+    private final KubernetesIdentityProviderConfig config;
+
+    public UDSKubernetesIdentityProvider(KeycloakSession session, KubernetesIdentityProviderConfig config) {
+        super(session, config);
+        this.session = session;
+        this.config = config;
+    }
+
+    @Override
+    public boolean verifyClientAssertion(ClientAuthenticationFlowContext context) throws Exception {
+        String discoveredIssuer = discoverIssuer(config.getIssuer());
+
+        UDSFederatedJWTClientValidator validator = new UDSFederatedJWTClientValidator(
+            context, this::verifySignature, discoveredIssuer, config.getAllowedClockSkew(), true
+        );
+        validator.setMaximumExpirationTime(3600);
+        return validator.validate();
+    }
+
+    /**
+     * Discovers the real OIDC issuer from the Kubernetes API server's OIDC discovery endpoint.
+     *
+     * <p>On k3d/self-hosted clusters: returns the same configured issuer (no-op).
+     * On EKS/AKS/GKE: returns the managed cluster's public OIDC issuer URL.
+     *
+     * <p>The SA token is included in the request because managed K8s API servers (notably EKS)
+     * return 401 Unauthorized for unauthenticated requests to the OIDC discovery endpoint
+     * when accessed via the internal {@code kubernetes.default.svc.cluster.local} URL.
+     *
+     * @param kubeApiServerUrl the configured K8s API server URL (e.g. https://kubernetes.default.svc.cluster.local)
+     * @return the discovered issuer URL, or {@code kubeApiServerUrl} as fallback on any failure
+     */
+    String discoverIssuer(String kubeApiServerUrl) {
+        String cached = ISSUER_CACHE.get(kubeApiServerUrl);
+        if (cached != null) {
+            LOGGER.debugf("Using cached OIDC issuer '%s' for K8s API server '%s'", cached, kubeApiServerUrl);
+            return cached;
+        }
+
+        String discovered = fetchIssuerFromOidc(kubeApiServerUrl);
+        // putIfAbsent is atomic -- if another thread raced us, use their result
+        String existing = ISSUER_CACHE.putIfAbsent(kubeApiServerUrl, discovered);
+        return existing != null ? existing : discovered;
+    }
+
+    private String fetchIssuerFromOidc(String kubeApiServerUrl) {
+        String wellKnownEndpoint = kubeApiServerUrl + "/.well-known/openid-configuration";
+        try {
+            String saToken = KubernetesUtils.readServiceAccountToken();
+
+            SimpleHttp simpleHttp = SimpleHttp.create(session);
+            var request = simpleHttp.doGet(wellKnownEndpoint).acceptJson();
+            if (saToken != null) {
+                request.header("Authorization", "Bearer " + saToken);
+            }
+
+            OIDCConfigurationRepresentation oidcConfig = JsonSerialization.readValue(
+                request.asString(), OIDCConfigurationRepresentation.class);
+            String discoveredIssuer = oidcConfig.getIssuer();
+
+            if (discoveredIssuer == null || discoveredIssuer.isEmpty()) {
+                LOGGER.errorf("OIDC discovery from '%s' returned empty issuer, falling back to '%s'",
+                    wellKnownEndpoint, kubeApiServerUrl);
+                return kubeApiServerUrl;
+            }
+
+            if (!discoveredIssuer.startsWith("https://")) {
+                LOGGER.errorf("OIDC discovery from '%s' returned non-HTTPS issuer '%s', falling back to '%s'",
+                    wellKnownEndpoint, discoveredIssuer, kubeApiServerUrl);
+                return kubeApiServerUrl;
+            }
+
+            LOGGER.debugf("Discovered OIDC issuer '%s' for K8s API server '%s'", discoveredIssuer, kubeApiServerUrl);
+            return discoveredIssuer;
+        } catch (Exception e) {
+            LOGGER.errorf(e, "Failed to discover OIDC issuer from '%s', falling back to '%s'",
+                wellKnownEndpoint, kubeApiServerUrl);
+            return kubeApiServerUrl;
+        }
+    }
+
+    /**
+     * Verifies the JWT signature using JWKS from the Kubernetes API server.
+     *
+     * <p>Copied from {@code KubernetesIdentityProvider.verifySignature()} because that method
+     * is {@code private} and cannot be overridden. The only change is using
+     * {@link UDSKubernetesJwksEndpointLoader} instead of the upstream
+     * {@code KubernetesJwksEndpointLoader} to ensure the SA token is always included
+     * in JWKS requests (the upstream loader skips the token when the issuer doesn't match).
+     */
+    private boolean verifySignature(AbstractJWTClientValidator validator) {
+        try {
+            JWSInput jws = validator.getState().getJws();
+            JWSHeader header = jws.getHeader();
+            String kid = header.getKeyId();
+            String alg = header.getRawAlgorithm();
+
+            String modelKey = PublicKeyStorageUtils.getIdpModelCacheKey(
+                validator.getContext().getRealm().getId(), config.getInternalId());
+            PublicKeyStorageProvider keyStorage = session.getProvider(PublicKeyStorageProvider.class);
+            KeyWrapper publicKey = keyStorage.getPublicKey(modelKey, kid, alg,
+                new UDSKubernetesJwksEndpointLoader(session, config.getIssuer()));
+            if (publicKey == null) {
+                LOGGER.warnf("Public key not found for kid='%s', alg='%s'", kid, alg);
+                return false;
+            }
+
+            SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, alg);
+            if (signatureProvider == null) {
+                LOGGER.debugf("Signature provider not found for algorithm '%s'", alg);
+                return false;
+            }
+
+            return signatureProvider.verifier(publicKey)
+                .verify(jws.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), jws.getSignature());
+        } catch (Exception e) {
+            LOGGER.debug("Failed to verify token signature", e);
+            return false;
+        }
+    }
+
+    // Visible for testing
+    static void clearIssuerCache() {
+        ISSUER_CACHE.clear();
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProvider.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProvider.java
@@ -8,8 +8,11 @@ package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jakarta.ws.rs.core.Response;
+import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.ClientAuthenticationFlowContext;
 import org.keycloak.authentication.authenticators.client.AbstractJWTClientValidator;
+import org.keycloak.authentication.authenticators.client.ClientAuthUtil;
 import org.keycloak.broker.kubernetes.KubernetesIdentityProvider;
 import org.keycloak.broker.kubernetes.KubernetesIdentityProviderConfig;
 import org.keycloak.crypto.KeyWrapper;
@@ -25,6 +28,7 @@ import org.keycloak.util.JsonSerialization;
 import com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client.UDSFederatedJWTClientValidator;
 
 import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
 
 import org.jboss.logging.Logger;
 
@@ -95,6 +99,11 @@ public class UDSKubernetesIdentityProvider extends KubernetesIdentityProvider {
     @Override
     public boolean verifyClientAssertion(ClientAuthenticationFlowContext context) throws Exception {
         String discoveredIssuer = discoverIssuer(config.getIssuer());
+        if (discoveredIssuer == null) {
+            Response challengeResponse = ClientAuthUtil.errorResponse(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "server_error", "Failed to discover OIDC issuer from Kubernetes API server");
+            context.failure(AuthenticationFlowError.INTERNAL_ERROR, challengeResponse);
+            return false;
+        }
 
         UDSFederatedJWTClientValidator validator = new UDSFederatedJWTClientValidator(
             context, this::verifySignature, discoveredIssuer, config.getAllowedClockSkew(), true
@@ -124,6 +133,11 @@ public class UDSKubernetesIdentityProvider extends KubernetesIdentityProvider {
         }
 
         String discovered = fetchIssuerFromOidc(kubeApiServerUrl);
+        if (discovered == null) {
+            // Discovery failed -- don't cache, fail the request and let the client retry.
+            // We don't want any fallback in this case as it may produce inconsistent results.
+            return null;
+        }
         // putIfAbsent is atomic -- if another thread raced us, use their result
         String existing = ISSUER_CACHE.putIfAbsent(kubeApiServerUrl, discovered);
         return existing != null ? existing : discovered;
@@ -137,31 +151,39 @@ public class UDSKubernetesIdentityProvider extends KubernetesIdentityProvider {
             SimpleHttp simpleHttp = SimpleHttp.create(session);
             var request = simpleHttp.doGet(wellKnownEndpoint).acceptJson();
             if (saToken != null) {
-                request.header("Authorization", "Bearer " + saToken);
+                request.auth(saToken);
             }
 
-            OIDCConfigurationRepresentation oidcConfig = JsonSerialization.readValue(
-                request.asString(), OIDCConfigurationRepresentation.class);
-            String discoveredIssuer = oidcConfig.getIssuer();
+            try (SimpleHttpResponse response = request.asResponse()) {
+                int status = response.getStatus();
+                if (status < 200 || status >= 300) {
+                    LOGGER.errorf("OIDC discovery from '%s' returned HTTP %d",
+                        wellKnownEndpoint, status);
+                    return null;
+                }
 
-            if (discoveredIssuer == null || discoveredIssuer.isEmpty()) {
-                LOGGER.errorf("OIDC discovery from '%s' returned empty issuer, falling back to '%s'",
-                    wellKnownEndpoint, kubeApiServerUrl);
-                return kubeApiServerUrl;
+                OIDCConfigurationRepresentation oidcConfig = JsonSerialization.readValue(
+                    response.asString(), OIDCConfigurationRepresentation.class);
+                String discoveredIssuer = oidcConfig.getIssuer();
+
+                if (discoveredIssuer == null || discoveredIssuer.isEmpty()) {
+                    LOGGER.errorf("OIDC discovery from '%s' returned empty issuer",
+                        wellKnownEndpoint);
+                    return null;
+                }
+
+                if (!discoveredIssuer.startsWith("https://")) {
+                    LOGGER.errorf("OIDC discovery from '%s' returned non-HTTPS issuer '%s'",
+                        wellKnownEndpoint, discoveredIssuer);
+                    return null;
+                }
+
+                LOGGER.infof("Discovered OIDC issuer '%s' for K8s API server '%s'", discoveredIssuer, kubeApiServerUrl);
+                return discoveredIssuer;
             }
-
-            if (!discoveredIssuer.startsWith("https://")) {
-                LOGGER.errorf("OIDC discovery from '%s' returned non-HTTPS issuer '%s', falling back to '%s'",
-                    wellKnownEndpoint, discoveredIssuer, kubeApiServerUrl);
-                return kubeApiServerUrl;
-            }
-
-            LOGGER.debugf("Discovered OIDC issuer '%s' for K8s API server '%s'", discoveredIssuer, kubeApiServerUrl);
-            return discoveredIssuer;
         } catch (Exception e) {
-            LOGGER.errorf(e, "Failed to discover OIDC issuer from '%s', falling back to '%s'",
-                wellKnownEndpoint, kubeApiServerUrl);
-            return kubeApiServerUrl;
+            LOGGER.errorf(e, "Failed to discover OIDC issuer from '%s'", wellKnownEndpoint);
+            return null;
         }
     }
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProvider.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -123,7 +123,7 @@ public class UDSKubernetesIdentityProvider extends KubernetesIdentityProvider {
      * when accessed via the internal {@code kubernetes.default.svc.cluster.local} URL.
      *
      * @param kubeApiServerUrl the configured K8s API server URL (e.g. https://kubernetes.default.svc.cluster.local)
-     * @return the discovered issuer URL, or {@code kubeApiServerUrl} as fallback on any failure
+     * @return the discovered issuer URL, or {@code null} if OIDC discovery fails
      */
     String discoverIssuer(String kubeApiServerUrl) {
         String cached = ISSUER_CACHE.get(kubeApiServerUrl);

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactory.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import org.keycloak.Config;
+import org.keycloak.broker.kubernetes.KubernetesIdentityProviderConfig;
+import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
+import org.keycloak.broker.provider.ClientAssertionIdentityProviderFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+
+import com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client.UDSClientAssertionStrategy;
+
+/**
+ * Factory for {@link UDSKubernetesIdentityProvider}.
+ *
+ * <p>Registered as a {@link ClientAssertionIdentityProviderFactory} SPI, which causes
+ * Keycloak's {@code FederatedJWTClientAuthenticator.postInit()} to collect our
+ * {@link UDSClientAssertionStrategy} into the strategies list. Because custom strategies
+ * are added before the {@code DefaultClientAssertionStrategy}, our strategy is tried first
+ * for JWT bearer assertions — acting as a superset of the default behavior.
+ *
+ * @see UDSClientAssertionStrategy
+ * @see UDSKubernetesIdentityProvider
+ */
+public class UDSKubernetesIdentityProviderFactory
+        extends AbstractIdentityProviderFactory<UDSKubernetesIdentityProvider>
+        implements ClientAssertionIdentityProviderFactory, EnvironmentDependentProviderFactory {
+
+    public static final String PROVIDER_ID = "uds-kubernetes";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getName() {
+        return "UDS Kubernetes";
+    }
+
+    @Override
+    public UDSKubernetesIdentityProvider create(KeycloakSession session, IdentityProviderModel model) {
+        return new UDSKubernetesIdentityProvider(session, new KubernetesIdentityProviderConfig(model));
+    }
+
+    @Override
+    public IdentityProviderModel createConfig() {
+        return new KubernetesIdentityProviderConfig();
+    }
+
+    @Override
+    public ClientAssertionStrategy getClientAssertionStrategy() {
+        return new UDSClientAssertionStrategy();
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.KUBERNETES_SERVICE_ACCOUNTS);
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactory.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
@@ -5,17 +5,21 @@
 
 package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
 
+import org.keycloak.common.util.UriUtils;
 import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.http.simple.SimpleHttpRequest;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.keys.PublicKeyLoader;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.util.JWKSUtils;
 
 import org.apache.http.HttpHeaders;
+import org.jboss.logging.Logger;
 
 /**
  * JWKS endpoint loader that always includes the service account token in requests.
@@ -50,6 +54,8 @@ import org.apache.http.HttpHeaders;
  */
 public class UDSKubernetesJwksEndpointLoader implements PublicKeyLoader {
 
+    private static final Logger LOGGER = Logger.getLogger(UDSKubernetesJwksEndpointLoader.class);
+
     private final KeycloakSession session;
     private final String issuer;
 
@@ -80,16 +86,41 @@ public class UDSKubernetesJwksEndpointLoader implements PublicKeyLoader {
             throw new IllegalStateException("OIDC discovery at " + wellKnownEndpoint + " returned no jwks_uri");
         }
 
-        // Forwarding a token along with the request is safe here. The Kubernetes API Server issuer is configured at the
-        // bootstrap time with the `--oidc-*` flags. So a successful attack would require controlling these flags
-        // and if that really happens, it's game over already.
-        // So essentially - we're not sacrificing any security here.
         SimpleHttpRequest jwksRequest = simpleHttp.doGet(jwksUri).header(HttpHeaders.ACCEPT, "application/jwk-set+json");
-        if (token != null) {
+        if (token != null && shouldIncludeToken(token, jwksUri)) {
             jwksRequest.auth(token);
         }
 
         JSONWebKeySet jwks = jwksRequest.asJson(JSONWebKeySet.class);
         return JWKSUtils.getKeyWrappersForUse(jwks, JWK.Use.SIG);
+    }
+
+    /**
+     * Determines whether the SA token should be included in the JWKS request by comparing
+     * the token's {@code iss} claim origin against the JWKS URI origin.
+     *
+     * <p>On vanilla Kubernetes both origins are {@code https://kubernetes.default.svc.cluster.local}.
+     * On managed clusters (EKS, AKS, GKE) both origins are the cloud OIDC endpoint
+     * (e.g. {@code https://oidc.eks.*.amazonaws.com}). In either case the token is only sent
+     * to an endpoint belonging to the same authority that issued it.
+     */
+    static boolean shouldIncludeToken(String token, String jwksUri) {
+        try {
+            JWSInput jws = new JWSInput(token);
+            JsonWebToken jwt = jws.readJsonContent(JsonWebToken.class);
+            String tokenIssuer = jwt.getIssuer();
+            if (tokenIssuer == null) {
+                LOGGER.debug("SA token has no issuer claim, skipping auth for JWKS request");
+                return false;
+            }
+
+            String tokenOrigin = UriUtils.getOrigin(tokenIssuer);
+            String jwksOrigin = UriUtils.getOrigin(jwksUri);
+            LOGGER.debugf("SA token issuer origin '%s', JWKS URI origin '%s'", tokenOrigin, jwksOrigin);
+            return tokenOrigin != null && tokenOrigin.equals(jwksOrigin);
+        } catch (Exception e) {
+            LOGGER.debug("Failed to parse SA token to extract issuer, skipping auth for JWKS request", e);
+            return false;
+        }
     }
 }

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import org.keycloak.crypto.PublicKeysWrapper;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.keys.PublicKeyLoader;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.util.JWKSUtils;
+
+import org.apache.http.HttpHeaders;
+
+/**
+ * JWKS endpoint loader that always includes the service account token in requests.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * The upstream {@code KubernetesJwksEndpointLoader.getToken()} only includes the mounted
+ * service account token when its {@code iss} claim matches the configured IdP issuer:
+ * <pre>
+ * if (jwt.getIssuer().equals(issuer)) {
+ *     return token;  // included
+ * } else {
+ *     return null;   // excluded — "issuer mismatch"
+ * }
+ * </pre>
+ *
+ * On managed Kubernetes clusters (EKS, AKS, GKE), the SA token issuer is a cloud-specific URL
+ * (e.g. {@code https://oidc.eks.us-gov-west-1.amazonaws.com/id/...}) while the configured issuer
+ * is {@code https://kubernetes.default.svc.cluster.local}. These never match, so the upstream
+ * loader always excludes the token. Without the token, the K8s API server returns 401 for both
+ * OIDC discovery and JWKS requests, causing signature verification to fail with a
+ * {@code NullPointerException} (null response body).
+ *
+ * <h2>What this loader changes</h2>
+ *
+ * The only difference from upstream is that {@link KubernetesUtils#readServiceAccountToken()}
+ * always returns the SA token if the file exists, without checking the issuer claim. The SA
+ * token is safe to include unconditionally because it's already scoped to the cluster and is
+ * the same token the upstream code would include if the issuer matched.
+ *
+ * @see UDSKubernetesIdentityProvider
+ */
+public class UDSKubernetesJwksEndpointLoader implements PublicKeyLoader {
+
+    private final KeycloakSession session;
+    private final String issuer;
+
+    public UDSKubernetesJwksEndpointLoader(KeycloakSession session, String issuer) {
+        this.session = session;
+        this.issuer = issuer;
+    }
+
+    /**
+     * Loads JWKS public keys from the Kubernetes OIDC endpoint.
+     *
+     * <p>Identical to upstream except it uses {@link KubernetesUtils#readServiceAccountToken()}
+     * which always includes the SA token regardless of issuer match.
+     */
+    @Override
+    public PublicKeysWrapper loadKeys() throws Exception {
+        SimpleHttp simpleHttp = SimpleHttp.create(session);
+        String token = KubernetesUtils.readServiceAccountToken();
+
+        String wellKnownEndpoint = issuer + "/.well-known/openid-configuration";
+
+        SimpleHttpRequest wellKnownRequest = simpleHttp.doGet(wellKnownEndpoint).acceptJson();
+        if (token != null) {
+            wellKnownRequest.auth(token);
+        }
+        String jwksUri = wellKnownRequest.asJson(OIDCConfigurationRepresentation.class).getJwksUri();
+        if (jwksUri == null || jwksUri.isEmpty()) {
+            throw new IllegalStateException("OIDC discovery at " + wellKnownEndpoint + " returned no jwks_uri");
+        }
+
+        // Forwarding a token along with the request is safe here. The Kubernetes API Server issuer is configured at the
+        // bootstrap time with the `--oidc-*` flags. So a successful attack would require controling these flags
+        // and if that really happens, it's game over already.
+        // So essentially - we're not sacrificing any security here.
+        SimpleHttpRequest jwksRequest = simpleHttp.doGet(jwksUri).header(HttpHeaders.ACCEPT, "application/jwk-set+json");
+        if (token != null) {
+            jwksRequest.auth(token);
+        }
+
+        JSONWebKeySet jwks = jwksRequest.asJson(JSONWebKeySet.class);
+        return JWKSUtils.getKeyWrappersForUse(jwks, JWK.Use.SIG);
+    }
+}

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
@@ -1,11 +1,10 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
 package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
 
-import org.keycloak.common.util.UriUtils;
 import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.http.simple.SimpleHttpRequest;
@@ -47,8 +46,9 @@ import org.jboss.logging.Logger;
  *
  * The only difference from upstream is that {@link KubernetesUtils#readServiceAccountToken()}
  * always returns the SA token if the file exists, without checking the issuer claim. The SA
- * token is safe to include unconditionally because it's already scoped to the cluster and is
- * the same token the upstream code would include if the issuer matched.
+ * token is only forwarded to the JWKS endpoint when the token's {@code iss} claim matches the
+ * {@code issuer} field from the OIDC discovery response. This ensures the token is only sent
+ * to endpoints belonging to the same authority that issued it.
  *
  * @see UDSKubernetesIdentityProvider
  */
@@ -81,30 +81,43 @@ public class UDSKubernetesJwksEndpointLoader implements PublicKeyLoader {
         if (token != null) {
             wellKnownRequest.auth(token);
         }
-        String jwksUri = wellKnownRequest.asJson(OIDCConfigurationRepresentation.class).getJwksUri();
+
+        OIDCConfigurationRepresentation oidcConfig = KubernetesUtils.executeAndParse(wellKnownRequest,
+            wellKnownEndpoint, OIDCConfigurationRepresentation.class);
+
+        String jwksUri = oidcConfig.getJwksUri();
         if (jwksUri == null || jwksUri.isEmpty()) {
             throw new IllegalStateException("OIDC discovery at " + wellKnownEndpoint + " returned no jwks_uri");
         }
 
         SimpleHttpRequest jwksRequest = simpleHttp.doGet(jwksUri).header(HttpHeaders.ACCEPT, "application/jwk-set+json");
-        if (token != null && shouldIncludeToken(token, jwksUri)) {
+        if (token != null && shouldIncludeToken(token, oidcConfig.getIssuer())) {
             jwksRequest.auth(token);
         }
 
-        JSONWebKeySet jwks = jwksRequest.asJson(JSONWebKeySet.class);
+        JSONWebKeySet jwks = KubernetesUtils.executeAndParse(jwksRequest, jwksUri, JSONWebKeySet.class);
         return JWKSUtils.getKeyWrappersForUse(jwks, JWK.Use.SIG);
     }
 
     /**
      * Determines whether the SA token should be included in the JWKS request by comparing
-     * the token's {@code iss} claim origin against the JWKS URI origin.
+     * the token's {@code iss} claim against the OIDC discovery {@code issuer} field.
      *
-     * <p>On vanilla Kubernetes both origins are {@code https://kubernetes.default.svc.cluster.local}.
-     * On managed clusters (EKS, AKS, GKE) both origins are the cloud OIDC endpoint
-     * (e.g. {@code https://oidc.eks.*.amazonaws.com}). In either case the token is only sent
-     * to an endpoint belonging to the same authority that issued it.
+     * <p>The OIDC discovery response includes both the {@code issuer} and the {@code jwks_uri}.
+     * When the SA token's {@code iss} matches the discovered {@code issuer}, the token belongs
+     * to the same authority that advertises the JWKS endpoint, so it is safe to forward.
+     * This works across all Kubernetes distributions:
+     * <ul>
+     *   <li>k3d/vanilla: both are {@code https://kubernetes.default.svc.cluster.local}</li>
+     *   <li>EKS: both are {@code https://oidc.eks.*.amazonaws.com/id/...}</li>
+     * </ul>
      */
-    static boolean shouldIncludeToken(String token, String jwksUri) {
+    static boolean shouldIncludeToken(String token, String discoveredIssuer) {
+        if (discoveredIssuer == null) {
+            LOGGER.debug("OIDC discovery returned no issuer, skipping auth for JWKS request");
+            return false;
+        }
+
         try {
             JWSInput jws = new JWSInput(token);
             JsonWebToken jwt = jws.readJsonContent(JsonWebToken.class);
@@ -114,10 +127,10 @@ public class UDSKubernetesJwksEndpointLoader implements PublicKeyLoader {
                 return false;
             }
 
-            String tokenOrigin = UriUtils.getOrigin(tokenIssuer);
-            String jwksOrigin = UriUtils.getOrigin(jwksUri);
-            LOGGER.debugf("SA token issuer origin '%s', JWKS URI origin '%s'", tokenOrigin, jwksOrigin);
-            return tokenOrigin != null && tokenOrigin.equals(jwksOrigin);
+            boolean match = tokenIssuer.equals(discoveredIssuer);
+            LOGGER.debugf("SA token issuer '%s', discovered issuer '%s', including token: %s",
+                tokenIssuer, discoveredIssuer, match);
+            return match;
         } catch (Exception e) {
             LOGGER.debug("Failed to parse SA token to extract issuer, skipping auth for JWKS request", e);
             return false;

--- a/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
+++ b/src/plugin/src/main/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoader.java
@@ -81,7 +81,7 @@ public class UDSKubernetesJwksEndpointLoader implements PublicKeyLoader {
         }
 
         // Forwarding a token along with the request is safe here. The Kubernetes API Server issuer is configured at the
-        // bootstrap time with the `--oidc-*` flags. So a successful attack would require controling these flags
+        // bootstrap time with the `--oidc-*` flags. So a successful attack would require controlling these flags
         // and if that really happens, it's game over already.
         // So essentially - we're not sacrificing any security here.
         SimpleHttpRequest jwksRequest = simpleHttp.doGet(jwksUri).header(HttpHeaders.ACCEPT, "application/jwk-set+json");

--- a/src/plugin/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderFactory
+++ b/src/plugin/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderFactory
@@ -1,0 +1,1 @@
+com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes.UDSKubernetesIdentityProviderFactory

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategyTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -20,6 +20,7 @@ import org.keycloak.authentication.authenticators.client.ClientAssertionState;
 import org.keycloak.broker.provider.ClientAssertionIdentityProviderFactory.LookupResult;
 import org.keycloak.cache.AlternativeLookupProvider;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientProvider;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.IdentityProviderStorageProvider;
 import org.keycloak.models.KeycloakSession;
@@ -49,6 +50,7 @@ public class UDSClientAssertionStrategyTest {
     @Mock private AlternativeLookupProvider lookupProvider;
     @Mock private ClientModel clientModel;
     @Mock private IdentityProviderModel udsIdpModel;
+    @Mock private ClientProvider clientProvider;
     @Mock private IdentityProviderStorageProvider idpStorageProvider;
 
     private UDSClientAssertionStrategy strategy;
@@ -61,6 +63,7 @@ public class UDSClientAssertionStrategyTest {
         when(context.getRealm()).thenReturn(realm);
         when(context.getState(eq(ClientAssertionState.class), any())).thenReturn(state);
         when(session.getProvider(AlternativeLookupProvider.class)).thenReturn(lookupProvider);
+        when(session.clients()).thenReturn(clientProvider);
         when(session.identityProviders()).thenReturn(idpStorageProvider);
 
         when(state.getToken()).thenReturn(token);
@@ -100,7 +103,7 @@ public class UDSClientAssertionStrategyTest {
         when(clientModel.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
         when(clientModel.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
         when(clientModel.getClientId()).thenReturn("uds-operator");
-        when(realm.getClientsStream()).thenReturn(Stream.of(clientModel));
+        when(clientProvider.searchClientsByAttributes(eq(realm), anyMap(), isNull(), isNull())).thenReturn(Stream.of(clientModel));
         when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(udsIdpModel);
 
         LookupResult result = strategy.lookup(context);
@@ -116,7 +119,7 @@ public class UDSClientAssertionStrategyTest {
         when(lookupProvider.lookupIdentityProviderFromIssuer(session, AKS_ISSUER)).thenReturn(null);
 
         // No clients match the subject
-        when(realm.getClientsStream()).thenReturn(Stream.empty());
+        when(clientProvider.searchClientsByAttributes(eq(realm), anyMap(), isNull(), isNull())).thenReturn(Stream.empty());
 
         LookupResult result = strategy.lookup(context);
 
@@ -131,7 +134,7 @@ public class UDSClientAssertionStrategyTest {
         when(clientModel.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
         when(clientModel.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
         when(clientModel.getClientId()).thenReturn("uds-operator");
-        when(realm.getClientsStream()).thenReturn(Stream.of(clientModel));
+        when(clientProvider.searchClientsByAttributes(eq(realm), anyMap(), isNull(), isNull())).thenReturn(Stream.of(clientModel));
         // IdP not found by alias
         when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(null);
 
@@ -148,7 +151,7 @@ public class UDSClientAssertionStrategyTest {
         when(clientModel.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
         when(clientModel.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
         when(clientModel.getClientId()).thenReturn("uds-operator");
-        when(realm.getClientsStream()).thenReturn(Stream.of(clientModel));
+        when(clientProvider.searchClientsByAttributes(eq(realm), anyMap(), isNull(), isNull())).thenReturn(Stream.of(clientModel));
         when(udsIdpModel.isEnabled()).thenReturn(false);
         when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(udsIdpModel);
 
@@ -173,7 +176,7 @@ public class UDSClientAssertionStrategyTest {
         when(client2.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
         when(client2.getClientId()).thenReturn("client-b");
 
-        when(realm.getClientsStream()).thenReturn(Stream.of(client1, client2));
+        when(clientProvider.searchClientsByAttributes(eq(realm), anyMap(), isNull(), isNull())).thenReturn(Stream.of(client1, client2));
         when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(udsIdpModel);
 
         IllegalStateException ex = assertThrows(IllegalStateException.class, () -> strategy.lookup(context));

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategyTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategyTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.ClientAuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.client.ClientAssertionState;
+import org.keycloak.broker.provider.ClientAssertionIdentityProviderFactory.LookupResult;
+import org.keycloak.cache.AlternativeLookupProvider;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderStorageProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.JsonWebToken;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes.UDSKubernetesIdentityProviderFactory;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UDSClientAssertionStrategyTest {
+
+    private static final String SUBJECT = "system:serviceaccount:pepr-system:pepr-uds-core";
+    private static final String K8S_ISSUER = "https://kubernetes.default.svc.cluster.local";
+    private static final String AKS_ISSUER = "https://centralus.oic.prod-aks.azure.com/tenant-id";
+    private static final String IDP_ALIAS = "uds";
+
+    @Mock private ClientAuthenticationFlowContext context;
+    @Mock private KeycloakSession session;
+    @Mock private RealmModel realm;
+    @Mock private ClientAssertionState state;
+    @Mock private JsonWebToken token;
+    @Mock private AlternativeLookupProvider lookupProvider;
+    @Mock private ClientModel clientModel;
+    @Mock private IdentityProviderModel udsIdpModel;
+    @Mock private IdentityProviderStorageProvider idpStorageProvider;
+
+    private UDSClientAssertionStrategy strategy;
+
+    @BeforeEach
+    void setup() throws Exception {
+        strategy = new UDSClientAssertionStrategy();
+
+        when(context.getSession()).thenReturn(session);
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getState(eq(ClientAssertionState.class), any())).thenReturn(state);
+        when(session.getProvider(AlternativeLookupProvider.class)).thenReturn(lookupProvider);
+        when(session.identityProviders()).thenReturn(idpStorageProvider);
+
+        when(state.getToken()).thenReturn(token);
+        when(token.getSubject()).thenReturn(SUBJECT);
+        when(token.getIssuer()).thenReturn(K8S_ISSUER);
+
+        // UDS Kubernetes IdP setup
+        when(udsIdpModel.getProviderId()).thenReturn(UDSKubernetesIdentityProviderFactory.PROVIDER_ID);
+        when(udsIdpModel.isEnabled()).thenReturn(true);
+        when(udsIdpModel.getAlias()).thenReturn(IDP_ALIAS);
+    }
+
+    @Test
+    void testLookupDelegatesToDefaultWhenIssuerMatches() throws Exception {
+        // Default strategy finds IdP by matching issuer
+        IdentityProviderModel matchingIdp = mock(IdentityProviderModel.class);
+        when(matchingIdp.isEnabled()).thenReturn(true);
+        when(matchingIdp.getAlias()).thenReturn(IDP_ALIAS);
+
+        when(lookupProvider.lookupIdentityProviderFromIssuer(session, K8S_ISSUER)).thenReturn(matchingIdp);
+        when(lookupProvider.lookupClientFromClientAttributes(eq(session), anyMap())).thenReturn(clientModel);
+
+        LookupResult result = strategy.lookup(context);
+
+        assertNotNull(result);
+        assertEquals(clientModel, result.clientModel());
+        assertEquals(matchingIdp, result.identityProviderModel());
+    }
+
+    @Test
+    void testLookupFallsBackToProviderTypeWhenIssuerMismatches() throws Exception {
+        // AKS issuer -- default lookup returns null (no matching IdP)
+        when(token.getIssuer()).thenReturn(AKS_ISSUER);
+        when(lookupProvider.lookupIdentityProviderFromIssuer(session, AKS_ISSUER)).thenReturn(null);
+
+        // Fallback: client has matching jwt.credential.sub, and jwt.credential.issuer points to uds-kubernetes IdP
+        when(clientModel.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
+        when(clientModel.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
+        when(clientModel.getClientId()).thenReturn("uds-operator");
+        when(realm.getClientsStream()).thenReturn(Stream.of(clientModel));
+        when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(udsIdpModel);
+
+        LookupResult result = strategy.lookup(context);
+
+        assertNotNull(result);
+        assertEquals(clientModel, result.clientModel());
+        assertEquals(udsIdpModel, result.identityProviderModel());
+    }
+
+    @Test
+    void testLookupReturnsNullWhenNoMatchingClient() throws Exception {
+        when(token.getIssuer()).thenReturn(AKS_ISSUER);
+        when(lookupProvider.lookupIdentityProviderFromIssuer(session, AKS_ISSUER)).thenReturn(null);
+
+        // No clients match the subject
+        when(realm.getClientsStream()).thenReturn(Stream.empty());
+
+        LookupResult result = strategy.lookup(context);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testLookupReturnsNullWhenIdpNotFound() throws Exception {
+        when(token.getIssuer()).thenReturn(AKS_ISSUER);
+        when(lookupProvider.lookupIdentityProviderFromIssuer(session, AKS_ISSUER)).thenReturn(null);
+
+        when(clientModel.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
+        when(clientModel.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
+        when(clientModel.getClientId()).thenReturn("uds-operator");
+        when(realm.getClientsStream()).thenReturn(Stream.of(clientModel));
+        // IdP not found by alias
+        when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(null);
+
+        LookupResult result = strategy.lookup(context);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testLookupSkipsDisabledIdps() throws Exception {
+        when(token.getIssuer()).thenReturn(AKS_ISSUER);
+        when(lookupProvider.lookupIdentityProviderFromIssuer(session, AKS_ISSUER)).thenReturn(null);
+
+        when(clientModel.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
+        when(clientModel.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
+        when(clientModel.getClientId()).thenReturn("uds-operator");
+        when(realm.getClientsStream()).thenReturn(Stream.of(clientModel));
+        when(udsIdpModel.isEnabled()).thenReturn(false);
+        when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(udsIdpModel);
+
+        LookupResult result = strategy.lookup(context);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testIsSupportedAssertionType() {
+        assertTrue(strategy.isSupportedAssertionType(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT));
+        assertFalse(strategy.isSupportedAssertionType("some-other-type"));
+        assertFalse(strategy.isSupportedAssertionType(null));
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategyTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSClientAssertionStrategyTest.java
@@ -158,6 +158,29 @@ public class UDSClientAssertionStrategyTest {
     }
 
     @Test
+    void testLookupThrowsWhenMultipleClientsMatch() throws Exception {
+        when(token.getIssuer()).thenReturn(AKS_ISSUER);
+        when(lookupProvider.lookupIdentityProviderFromIssuer(session, AKS_ISSUER)).thenReturn(null);
+
+        // Two clients with the same jwt.credential.sub
+        ClientModel client1 = mock(ClientModel.class);
+        when(client1.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
+        when(client1.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
+        when(client1.getClientId()).thenReturn("client-a");
+
+        ClientModel client2 = mock(ClientModel.class);
+        when(client2.getAttribute("jwt.credential.sub")).thenReturn(SUBJECT);
+        when(client2.getAttribute("jwt.credential.issuer")).thenReturn(IDP_ALIAS);
+        when(client2.getClientId()).thenReturn("client-b");
+
+        when(realm.getClientsStream()).thenReturn(Stream.of(client1, client2));
+        when(idpStorageProvider.getByAlias(IDP_ALIAS)).thenReturn(udsIdpModel);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> strategy.lookup(context));
+        assertTrue(ex.getMessage().contains("matched 2 clients"));
+    }
+
+    @Test
     void testIsSupportedAssertionType() {
         assertTrue(strategy.isSupportedAssertionType(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT));
         assertFalse(strategy.isSupportedAssertionType("some-other-type"));

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidatorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidatorTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/authentication/authenticators/client/UDSFederatedJWTClientValidatorTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.authentication.authenticators.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.ClientAuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.client.AbstractJWTClientValidator.SignatureValidator;
+import org.keycloak.authentication.authenticators.client.ClientAssertionState;
+import org.keycloak.authentication.authenticators.client.ClientAuthUtil;
+import org.keycloak.common.util.Time;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.services.Urls;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.net.URI;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UDSFederatedJWTClientValidatorTest {
+
+    private static final String EXPECTED_ISSUER = "https://kubernetes.default.svc.cluster.local";
+    private static final String REALM_NAME = "uds";
+    private static final String REALM_ISSUER_URL = "https://keycloak.admin.uds.dev/realms/uds";
+    private static final String CLIENT_ID = "uds-operator";
+    private static final String SUBJECT = "system:serviceaccount:pepr-system:pepr-uds-core";
+
+    @Mock private ClientAuthenticationFlowContext context;
+    @Mock private KeycloakSession session;
+    @Mock private RealmModel realm;
+    @Mock private ClientModel clientModel;
+    @Mock private ClientAssertionState state;
+    @Mock private JsonWebToken token;
+    @Mock private JWSInput jws;
+    @Mock private JWSHeader header;
+    @Mock private HttpRequest httpRequest;
+    @Mock private EventBuilder event;
+    @Mock private UriInfo uriInfo;
+    @Mock private SignatureValidator signatureValidator;
+
+    private MultivaluedMap<String, String> formParams;
+    private MockedStatic<Urls> urlsMock;
+    private MockedStatic<ClientAuthUtil> clientAuthUtilMock;
+
+    @BeforeEach
+    void setup() throws Exception {
+        formParams = new MultivaluedHashMap<>();
+
+        // Mock static methods that require JAX-RS RuntimeDelegate
+        urlsMock = mockStatic(Urls.class);
+        urlsMock.when(() -> Urls.realmIssuer(any(URI.class), anyString())).thenReturn(REALM_ISSUER_URL);
+
+        clientAuthUtilMock = mockStatic(ClientAuthUtil.class);
+        clientAuthUtilMock.when(() -> ClientAuthUtil.errorResponse(anyInt(), anyString(), anyString()))
+            .thenReturn(mock(Response.class));
+
+        // Context mocks
+        when(context.getSession()).thenReturn(session);
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getState(eq(ClientAssertionState.class), any())).thenReturn(state);
+        when(context.getHttpRequest()).thenReturn(httpRequest);
+        when(context.getEvent()).thenReturn(event);
+        when(context.getUriInfo()).thenReturn(uriInfo);
+
+        // Realm
+        when(realm.getName()).thenReturn(REALM_NAME);
+
+        // UriInfo for audience validation
+        when(uriInfo.getBaseUri()).thenReturn(URI.create("https://keycloak.admin.uds.dev"));
+
+        // HTTP Request
+        when(httpRequest.getDecodedFormParameters()).thenReturn(formParams);
+
+        // ClientAssertionState - happy path
+        when(state.getClientAssertionType()).thenReturn(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT);
+        when(state.getClientAssertion()).thenReturn("dummy.jwt.assertion");
+        when(state.getToken()).thenReturn(token);
+        when(state.getJws()).thenReturn(jws);
+        when(state.getClient()).thenReturn(clientModel);
+
+        // Token claims - happy path
+        when(token.getSubject()).thenReturn(SUBJECT);
+        when(token.getIssuer()).thenReturn(EXPECTED_ISSUER);
+        when(token.getExp()).thenReturn((long) Time.currentTime() + 600);
+        when(token.isActive(anyInt())).thenReturn(true);
+        when(token.getIat()).thenReturn(null);
+        when(token.hasAnyAudience(anyList())).thenReturn(true);
+        when(token.getAudience()).thenReturn(new String[]{REALM_ISSUER_URL});
+
+        // JWS header - non-null algorithm required by validateSignatureAlgorithm
+        when(jws.getHeader()).thenReturn(header);
+        when(header.getAlgorithm()).thenReturn(org.keycloak.jose.jws.Algorithm.RS256);
+
+        // Client model
+        when(clientModel.isEnabled()).thenReturn(true);
+        when(clientModel.getClientId()).thenReturn(CLIENT_ID);
+
+        // Signature validator
+        when(signatureValidator.verifySignature(any())).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        urlsMock.close();
+        clientAuthUtilMock.close();
+    }
+
+    @Test
+    void testValidateSucceedsWhenAllChecksPass() throws Exception {
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertTrue(validator.validate());
+    }
+
+    @Test
+    void testValidateSucceedsWhenClientIdParamMismatch() throws Exception {
+        // client_id form param (uds-operator) differs from JWT subject (SA name)
+        // UDS validator logs debug and continues instead of failing
+        formParams.putSingle(OAuth2Constants.CLIENT_ID, "uds-operator");
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertTrue(validator.validate());
+    }
+
+    @Test
+    void testValidateFailsWhenSubjectMissing() throws Exception {
+        when(token.getSubject()).thenReturn(null);
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertFalse(validator.validate());
+    }
+
+    @Test
+    void testValidateFailsWhenIssuerMismatch() throws Exception {
+        when(token.getIssuer()).thenReturn("https://centralus.oic.prod-aks.azure.com/different");
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertFalse(validator.validate());
+    }
+
+    @Test
+    void testValidateFailsWhenClientNotFound() throws Exception {
+        when(state.getClient()).thenReturn(null);
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertFalse(validator.validate());
+        verify(context).failure(eq(AuthenticationFlowError.CLIENT_NOT_FOUND), isNull());
+    }
+
+    @Test
+    void testValidateFailsWhenClientDisabled() throws Exception {
+        when(clientModel.isEnabled()).thenReturn(false);
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertFalse(validator.validate());
+        verify(context).failure(eq(AuthenticationFlowError.CLIENT_DISABLED), isNull());
+    }
+
+    @Test
+    void testValidateFailsWhenSignatureInvalid() throws Exception {
+        when(signatureValidator.verifySignature(any())).thenReturn(false);
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertFalse(validator.validate());
+    }
+
+    @Test
+    void testValidateFailsWhenAssertionTypeMissing() throws Exception {
+        when(state.getClientAssertionType()).thenReturn(null);
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertFalse(validator.validate());
+    }
+
+    @Test
+    void testValidateFailsWhenAssertionMissing() throws Exception {
+        when(state.getClientAssertion()).thenReturn(null);
+
+        UDSFederatedJWTClientValidator validator = createValidator();
+        assertFalse(validator.validate());
+    }
+
+    private UDSFederatedJWTClientValidator createValidator() throws Exception {
+        UDSFederatedJWTClientValidator validator = new UDSFederatedJWTClientValidator(
+            context, signatureValidator, EXPECTED_ISSUER, 0, true
+        );
+        validator.setMaximumExpirationTime(3600);
+        return validator;
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/KubernetesUtilsTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/KubernetesUtilsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.keycloak.broker.kubernetes.KubernetesConstants.SERVICE_ACCOUNT_TOKEN_PATH;
+
+public class KubernetesUtilsTest {
+
+    @Test
+    void testReadServiceAccountTokenReturnsTokenContent(@TempDir Path tempDir) throws Exception {
+        Path tokenFile = tempDir.resolve("token");
+        Files.write(tokenFile, "my-sa-token".getBytes(StandardCharsets.UTF_8));
+
+        try (MockedStatic<java.nio.file.Paths> pathsMock = Mockito.mockStatic(java.nio.file.Paths.class)) {
+            pathsMock.when(() -> java.nio.file.Paths.get(SERVICE_ACCOUNT_TOKEN_PATH))
+                .thenReturn(tokenFile);
+
+            String result = KubernetesUtils.readServiceAccountToken();
+            assertEquals("my-sa-token", result);
+        }
+    }
+
+    @Test
+    void testReadServiceAccountTokenTrimsWhitespace(@TempDir Path tempDir) throws Exception {
+        Path tokenFile = tempDir.resolve("token");
+        Files.write(tokenFile, "my-sa-token\n  ".getBytes(StandardCharsets.UTF_8));
+
+        try (MockedStatic<java.nio.file.Paths> pathsMock = Mockito.mockStatic(java.nio.file.Paths.class)) {
+            pathsMock.when(() -> java.nio.file.Paths.get(SERVICE_ACCOUNT_TOKEN_PATH))
+                .thenReturn(tokenFile);
+
+            String result = KubernetesUtils.readServiceAccountToken();
+            assertEquals("my-sa-token", result);
+        }
+    }
+
+    @Test
+    void testReadServiceAccountTokenReturnsNullWhenFileDoesNotExist(@TempDir Path tempDir) {
+        Path nonExistent = tempDir.resolve("does-not-exist");
+
+        try (MockedStatic<java.nio.file.Paths> pathsMock = Mockito.mockStatic(java.nio.file.Paths.class)) {
+            pathsMock.when(() -> java.nio.file.Paths.get(SERVICE_ACCOUNT_TOKEN_PATH))
+                .thenReturn(nonExistent);
+
+            String result = KubernetesUtils.readServiceAccountToken();
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void testExecuteAndParseReturnsDeserializedBody() throws Exception {
+        SimpleHttpRequest request = mock(SimpleHttpRequest.class);
+        SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+        when(request.asResponse()).thenReturn(response);
+        when(response.getStatus()).thenReturn(200);
+        when(response.asString()).thenReturn("{\"value\":\"hello\"}");
+
+        TestPayload result = KubernetesUtils.executeAndParse(request, "https://example.com", TestPayload.class);
+        assertEquals("hello", result.value);
+    }
+
+    @Test
+    void testExecuteAndParseThrowsOnNon2xx() throws Exception {
+        SimpleHttpRequest request = mock(SimpleHttpRequest.class);
+        SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+        when(request.asResponse()).thenReturn(response);
+        when(response.getStatus()).thenReturn(503);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> KubernetesUtils.executeAndParse(request, "https://example.com/api", TestPayload.class));
+        assertTrue(ex.getMessage().contains("https://example.com/api"));
+        assertTrue(ex.getMessage().contains("503"));
+    }
+
+    /** Simple POJO for JSON deserialization tests. */
+    public static class TestPayload {
+        public String value;
+    }
+
+    @Test
+    void testReadServiceAccountTokenReturnsNullOnException() {
+        try (MockedStatic<java.nio.file.Paths> pathsMock = Mockito.mockStatic(java.nio.file.Paths.class)) {
+            pathsMock.when(() -> java.nio.file.Paths.get(SERVICE_ACCOUNT_TOKEN_PATH))
+                .thenThrow(new RuntimeException("simulated failure"));
+
+            String result = KubernetesUtils.readServiceAccountToken();
+            assertNull(result);
+        }
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactoryTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactoryTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.broker.provider.ClientAssertionIdentityProviderFactory.ClientAssertionStrategy;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UDSKubernetesIdentityProviderFactoryTest {
+
+    @Mock private KeycloakSession session;
+
+    private final UDSKubernetesIdentityProviderFactory factory = new UDSKubernetesIdentityProviderFactory();
+
+    @Test
+    void testGetIdReturnsCorrectProviderId() {
+        assertEquals("uds-kubernetes", factory.getId());
+    }
+
+    @Test
+    void testCreateReturnsUDSKubernetesIdentityProvider() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        model.getConfig().put("issuer", "https://kubernetes.default.svc.cluster.local");
+
+        UDSKubernetesIdentityProvider provider = factory.create(session, model);
+
+        assertNotNull(provider);
+        assertInstanceOf(UDSKubernetesIdentityProvider.class, provider);
+    }
+
+    @Test
+    void testGetClientAssertionStrategyReturnsNonNull() {
+        ClientAssertionStrategy strategy = factory.getClientAssertionStrategy();
+        assertNotNull(strategy);
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.broker.kubernetes.KubernetesIdentityProviderConfig;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UDSKubernetesIdentityProviderTest {
+
+    private static final String K8S_ISSUER = "https://kubernetes.default.svc.cluster.local";
+    private static final String EKS_ISSUER = "https://oidc.eks.us-gov-west-1.amazonaws.com/id/ABC123";
+
+    @Mock private KeycloakSession session;
+
+    private UDSKubernetesIdentityProvider provider;
+
+    @BeforeEach
+    void setup() {
+        UDSKubernetesIdentityProvider.clearIssuerCache();
+
+        IdentityProviderModel model = new IdentityProviderModel();
+        model.getConfig().put("issuer", K8S_ISSUER);
+        KubernetesIdentityProviderConfig config = new KubernetesIdentityProviderConfig(model);
+
+        provider = new UDSKubernetesIdentityProvider(session, config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        UDSKubernetesIdentityProvider.clearIssuerCache();
+    }
+
+    @Test
+    void testDiscoverIssuerReturnsDiscoveredIssuer() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"" + EKS_ISSUER + "\"}");
+
+            String result = provider.discoverIssuer(K8S_ISSUER);
+
+            assertEquals(EKS_ISSUER, result);
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerCachesResult() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            SimpleHttp mockHttp = setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"" + EKS_ISSUER + "\"}");
+
+            String result1 = provider.discoverIssuer(K8S_ISSUER);
+            assertEquals(EKS_ISSUER, result1);
+
+            // Second call should use cache -- no additional HTTP call
+            String result2 = provider.discoverIssuer(K8S_ISSUER);
+            assertEquals(EKS_ISSUER, result2);
+
+            verify(mockHttp, times(1)).doGet(anyString());
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerFallsBackOnFailure() {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+            when(mockHttp.doGet(anyString())).thenThrow(new RuntimeException("Connection refused"));
+
+            String result = provider.discoverIssuer(K8S_ISSUER);
+
+            assertEquals(K8S_ISSUER, result);
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerRejectsNonHttpsIssuer() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"http://insecure-issuer.example.com\"}");
+
+            String result = provider.discoverIssuer(K8S_ISSUER);
+
+            assertEquals(K8S_ISSUER, result);
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerRejectsEmptyIssuer() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"\"}");
+
+            String result = provider.discoverIssuer(K8S_ISSUER);
+
+            assertEquals(K8S_ISSUER, result);
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerRejectsNullIssuer() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            setupMockOidcDiscovery(simpleHttpMock, "{\"jwks_uri\":\"https://example.com/keys\"}");
+
+            String result = provider.discoverIssuer(K8S_ISSUER);
+
+            assertEquals(K8S_ISSUER, result);
+        }
+    }
+
+    /**
+     * Sets up mock SimpleHttp to return a raw JSON string from the OIDC discovery endpoint.
+     * The discoverIssuer method uses asString() + JsonSerialization to parse the response,
+     * so we mock the string response rather than asJson().
+     */
+    private SimpleHttp setupMockOidcDiscovery(MockedStatic<SimpleHttp> simpleHttpMock, String responseBody) throws Exception {
+        SimpleHttp mockHttp = mock(SimpleHttp.class);
+        SimpleHttpRequest mockRequest = mock(SimpleHttpRequest.class);
+
+        simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+        when(mockHttp.doGet(anyString())).thenReturn(mockRequest);
+        when(mockRequest.acceptJson()).thenReturn(mockRequest);
+        when(mockRequest.header(anyString(), anyString())).thenReturn(mockRequest);
+        when(mockRequest.asString()).thenReturn(responseBody);
+
+        return mockHttp;
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.broker.kubernetes.KubernetesIdentityProviderConfig;
 import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.http.simple.SimpleHttpResponse;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.mockito.Mock;
@@ -54,7 +55,7 @@ public class UDSKubernetesIdentityProviderTest {
     @Test
     void testDiscoverIssuerReturnsDiscoveredIssuer() throws Exception {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
-            setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"" + EKS_ISSUER + "\"}");
+            setupMockOidcDiscovery(simpleHttpMock, 200, "{\"issuer\":\"" + EKS_ISSUER + "\"}");
 
             String result = provider.discoverIssuer(K8S_ISSUER);
 
@@ -65,7 +66,7 @@ public class UDSKubernetesIdentityProviderTest {
     @Test
     void testDiscoverIssuerCachesResult() throws Exception {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
-            SimpleHttp mockHttp = setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"" + EKS_ISSUER + "\"}");
+            SimpleHttp mockHttp = setupMockOidcDiscovery(simpleHttpMock, 200, "{\"issuer\":\"" + EKS_ISSUER + "\"}");
 
             String result1 = provider.discoverIssuer(K8S_ISSUER);
             assertEquals(EKS_ISSUER, result1);
@@ -79,7 +80,7 @@ public class UDSKubernetesIdentityProviderTest {
     }
 
     @Test
-    void testDiscoverIssuerFallsBackOnFailure() {
+    void testDiscoverIssuerReturnsNullOnConnectionFailure() {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
@@ -87,57 +88,123 @@ public class UDSKubernetesIdentityProviderTest {
 
             String result = provider.discoverIssuer(K8S_ISSUER);
 
-            assertEquals(K8S_ISSUER, result);
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerDoesNotCacheOnFailure() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            // First call: simulate a connection failure
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+            when(mockHttp.doGet(anyString())).thenThrow(new RuntimeException("Connection refused"));
+
+            String result1 = provider.discoverIssuer(K8S_ISSUER);
+            assertNull(result1, "Should return null on failure");
+
+            // Second call: simulate a successful discovery
+            reset(mockHttp);
+            SimpleHttpRequest mockRequest = mock(SimpleHttpRequest.class);
+            SimpleHttpResponse mockResponse = mock(SimpleHttpResponse.class);
+
+            when(mockHttp.doGet(anyString())).thenReturn(mockRequest);
+            when(mockRequest.acceptJson()).thenReturn(mockRequest);
+            when(mockRequest.auth(anyString())).thenReturn(mockRequest);
+            when(mockRequest.asResponse()).thenReturn(mockResponse);
+            when(mockResponse.getStatus()).thenReturn(200);
+            when(mockResponse.asString()).thenReturn("{\"issuer\":\"" + EKS_ISSUER + "\"}");
+
+            String result2 = provider.discoverIssuer(K8S_ISSUER);
+            assertEquals(EKS_ISSUER, result2, "Should discover after transient failure");
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerReturnsNullOnNon2xxStatus() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            setupMockOidcDiscovery(simpleHttpMock, 401, "Unauthorized");
+
+            String result = provider.discoverIssuer(K8S_ISSUER);
+
+            assertNull(result);
+        }
+    }
+
+    @Test
+    void testDiscoverIssuerDoesNotCacheOnNon2xxStatus() throws Exception {
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
+            // First call: 401
+            SimpleHttp mockHttp = setupMockOidcDiscovery(simpleHttpMock, 401, "Unauthorized");
+
+            String result1 = provider.discoverIssuer(K8S_ISSUER);
+            assertNull(result1, "Should return null on 401");
+
+            // Second call: reconfigure mock for success
+            reset(mockHttp);
+            SimpleHttpRequest mockRequest = mock(SimpleHttpRequest.class);
+            SimpleHttpResponse mockResponse = mock(SimpleHttpResponse.class);
+
+            when(mockHttp.doGet(anyString())).thenReturn(mockRequest);
+            when(mockRequest.acceptJson()).thenReturn(mockRequest);
+            when(mockRequest.auth(anyString())).thenReturn(mockRequest);
+            when(mockRequest.asResponse()).thenReturn(mockResponse);
+            when(mockResponse.getStatus()).thenReturn(200);
+            when(mockResponse.asString()).thenReturn("{\"issuer\":\"" + EKS_ISSUER + "\"}");
+
+            String result2 = provider.discoverIssuer(K8S_ISSUER);
+            assertEquals(EKS_ISSUER, result2, "Should discover after transient 401");
         }
     }
 
     @Test
     void testDiscoverIssuerRejectsNonHttpsIssuer() throws Exception {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
-            setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"http://insecure-issuer.example.com\"}");
+            setupMockOidcDiscovery(simpleHttpMock, 200, "{\"issuer\":\"http://insecure-issuer.example.com\"}");
 
             String result = provider.discoverIssuer(K8S_ISSUER);
 
-            assertEquals(K8S_ISSUER, result);
+            assertNull(result);
         }
     }
 
     @Test
     void testDiscoverIssuerRejectsEmptyIssuer() throws Exception {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
-            setupMockOidcDiscovery(simpleHttpMock, "{\"issuer\":\"\"}");
+            setupMockOidcDiscovery(simpleHttpMock, 200, "{\"issuer\":\"\"}");
 
             String result = provider.discoverIssuer(K8S_ISSUER);
 
-            assertEquals(K8S_ISSUER, result);
+            assertNull(result);
         }
     }
 
     @Test
     void testDiscoverIssuerRejectsNullIssuer() throws Exception {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class)) {
-            setupMockOidcDiscovery(simpleHttpMock, "{\"jwks_uri\":\"https://example.com/keys\"}");
+            setupMockOidcDiscovery(simpleHttpMock, 200, "{\"jwks_uri\":\"https://example.com/keys\"}");
 
             String result = provider.discoverIssuer(K8S_ISSUER);
 
-            assertEquals(K8S_ISSUER, result);
+            assertNull(result);
         }
     }
 
     /**
-     * Sets up mock SimpleHttp to return a raw JSON string from the OIDC discovery endpoint.
-     * The discoverIssuer method uses asString() + JsonSerialization to parse the response,
-     * so we mock the string response rather than asJson().
+     * Sets up mock SimpleHttp to return a response with the given status code and body.
      */
-    private SimpleHttp setupMockOidcDiscovery(MockedStatic<SimpleHttp> simpleHttpMock, String responseBody) throws Exception {
+    private SimpleHttp setupMockOidcDiscovery(MockedStatic<SimpleHttp> simpleHttpMock, int statusCode, String responseBody) throws Exception {
         SimpleHttp mockHttp = mock(SimpleHttp.class);
         SimpleHttpRequest mockRequest = mock(SimpleHttpRequest.class);
+        SimpleHttpResponse mockResponse = mock(SimpleHttpResponse.class);
 
         simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
         when(mockHttp.doGet(anyString())).thenReturn(mockRequest);
         when(mockRequest.acceptJson()).thenReturn(mockRequest);
-        when(mockRequest.header(anyString(), anyString())).thenReturn(mockRequest);
-        when(mockRequest.asString()).thenReturn(responseBody);
+        when(mockRequest.auth(anyString())).thenReturn(mockRequest);
+        when(mockRequest.asResponse()).thenReturn(mockResponse);
+        when(mockResponse.getStatus()).thenReturn(statusCode);
+        when(mockResponse.asString()).thenReturn(responseBody);
 
         return mockHttp;
     }

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesIdentityProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
@@ -98,4 +98,65 @@ public class UDSKubernetesJwksEndpointLoaderTest {
             assertTrue(ex.getMessage().contains("returned no jwks_uri"));
         }
     }
+
+    @Test
+    void testLoadKeysThrowsOnEmptyJwksUri() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setJwksUri("");
+
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+
+            IllegalStateException ex = assertThrows(IllegalStateException.class, loader::loadKeys);
+            assertTrue(ex.getMessage().contains("returned no jwks_uri"));
+        }
+    }
+
+    @Test
+    void testLoadKeysSkipsAuthWhenNoSaToken() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(null);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setJwksUri(JWKS_URI);
+
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            JSONWebKeySet jwks = new JSONWebKeySet();
+            jwks.setKeys(new JWK[0]);
+
+            when(mockHttp.doGet(JWKS_URI)).thenReturn(jwksRequest);
+            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
+            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
+
+            PublicKeysWrapper result = loader.loadKeys();
+
+            assertNotNull(result);
+            verify(wellKnownRequest, never()).auth(anyString());
+            verify(jwksRequest, never()).auth(anyString());
+        }
+    }
 }

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.crypto.PublicKeysWrapper;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UDSKubernetesJwksEndpointLoaderTest {
+
+    private static final String ISSUER = "https://kubernetes.default.svc.cluster.local";
+    private static final String WELL_KNOWN = ISSUER + "/.well-known/openid-configuration";
+    private static final String JWKS_URI = ISSUER + "/openid/v1/jwks";
+    private static final String SA_TOKEN = "my-sa-token";
+
+    @Mock private KeycloakSession session;
+
+    @Test
+    void testLoadKeysReturnsKeysFromJwksEndpoint() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            // Mock OIDC discovery endpoint
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setJwksUri(JWKS_URI);
+
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+
+            // Mock JWKS endpoint
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            JSONWebKeySet jwks = new JSONWebKeySet();
+            jwks.setKeys(new JWK[0]);
+
+            when(mockHttp.doGet(JWKS_URI)).thenReturn(jwksRequest);
+            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
+            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
+
+            PublicKeysWrapper result = loader.loadKeys();
+
+            assertNotNull(result);
+            verify(wellKnownRequest).auth(SA_TOKEN);
+            verify(jwksRequest).auth(SA_TOKEN);
+        }
+    }
+
+    @Test
+    void testLoadKeysThrowsOnNullJwksUri() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            // Mock OIDC discovery returning no jwks_uri
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            // jwksUri is null by default
+
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+
+            IllegalStateException ex = assertThrows(IllegalStateException.class, loader::loadKeys);
+            assertTrue(ex.getMessage().contains("returned no jwks_uri"));
+        }
+    }
+}

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Base64;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.crypto.PublicKeysWrapper;
@@ -31,23 +33,35 @@ public class UDSKubernetesJwksEndpointLoaderTest {
     private static final String ISSUER = "https://kubernetes.default.svc.cluster.local";
     private static final String WELL_KNOWN = ISSUER + "/.well-known/openid-configuration";
     private static final String JWKS_URI = ISSUER + "/openid/v1/jwks";
-    private static final String SA_TOKEN = "my-sa-token";
+    private static final String EKS_ISSUER = "https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE";
+    private static final String EKS_JWKS_URI = EKS_ISSUER + "/keys";
+
+    /** Builds a minimal unsigned JWT (header.payload.signature) with the given issuer claim. */
+    private static String buildTokenWithIssuer(String issuer) {
+        String header = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("{\"alg\":\"none\"}".getBytes());
+        String payload = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(("{\"iss\":\"" + issuer + "\",\"sub\":\"system:serviceaccount:ns:sa\"}").getBytes());
+        return header + "." + payload + ".";
+    }
+
+    private static final String K8S_SA_TOKEN = buildTokenWithIssuer(ISSUER);
+    private static final String EKS_SA_TOKEN = buildTokenWithIssuer(EKS_ISSUER);
 
     @Mock private KeycloakSession session;
 
     @Test
-    void testLoadKeysReturnsKeysFromJwksEndpoint() throws Exception {
+    void testLoadKeysSameOriginTokenIncluded() throws Exception {
         UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
 
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
              MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
 
-            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(SA_TOKEN);
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
 
-            // Mock OIDC discovery endpoint
             SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
             oidcConfig.setJwksUri(JWKS_URI);
@@ -56,7 +70,6 @@ public class UDSKubernetesJwksEndpointLoaderTest {
             when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
             when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
 
-            // Mock JWKS endpoint
             SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
             JSONWebKeySet jwks = new JSONWebKeySet();
             jwks.setKeys(new JWK[0]);
@@ -68,8 +81,84 @@ public class UDSKubernetesJwksEndpointLoaderTest {
             PublicKeysWrapper result = loader.loadKeys();
 
             assertNotNull(result);
-            verify(wellKnownRequest).auth(SA_TOKEN);
-            verify(jwksRequest).auth(SA_TOKEN);
+            verify(wellKnownRequest).auth(K8S_SA_TOKEN);
+            verify(jwksRequest).auth(K8S_SA_TOKEN);
+        }
+    }
+
+    @Test
+    void testLoadKeysEksSameOriginTokenIncluded() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+
+            // EKS token: iss matches the EKS JWKS URI origin
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(EKS_SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setJwksUri(EKS_JWKS_URI);
+
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            JSONWebKeySet jwks = new JSONWebKeySet();
+            jwks.setKeys(new JWK[0]);
+
+            when(mockHttp.doGet(EKS_JWKS_URI)).thenReturn(jwksRequest);
+            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
+            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
+
+            PublicKeysWrapper result = loader.loadKeys();
+
+            assertNotNull(result);
+            verify(wellKnownRequest).auth(EKS_SA_TOKEN);
+            // Token issuer matches JWKS URI origin — token IS included
+            verify(jwksRequest).auth(EKS_SA_TOKEN);
+        }
+    }
+
+    @Test
+    void testLoadKeysCrossOriginTokenNotIncluded() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+
+            // K8s-issued token (iss=kubernetes.default.svc) but JWKS URI points to EKS
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setJwksUri(EKS_JWKS_URI);
+
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            JSONWebKeySet jwks = new JSONWebKeySet();
+            jwks.setKeys(new JWK[0]);
+
+            when(mockHttp.doGet(EKS_JWKS_URI)).thenReturn(jwksRequest);
+            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
+            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
+
+            PublicKeysWrapper result = loader.loadKeys();
+
+            assertNotNull(result);
+            verify(wellKnownRequest).auth(K8S_SA_TOKEN);
+            // Token issuer does NOT match JWKS URI origin — token is NOT sent
+            verify(jwksRequest, never()).auth(anyString());
         }
     }
 
@@ -80,15 +169,13 @@ public class UDSKubernetesJwksEndpointLoaderTest {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
              MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
 
-            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(SA_TOKEN);
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
 
-            // Mock OIDC discovery returning no jwks_uri
             SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
-            // jwksUri is null by default
 
             when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
             when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
@@ -106,7 +193,7 @@ public class UDSKubernetesJwksEndpointLoaderTest {
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
              MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
 
-            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(SA_TOKEN);
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
@@ -158,5 +245,41 @@ public class UDSKubernetesJwksEndpointLoaderTest {
             verify(wellKnownRequest, never()).auth(anyString());
             verify(jwksRequest, never()).auth(anyString());
         }
+    }
+
+    @Test
+    void testShouldIncludeTokenSameOrigin() {
+        assertTrue(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
+            K8S_SA_TOKEN, JWKS_URI));
+    }
+
+    @Test
+    void testShouldIncludeTokenEksSameOrigin() {
+        assertTrue(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
+            EKS_SA_TOKEN, EKS_JWKS_URI));
+    }
+
+    @Test
+    void testShouldIncludeTokenCrossOrigin() {
+        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
+            K8S_SA_TOKEN, EKS_JWKS_URI));
+    }
+
+    @Test
+    void testShouldIncludeTokenMalformedToken() {
+        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
+            "not-a-jwt", JWKS_URI));
+    }
+
+    @Test
+    void testShouldIncludeTokenNoIssuer() {
+        String header = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("{\"alg\":\"none\"}".getBytes());
+        String payload = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("{\"sub\":\"test\"}".getBytes());
+        String tokenWithoutIss = header + "." + payload + ".";
+
+        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
+            tokenWithoutIss, JWKS_URI));
     }
 }

--- a/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
+++ b/src/plugin/src/test/java/com/defenseunicorns/uds/keycloak/plugin/broker/kubernetes/UDSKubernetesJwksEndpointLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -8,6 +8,7 @@ package com.defenseunicorns.uds.keycloak.plugin.broker.kubernetes;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
 import java.util.Base64;
 
@@ -16,10 +17,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.http.simple.SimpleHttpResponse;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.util.JsonSerialization;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -33,10 +36,10 @@ public class UDSKubernetesJwksEndpointLoaderTest {
     private static final String ISSUER = "https://kubernetes.default.svc.cluster.local";
     private static final String WELL_KNOWN = ISSUER + "/.well-known/openid-configuration";
     private static final String JWKS_URI = ISSUER + "/openid/v1/jwks";
+    private static final String K3D_JWKS_URI = "https://172.18.0.3:6443/openid/v1/jwks";
     private static final String EKS_ISSUER = "https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE";
     private static final String EKS_JWKS_URI = EKS_ISSUER + "/keys";
 
-    /** Builds a minimal unsigned JWT (header.payload.signature) with the given issuer claim. */
     private static String buildTokenWithIssuer(String issuer) {
         String header = Base64.getUrlEncoder().withoutPadding()
             .encodeToString("{\"alg\":\"none\"}".getBytes());
@@ -50,33 +53,51 @@ public class UDSKubernetesJwksEndpointLoaderTest {
 
     @Mock private KeycloakSession session;
 
+    private SimpleHttpResponse buildResponse(int status, Object body) throws Exception {
+        SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+        when(response.getStatus()).thenReturn(status);
+        if (body != null) {
+            when(response.asString()).thenReturn(JsonSerialization.writeValueAsString(body));
+        }
+        return response;
+    }
+
+    private SimpleHttpResponse buildResponse(int status) throws Exception {
+        return buildResponse(status, null);
+    }
+
+    // --- loadKeys integration tests ---
+
     @Test
-    void testLoadKeysSameOriginTokenIncluded() throws Exception {
+    void testLoadKeysVanillaK8s() throws Exception {
         UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
 
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
-             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
 
             kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
 
-            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setIssuer(ISSUER);
             oidcConfig.setJwksUri(JWKS_URI);
+            SimpleHttpResponse wellKnownResponse = buildResponse(200, oidcConfig);
 
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
             when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
-            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
 
-            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
             JSONWebKeySet jwks = new JSONWebKeySet();
             jwks.setKeys(new JWK[0]);
+            SimpleHttpResponse jwksResponse = buildResponse(200, jwks);
 
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
             when(mockHttp.doGet(JWKS_URI)).thenReturn(jwksRequest);
             when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
-            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
+            when(jwksRequest.asResponse()).thenReturn(jwksResponse);
 
             PublicKeysWrapper result = loader.loadKeys();
 
@@ -87,77 +108,118 @@ public class UDSKubernetesJwksEndpointLoaderTest {
     }
 
     @Test
-    void testLoadKeysEksSameOriginTokenIncluded() throws Exception {
+    void testLoadKeysK3dWithIpJwksUri() throws Exception {
         UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
 
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
-             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
 
-            // EKS token: iss matches the EKS JWKS URI origin
-            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(EKS_SA_TOKEN);
-
-            SimpleHttp mockHttp = mock(SimpleHttp.class);
-            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
-
-            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
-            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
-            oidcConfig.setJwksUri(EKS_JWKS_URI);
-
-            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
-            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
-            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
-
-            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
-            JSONWebKeySet jwks = new JSONWebKeySet();
-            jwks.setKeys(new JWK[0]);
-
-            when(mockHttp.doGet(EKS_JWKS_URI)).thenReturn(jwksRequest);
-            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
-            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
-
-            PublicKeysWrapper result = loader.loadKeys();
-
-            assertNotNull(result);
-            verify(wellKnownRequest).auth(EKS_SA_TOKEN);
-            // Token issuer matches JWKS URI origin — token IS included
-            verify(jwksRequest).auth(EKS_SA_TOKEN);
-        }
-    }
-
-    @Test
-    void testLoadKeysCrossOriginTokenNotIncluded() throws Exception {
-        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
-
-        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
-             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
-
-            // K8s-issued token (iss=kubernetes.default.svc) but JWKS URI points to EKS
             kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
 
-            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
-            oidcConfig.setJwksUri(EKS_JWKS_URI);
+            oidcConfig.setIssuer(ISSUER);
+            oidcConfig.setJwksUri(K3D_JWKS_URI);
+            SimpleHttpResponse wellKnownResponse = buildResponse(200, oidcConfig);
 
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
             when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
-            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
 
-            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
             JSONWebKeySet jwks = new JSONWebKeySet();
             jwks.setKeys(new JWK[0]);
+            SimpleHttpResponse jwksResponse = buildResponse(200, jwks);
 
-            when(mockHttp.doGet(EKS_JWKS_URI)).thenReturn(jwksRequest);
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            when(mockHttp.doGet(K3D_JWKS_URI)).thenReturn(jwksRequest);
             when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
-            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
+            when(jwksRequest.asResponse()).thenReturn(jwksResponse);
 
             PublicKeysWrapper result = loader.loadKeys();
 
             assertNotNull(result);
             verify(wellKnownRequest).auth(K8S_SA_TOKEN);
-            // Token issuer does NOT match JWKS URI origin — token is NOT sent
+            verify(jwksRequest).auth(K8S_SA_TOKEN);
+        }
+    }
+
+    @Test
+    void testLoadKeysEksTokenIncluded() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
+
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(EKS_SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setIssuer(EKS_ISSUER);
+            oidcConfig.setJwksUri(EKS_JWKS_URI);
+            SimpleHttpResponse wellKnownResponse = buildResponse(200, oidcConfig);
+
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
+
+            JSONWebKeySet jwks = new JSONWebKeySet();
+            jwks.setKeys(new JWK[0]);
+            SimpleHttpResponse jwksResponse = buildResponse(200, jwks);
+
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            when(mockHttp.doGet(EKS_JWKS_URI)).thenReturn(jwksRequest);
+            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
+            when(jwksRequest.asResponse()).thenReturn(jwksResponse);
+
+            PublicKeysWrapper result = loader.loadKeys();
+
+            assertNotNull(result);
+            verify(wellKnownRequest).auth(EKS_SA_TOKEN);
+            verify(jwksRequest).auth(EKS_SA_TOKEN);
+        }
+    }
+
+    @Test
+    void testLoadKeysCrossIssuerTokenNotIncluded() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
+
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setIssuer(EKS_ISSUER);
+            oidcConfig.setJwksUri(EKS_JWKS_URI);
+            SimpleHttpResponse wellKnownResponse = buildResponse(200, oidcConfig);
+
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
+
+            JSONWebKeySet jwks = new JSONWebKeySet();
+            jwks.setKeys(new JWK[0]);
+            SimpleHttpResponse jwksResponse = buildResponse(200, jwks);
+
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            when(mockHttp.doGet(EKS_JWKS_URI)).thenReturn(jwksRequest);
+            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
+            when(jwksRequest.asResponse()).thenReturn(jwksResponse);
+
+            PublicKeysWrapper result = loader.loadKeys();
+
+            assertNotNull(result);
+            verify(wellKnownRequest).auth(K8S_SA_TOKEN);
             verify(jwksRequest, never()).auth(anyString());
         }
     }
@@ -167,19 +229,21 @@ public class UDSKubernetesJwksEndpointLoaderTest {
         UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
 
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
-             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
 
             kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
 
-            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setIssuer(ISSUER);
+            SimpleHttpResponse wellKnownResponse = buildResponse(200, oidcConfig);
 
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
             when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
-            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
 
             IllegalStateException ex = assertThrows(IllegalStateException.class, loader::loadKeys);
             assertTrue(ex.getMessage().contains("returned no jwks_uri"));
@@ -187,27 +251,60 @@ public class UDSKubernetesJwksEndpointLoaderTest {
     }
 
     @Test
-    void testLoadKeysThrowsOnEmptyJwksUri() throws Exception {
+    void testLoadKeysThrowsOnWellKnownNon200() throws Exception {
         UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
 
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
-             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
 
             kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
 
-            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
-            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
-            oidcConfig.setJwksUri("");
+            SimpleHttpResponse wellKnownResponse = buildResponse(401);
 
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
             when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
-            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
 
             IllegalStateException ex = assertThrows(IllegalStateException.class, loader::loadKeys);
-            assertTrue(ex.getMessage().contains("returned no jwks_uri"));
+            assertTrue(ex.getMessage().contains("returned HTTP 401"));
+        }
+    }
+
+    @Test
+    void testLoadKeysThrowsOnJwksNon200() throws Exception {
+        UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
+
+        try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
+
+            kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(K8S_SA_TOKEN);
+
+            SimpleHttp mockHttp = mock(SimpleHttp.class);
+            simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
+
+            OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setIssuer(ISSUER);
+            oidcConfig.setJwksUri(JWKS_URI);
+            SimpleHttpResponse wellKnownResponse = buildResponse(200, oidcConfig);
+
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
+            when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
+
+            SimpleHttpResponse jwksResponse = buildResponse(403);
+
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
+            when(mockHttp.doGet(JWKS_URI)).thenReturn(jwksRequest);
+            when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
+            when(jwksRequest.asResponse()).thenReturn(jwksResponse);
+
+            IllegalStateException ex = assertThrows(IllegalStateException.class, loader::loadKeys);
+            assertTrue(ex.getMessage().contains("returned HTTP 403"));
         }
     }
 
@@ -216,28 +313,31 @@ public class UDSKubernetesJwksEndpointLoaderTest {
         UDSKubernetesJwksEndpointLoader loader = new UDSKubernetesJwksEndpointLoader(session, ISSUER);
 
         try (MockedStatic<SimpleHttp> simpleHttpMock = mockStatic(SimpleHttp.class);
-             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class)) {
+             MockedStatic<KubernetesUtils> kubeUtilsMock = mockStatic(KubernetesUtils.class, CALLS_REAL_METHODS)) {
 
             kubeUtilsMock.when(KubernetesUtils::readServiceAccountToken).thenReturn(null);
 
             SimpleHttp mockHttp = mock(SimpleHttp.class);
             simpleHttpMock.when(() -> SimpleHttp.create(session)).thenReturn(mockHttp);
 
-            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             OIDCConfigurationRepresentation oidcConfig = new OIDCConfigurationRepresentation();
+            oidcConfig.setIssuer(ISSUER);
             oidcConfig.setJwksUri(JWKS_URI);
+            SimpleHttpResponse wellKnownResponse = buildResponse(200, oidcConfig);
 
+            SimpleHttpRequest wellKnownRequest = mock(SimpleHttpRequest.class);
             when(mockHttp.doGet(WELL_KNOWN)).thenReturn(wellKnownRequest);
             when(wellKnownRequest.acceptJson()).thenReturn(wellKnownRequest);
-            when(wellKnownRequest.asJson(OIDCConfigurationRepresentation.class)).thenReturn(oidcConfig);
+            when(wellKnownRequest.asResponse()).thenReturn(wellKnownResponse);
 
-            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
             JSONWebKeySet jwks = new JSONWebKeySet();
             jwks.setKeys(new JWK[0]);
+            SimpleHttpResponse jwksResponse = buildResponse(200, jwks);
 
+            SimpleHttpRequest jwksRequest = mock(SimpleHttpRequest.class);
             when(mockHttp.doGet(JWKS_URI)).thenReturn(jwksRequest);
             when(jwksRequest.header(anyString(), anyString())).thenReturn(jwksRequest);
-            when(jwksRequest.asJson(JSONWebKeySet.class)).thenReturn(jwks);
+            when(jwksRequest.asResponse()).thenReturn(jwksResponse);
 
             PublicKeysWrapper result = loader.loadKeys();
 
@@ -247,39 +347,41 @@ public class UDSKubernetesJwksEndpointLoaderTest {
         }
     }
 
+    // --- shouldIncludeToken unit tests ---
+
     @Test
-    void testShouldIncludeTokenSameOrigin() {
-        assertTrue(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
-            K8S_SA_TOKEN, JWKS_URI));
+    void testShouldIncludeTokenMatchingIssuers() {
+        assertTrue(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(K8S_SA_TOKEN, ISSUER));
     }
 
     @Test
-    void testShouldIncludeTokenEksSameOrigin() {
-        assertTrue(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
-            EKS_SA_TOKEN, EKS_JWKS_URI));
+    void testShouldIncludeTokenEksMatchingIssuers() {
+        assertTrue(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(EKS_SA_TOKEN, EKS_ISSUER));
     }
 
     @Test
-    void testShouldIncludeTokenCrossOrigin() {
-        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
-            K8S_SA_TOKEN, EKS_JWKS_URI));
+    void testShouldIncludeTokenMismatchedIssuers() {
+        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(K8S_SA_TOKEN, EKS_ISSUER));
     }
 
     @Test
     void testShouldIncludeTokenMalformedToken() {
-        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
-            "not-a-jwt", JWKS_URI));
+        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken("not-a-jwt", ISSUER));
     }
 
     @Test
-    void testShouldIncludeTokenNoIssuer() {
+    void testShouldIncludeTokenNoIssuerInToken() {
         String header = Base64.getUrlEncoder().withoutPadding()
             .encodeToString("{\"alg\":\"none\"}".getBytes());
         String payload = Base64.getUrlEncoder().withoutPadding()
             .encodeToString("{\"sub\":\"test\"}".getBytes());
         String tokenWithoutIss = header + "." + payload + ".";
 
-        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(
-            tokenWithoutIss, JWKS_URI));
+        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(tokenWithoutIss, ISSUER));
+    }
+
+    @Test
+    void testShouldIncludeTokenNullDiscoveredIssuer() {
+        assertFalse(UDSKubernetesJwksEndpointLoader.shouldIncludeToken(K8S_SA_TOKEN, null));
     }
 }

--- a/src/realm.json5
+++ b/src/realm.json5
@@ -882,7 +882,7 @@
                 "use.jwks.url": "false",
                 "backchannel.logout.revoke.offline.tokens": "false",
                 "jwt.credential.sub": "system:serviceaccount:pepr-system:pepr-uds-core",
-                "jwt.credential.issuer": "kubernetes"
+                "jwt.credential.issuer": "uds"
             },
             "fullScopeAllowed": true
         },
@@ -1937,9 +1937,9 @@
     "adminEventsDetailsEnabled": true,
     "identityProviders": [
         {
-            "alias": "kubernetes",
+            "alias": "uds",
             "internalId": "31314c45-48d0-4bdf-8710-ce16073ded30",
-            "providerId": "kubernetes",
+            "providerId": "uds-kubernetes",
             "enabled": true,
             "hideOnLogin": true,
             "config": {

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -130,7 +130,7 @@ tasks:
     description: "Clone UDS Core for integration testing"
     actions:
       - cmd: rm -rf uds-core
-      - cmd: git clone --branch main https://github.com/defenseunicorns/uds-core.git
+      - cmd: git clone --branch sebastianlaskawiec/core-152-use-signed-jwts-for-uds-operator-2 https://github.com/defenseunicorns/uds-core.git
 
   - name: build-deploy-custom-slim
     description: "Build/Deploy custom slim dev bundle for integration testing"


### PR DESCRIPTION
## Description

This Pull Request attempts to re-introduce the Signed JWTs into the UDS Core with a custom - UDS Identity Provider.

The approach in this PR differs from the upstream as the upstream assumes Kubernetes **IS** the IdP that issues Service Account Tokens. This doesn't have to be the truth in case of managed Kubernetes installation that may use a centralized IdP (e.g. Azure will use Entra etc). 

If such a 3rd party IdP integration is used, the Kubernetes JWKS url correctly points the keys (so the signature validation is not impacted) but the OIDC Discovery endpoint points to that 3rd party:

```
$ kubectl get --raw /.well-known/openid-configuration | jq
{
  "issuer": "https://oidc.eks.<MASKED>.amazonaws.com/id/<MASKED>",
  "jwks_uri": "https://oidc.eks.<MASKED>amazonaws.com/id/<MASKED>/keys",
  "response_types_supported": [
    "id_token"
  ],
  "subject_types_supported": [
    "public"
  ],
  "id_token_signing_alg_values_supported": [
    "RS256"
  ]
}
```

This means, we need to take a different approach - the Client Assertions validation need to first load the OIDC discovery endpoint from Kubernetes, get the issuer and then proceed with the validation based on that obtained issuer. 

## Related Issue

Relates to Relates to https://linear.app/defense-unicorns/issue/CORE-152/use-signed-jwts-for-uds-operator

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed