### PR TITLE
wip: keycloak config cli expirement

### DIFF
--- a/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
+++ b/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
@@ -68,6 +68,14 @@ packages:
             - name: KEYCLOAK_CONFIG_IMAGE
               description: "The keycloak config image to deploy plugin and initial setup configuration"
               path: configImage
+            - name: REALM_IMPORT_ENABLED
+              description: "Toggle Keycloak --import-realm at boot"
+              path: realmImport.enabled
+              default: true
+            - name: REALM_SYNC_ENABLED
+              description: "Toggle keycloak-config-cli realm reconciliation Job"
+              path: realmSync.enabled
+              default: true
           values:
             - path: realmInitEnv
               value:
@@ -93,6 +101,10 @@ packages:
               value:
                 name: JAVA_OPTS_KC_HEAP
                 value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
+            - path: insecureAdminPasswordGeneration.enabled
+              value: true
+            - path: insecureAdminPasswordGeneration.username
+              value: admin
   - name: core-monitoring
     path: ../../uds-core/build/
     # This version will get automatically updated by build-deploy-custom-slim task

--- a/docs/dev/keycloak-config-cli-experiment/findings.md
+++ b/docs/dev/keycloak-config-cli-experiment/findings.md
@@ -1,0 +1,320 @@
+# Findings — callouts for the TDD
+
+Each finding: what we observed, why it matters, and what it implies for the TDD.
+
+---
+
+## F-1 — Variable-substitution syntax: kcc and Keycloak don't share a dialect
+
+**Observed.** TC-1 first-run failed at JSON parse with `IMPORT_VARSUBSTITUTION_ENABLED=true` (kcc default delimiters `$(...)`):
+
+```
+Cannot deserialize value of type `java.lang.Integer` from String
+"${REALM_ACCESS_TOKEN_LIFESPAN:60}"
+```
+
+Tracing kcc internals: it uses Apache commons-text `StringSubstitutor.createInterpolator()`. Two breaking facts about that engine:
+
+1. The colon inside `${...}` is the **lookup-prefix separator** (e.g. `${env:VAR}`, `${file:path}`, `${script:javascript:...}`). It is **not** a default-value separator.
+2. The default value-delimiter is `:-` (commons-text default). kcc never calls `setValueDelimiter`, so the engine treats `${REALM_ACCESS_TOKEN_LIFESPAN:60}` as "lookup with prefix `REALM_ACCESS_TOKEN_LIFESPAN`, key `60`" — fails because no such lookup exists.
+
+Keycloak's own realm-import substitution (`org.keycloak.common.util.StringPropertyReplacer`) uses `${VAR}` and `${VAR:default}` (single colon). Confirmed by reading both engines' source.
+
+The two engines do not agree on the colon's meaning. There is **no single placeholder dialect** — with defaults — that both natively accept. This is documented incompatibility upstream: see kcc issue #412, where the maintainer explains kcc v3 used `${...}` defaults and v4 switched to `$(...)` precisely because of this collision.
+
+**Why it matters.** Our `realm.json` mixes two `${...}` flavors:
+
+- 42 unique env-var placeholders (`${UPPER_CASE[:default]}`) intended to be resolved at deploy time from operator-provided Helm values.
+- 16 unique Keycloak i18n message refs (`${camelCase}` or `${snake_case}`, e.g. `${role_uma_authorization}`, `${addressScopeConsentText}`) that must stay literal so Keycloak renders translations correctly.
+
+Both share the `${ }` delimiter. Letting kcc loose on the file with native syntax errors immediately on the first env-var placeholder.
+
+**Workaround for the experiment (and likely TDD direction).** Rewrite env-var placeholders to kcc-native lookup syntax during build:
+
+- `${VAR}` → `${env:VAR}`
+- `${VAR:default}` → `${env:VAR:-default}`
+
+Leave `${camelCase}` i18n refs untouched.
+
+Then run kcc with:
+
+- `IMPORT_VARSUBSTITUTION_PREFIX='${'`
+- `IMPORT_VARSUBSTITUTION_SUFFIX='}'`
+- `IMPORT_VARSUBSTITUTION_UNDEFINEDISERROR=false` — so the i18n refs (which have no env var to back them) are passed through untouched instead of erroring.
+
+`scripts/to-kcc-syntax.py` performs this rewrite.
+
+**Authoring implication.** The `realm.json5` source itself can stay in Keycloak's native `${VAR:default}` syntax. The conversion happens at build time. This preserves the `--import-realm` boot path that today's chart uses — important if we keep that path for first-install while letting kcc handle subsequent reconciles.
+
+---
+
+## F-2 — Raw realm exports collide with Keycloak's auto-managed resources
+
+**Observed.** With the kcc-native rewrite in place, kcc got past JSON parse but threw HTTP 403 in `RoleCompositeRepository.addClientComposites`:
+
+```
+Error during Keycloak import: HTTP 403 Forbidden
+```
+
+Stack trace pointed at composite role mapping for the built-in `realm-management` client. Specifically: kcc was trying to add `manage-realm`, `manage-users`, etc. as composites of `realm-admin` — but the master `admin` user's transitive permissions for the freshly-created realm aren't sufficient at that exact moment, **and** these mappings are auto-created by Keycloak when the realm is created. They're already there.
+
+The realm.json file is a `kcadm get realms/uds` export, which dumps **everything** including:
+
+- The 6 Keycloak built-in clients (`account`, `account-console`, `admin-cli`, `broker`, `realm-management`, `security-admin-console`).
+- Their composite role mappings.
+- All built-in authentication flows (`builtIn: true`).
+- Built-in client scopes (`role_list`, `email`, `profile`, `phone`, etc.).
+- Default required actions, default event-type sets, key providers, etc.
+
+Keycloak auto-creates and auto-manages all of these; kcc has no way to "win" against them.
+
+**Why it matters.** The SN's scope preface argues UDS owns only the *essential* subset. F-2 is the empirical proof that the boundary catalog (M1) isn't optional — without it, kcc cannot import a realm at all. The catalog isn't a polish step; it's load-bearing.
+
+**Workaround for the experiment.** `scripts/curate.py` strips the 6 built-in clients, their `roles.client` blocks, and any `scopeMappings`/`clientScopeMappings` that reference them. See "Empirical curation log" below for the running tally.
+
+**Implication for the TDD.** M1 must produce a curated `realm.json` (or a build step that emits one) that contains only UDS-essential resources. The curation is non-trivial — the rest of this document is empirical evidence of the corner cases.
+
+---
+
+## F-3 — kcc 6.x does not URL-encode flow aliases on the sub-flow execution endpoint
+
+**Observed.** With the built-in clients curated out, kcc made it into the auth-flow phase and threw HTTP 404:
+
+```
+Cannot create execution 'auth-username-password-form' for non-top-level-flow
+'Username/Password Authentication' in realm 'uds-kcc-test': HTTP 404 Not Found
+```
+
+The flow alias `Username/Password Authentication` contains a literal `/`. kcc constructs the Admin API URL by concatenating the alias into the path without URL-encoding. The slash terminates the path early, the request misses the intended endpoint, and Keycloak returns 404.
+
+**Why it matters.** Our existing `realm.json5` has a flow named `Username/Password Authentication`. It has worked for years with Keycloak's `--import-realm`. Switching to kcc requires either:
+
+- Renaming the flow to remove the `/` (breaking change for any external reference).
+- Patching kcc upstream to URL-encode aliases (small PR, the right long-term fix).
+
+**Workaround for the experiment.** The curator does a global string-replace `Username/Password Authentication` → `Username-Password Authentication` covering the alias and every `flowAlias` reference.
+
+**Implication for the TDD.** Either we rename in `realm.json5` (bigger blast radius — affects existing realms in the field) and ship the rename in a single release, or we contribute the URL-encoding fix upstream and gate on it landing. A small upstream PR is the cleaner answer.
+
+---
+
+## F-4 — Keycloak Admin API refuses to "create" any flow with `builtIn: true`
+
+**Observed.** After the rename in F-3, kcc threw:
+
+```
+Cannot create flow 'Authentication Options' in realm 'uds-kcc-test':
+Unable to create built-in flows.
+```
+
+Reading kcc issue #1251 and Keycloak PR #19794: post-Keycloak 21, the Admin API explicitly refuses to *create* flows whose `builtIn` field is true. Keycloak owns its built-ins; you cannot manage them from outside.
+
+Realm exports include all built-ins regardless. When kcc walks `authenticationFlows[]` and hits one with `builtIn: true` that doesn't yet exist in the new realm, the create call fails.
+
+**Why it matters.** Confirms the curated declared file must contain only `builtIn: false` flows. UDS top-level flows that *reference* built-in sub-flows via `flowAlias` (e.g. `UDS Authentication` referencing the built-in `idp redirector`) continue to work, because the built-in flows exist in the new realm by the time those references are resolved.
+
+**Workaround for the experiment.** `curate.py` drops every `authenticationFlows[]` entry where `builtIn: true`. Both top-level built-ins and built-in sub-flows go.
+
+**Implication for the TDD.** The boundary catalog must mark every authentication flow as either UDS-owned or Keycloak-owned. The build pipeline must strip Keycloak-owned flows before kcc reads the file. UDS-owned customizations of built-in flows (flow extensions, execution overrides) are not currently representable through kcc against modern Keycloak — that's a separate constraint reviewers should know about.
+
+---
+
+## F-5 — Identity provider exports carry fields kcc can't pass through
+
+**Observed.** Round 3 hit HTTP 500 in `IdentityProviderRepository.create`. Two distinct issues in our SAML IdP entry:
+
+1. `firstBrokerLoginFlowAlias: null`. The realm export dumps null for "use Keycloak's default", but the Admin API on create returns 500 instead of defaulting. Filling in `"first broker login"` (the built-in alias) fixed it.
+2. `internalId: "1538a301-8427-46d2-b59f-203f2f76e573"`. This is the UUID Keycloak assigned in the original `uds` realm. Our top-level `walk(del(.id))` cleanup didn't strip it. Submitting it to a different realm where the same internalId may conflict (or where Keycloak refuses an external internalId) yields 500.
+
+**Why it matters.** Anything we declare for kcc has to be a *creatable* representation, not a verbatim export. The boundary catalog must include sanitization rules for IdP entries (and likely other resource types) to scrub fields that the Admin API treats as "Keycloak-internal."
+
+**Workaround for the experiment.** `curate.py` (Round 4):
+
+- Replaces null `firstBrokerLoginFlowAlias` with `"first broker login"`.
+- Strips `internalId` from every IdP entry.
+
+**Implication for the TDD.** Beyond clients/flows, IdPs and IdP mappers need their own sanitization story. Likely true for `components`, `users` (service accounts), `keys`, etc. as well — to be confirmed once we run drift / reconcile cases. The curation pipeline is a real piece of work, not a one-liner.
+
+---
+
+## F-6 — kcc skips reconcile by default if the input file checksum hasn't changed
+
+**Observed.** TC-5 (drift correction) failed silently. We manually drifted `kcc-test-additive-client.redirectUris` via the Admin API, then re-ran kcc with the same declared file. kcc finished in 721 ms with no operations logged. The drift was **not** corrected.
+
+Inspecting the `uds-kcc-test` realm attributes after the run revealed the cause:
+
+```
+de.adorsys.keycloak.config.import-checksum-default: e4b6db…
+```
+
+kcc records the SHA256 of the imported file as a realm attribute. On the next run, if the file's checksum matches the stored value, **kcc skips the entire import** — it does not query Keycloak for the live state, doesn't diff, doesn't reconcile drift.
+
+Setting `IMPORT_CACHE_ENABLED=false` disables the optimization. With the flag, the same TC-5 setup ran in 16 s and correctly reverted the drift to the declared value.
+
+**Why it matters.** This is a load-bearing question for the SN, and the answer changes the operational model:
+
+- "Run kcc on every UDS Core upgrade" with the default cache → kcc only does work when the *file* changes. Drift introduced manually between upgrades is invisible to it.
+- "Run kcc on every upgrade with `IMPORT_CACHE_ENABLED=false`" → kcc reconciles every time. Slower, but actually idempotent against drift.
+
+**Implication for the TDD.** The reconciler should run with cache disabled. The trade-off is a few extra seconds per upgrade vs. the entire correctness story. The TDD also needs to address whether kcc should run periodically (drift detection cadence — Open Question 5 in the SN) or only on upgrades. With cache disabled, "on upgrade" still doesn't catch drift between upgrades — that's the same gap the SN flagged.
+
+---
+
+## F-7 — kcc applied cleanly against the live `uds` realm Keycloak imported at boot
+
+**Observed.** With `realm-uds-baseline.json` (this directory's curated, kcc-syntax baseline) handed to kcc, against the realm Keycloak created at boot via `--import-realm`:
+
+- **β-soft** (default cache, first kcc run on `uds`): 14.6 s. Snapshot diff returned only:
+  - kcc remote-state attributes added (expected — kcc establishing ownership).
+  - SAML IdP gained `hideOnLogin: false` (Keycloak default, made explicit).
+  - SAML IdP gained `firstBrokerLoginFlowAlias: "first broker login"` (the F-5 fix; was null in the export).
+  - Inside `UDS Authentication`, the sub-flow execution previously named `Username/Password Authentication` (slash) was replaced by `Username-Password Authentication` (dash) — matching our declared file. Parent flow execution refs updated atomically; no orphaned flows left.
+- **β-hard** (cache disabled, second run): 4.6 s. **Zero-line semantic diff.** True idempotence.
+- SSO endpoint healthy throughout. `uds-operator` client + its service-account user untouched. Pepr's auth path intact.
+
+**Why it matters.** This is the production-shape question the SN proposes to solve. The answer is "yes, this works" — `realm-uds-baseline.json` can be dropped onto an existing UDS cluster and kcc reconciles without breakage. A second-run idempotency check confirms there's no churn.
+
+**Implication for the TDD.** The reconciler integration is viable. Build pipeline:
+
+```
+src/realm.json5  (authoring source — unchanged today)
+  → realm.json  (json5 compile, same as today)
+  → realm-uds-kcc.json  (placeholder rewrite, F-1)
+  → realm-uds-baseline.json  (curate per F-2..F-5)
+```
+
+The chart ships the curated artifact as a ConfigMap, the kcc Job mounts it + `keycloak-realm-env` Secret + UDS_*_DOMAIN env, runs with cache disabled to ensure drift detection on every reconcile. Open Question 5 in the SN (drift detection cadence) collapses to "every reconcile, free."
+
+---
+
+## F-8 — kcc remote-state can be cleared in-place to "re-adopt" without realm rebuild
+
+**Observed.** When iterating on the curated baseline (e.g. moving from R4 to R5), the live `uds` realm carried kcc's prior remote-state attributes (`de.adorsys.keycloak.config.state-default-roles-realm-0` and similar). Applying a more aggressively-curated declared file with that state still in place would cause kcc to interpret "I previously owned X but X is no longer declared" as **delete X** (with default `IMPORT_MANAGED_*=full` modes), risking destruction of resources Keycloak auto-manages (`uma_authorization`, `default-roles-uds`, etc.).
+
+Workaround: clear all `de.adorsys.keycloak.config.*` attributes from the realm before applying the new baseline:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE/admin/realms/uds" \
+  | jq '.attributes |= with_entries(select(.key | startswith("de.adorsys.keycloak.config") | not))' \
+  | curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d @- "$BASE/admin/realms/uds"
+```
+
+Verified non-destructive: the actual resources (clients, scopes, roles, IdPs) stay in place. Only kcc's ownership memory is wiped. Next kcc run re-adopts everything in the new declared file as kcc-owned, ignores everything else.
+
+**Why it matters.** Iterating on the boundary catalog after first adoption is a real workflow — curators will narrow / widen scope as the catalog matures. Without F-8, every catalog change risks data loss. With it, catalog evolution is safe.
+
+**Implication for the TDD.** Operationally, the reconciler bundle should expose a "reset ownership" command (or a reconciler-level option). Alternative: ship default `IMPORT_MANAGED_*=no-delete` so that even with stale ownership state, kcc never deletes; the no-delete posture removes the urgency of clearing state.
+
+---
+
+## F-9 — UUID-bearing fields must all be stripped, not just `id`
+
+**Observed.** After applying the upstream `walk(del(.id))` step in the build pipeline, an audit (regex for UUID-shaped strings in the curated baseline) found one UUID still present:
+
+```
+groups[*].subGroups[*].parentId = 53521ed0-aa44-4007-9727-0015d5281c3e
+```
+
+`parentId` references the parent group's UUID. After we strip the parent's `id`, this reference is dangling — points to a UUID nothing on a fresh cluster will own. Empirically Keycloak/kcc fall back to the `path` field for parent linkage so this didn't break β-soft, but it's a latent failure mode: if a future Keycloak version starts validating UUID references, applying our baseline to a fresh cluster would error.
+
+A full audit of all reference-shaped fields confirmed every other reference uses **stable name-based identifiers**:
+
+- `clientId: "uds-operator"` (client name)
+- `browserFlow: "UDS Authentication"` (flow alias)
+- `firstBrokerLoginFlowAlias: "first broker login"` (flow alias)
+- `directGrantFlow`, `resetCredentialsFlow`, `clientAuthenticationFlow`, etc. — all flow aliases
+- SAML `entityId`, `idpEntityId`, `webAuthnPolicy*RpId` — URLs / hostnames, not UUIDs
+
+Only `parentId` was the offender.
+
+**Why it matters.** Cross-cluster portability of the baseline depends on having zero hardcoded Keycloak-internal IDs. Every UUID we leave in the file is a future failure mode.
+
+**Fix.** Curator (`curate.py`) now strips `parentId` recursively after the upstream `walk(del(.id))` step. Audit confirmed no UUID-shaped strings remain in the curated baseline.
+
+**Implication for the TDD.** The build pipeline rule is "strip every UUID-bearing field, not just `id`." The complete strip set today: `id`, `internalId` (F-5), `parentId`. CI should regex-audit the curated output for any remaining UUID-shaped strings on every PR, so a future Keycloak version that introduces a new UUID-bearing field gets caught immediately.
+
+---
+
+## F-10 — Sub-flow execution priorities silently reset to 0 (upstream kcc bug)
+
+**Observed.** When kcc creates a sub-flow's executions, it does not pass the declared `priority` value to Keycloak's `addExecutionToFlow` Admin API. Keycloak then auto-assigns a priority (starting at 0, incrementing per execution), ignoring whatever the source declared.
+
+**Confirmed by minimal repro:**
+
+```json
+{
+  "alias": "Conditional 2FA",
+  "topLevel": false,
+  "authenticationExecutions": [
+    {
+      "authenticator": "conditional-user-configured",
+      "requirement": "REQUIRED",
+      "priority": 1
+    }
+  ]
+}
+```
+
+After `kcc` runs against a fresh Keycloak 26.5.7:
+
+```
+Conditional 2FA / conditional-user-configured → priority 0   (declared 1)
+```
+
+Top-level flow executions are not affected — kcc preserves their priorities correctly. Only sub-flow executions hit this.
+
+**Root cause** (read from kcc source `ExecutionFlowsImportService.createExecutionForSubFlow` + `ExecutionFlowRepository.createSubFlowExecution`): kcc builds a `HashMap<String,String>` for the sub-flow create payload containing `alias`, `provider`, `type`, `description`, `authenticator` — but NOT `priority`. Keycloak 26.5.7's `addExecutionToFlow` falls into the `getNextPriority(parentFlow)` branch and auto-assigns 0 (or next-incremented).
+
+The follow-up `configureExecutionFlow` PUT/update path tries to set the priority but the Admin API's `update` endpoint does not honor priority changes for sub-flow executions (related to Keycloak issue #20747).
+
+**Functional impact in our realm.** Categorized by execution-type and Keycloak's runtime semantics:
+
+| Sub-flow | Executions | Type | Impact |
+|---|---|---|---|
+| `Authentication` | cookie / idp / x509 / username-password | ALTERNATIVE | None practical. Alternatives run in priority order until one succeeds; cookie wins for logged-in users; idp/x509 are conditional (no-op when not configured); username-password is fallback. Priority compaction doesn't change which one wins. |
+| `Conditional OTP` | conditional-user-configured / auth-otp-form / webauthn-authenticator | REQUIRED | None practical. REQUIRED executions run sequentially. With all priorities collapsed to 0, Keycloak processes them in insertion order — which matches source order. |
+| `UDS registration form` and other custom sub-flows | various | REQUIRED | Same — insertion order matches source intent. |
+
+**Verdict.** The bug is real and it's driving the test diff (`priority: 1` → `priority: 0`), but for our specific realm structure it doesn't change runtime behavior because:
+
+1. ALTERNATIVE executions in our flows have mutually-exclusive conditions, so order is dominated by which condition succeeds, not by priority numbers.
+2. REQUIRED executions are listed in source in the order we want them to run, and Keycloak processes same-priority executions in insertion order.
+
+**Implication for the TDD.** Cosmetic, not blocking. Worth noting as a known divergence between `--import-realm` (preserves declared priority) and kcc (collapses sub-flow priorities to 0). If we ever introduce a sub-flow where two REQUIRED executions need a specific order that doesn't match source array order, OR an ALTERNATIVE flow where same-priority means parallel/race, the bug could surface as a real behavior change. Prevention: keep authoring sub-flow executions in the order they should run.
+
+**Filed upstream** as [adorsys/keycloak-config-cli#1539](https://github.com/adorsys/keycloak-config-cli/issues/1539) with minimal repro and suggested one-line fix (include `priority` in the create payload).
+
+---
+
+## Empirical curation log (round-by-round)
+
+Each round is "kcc ran further than before; here is what stopped it."
+
+| Round | Removal / change | Justification |
+|-------|------------------|---------------|
+| R1 | 6 Keycloak built-in clients (`account`, `account-console`, `admin-cli`, `broker`, `realm-management`, `security-admin-console`) and their `roles.client` blocks. | F-2 — Keycloak auto-manages these; declarations collide. |
+| R1 | `scopeMappings` / `clientScopeMappings` entries referencing those clients. | F-2 — dangling references. |
+| R2 | Rename flow `Username/Password Authentication` → `Username-Password Authentication` (alias + all `flowAlias` refs). | F-3 — kcc URL-encoding bug on `/`. |
+| R3 | All `authenticationFlows[]` entries where `builtIn: true`. | F-4 — Keycloak Admin API refuses to create them. |
+| R4 | IdP `firstBrokerLoginFlowAlias: null` → `"first broker login"`. | F-5 — Admin API doesn't default null. |
+| R4 | IdP `internalId` field stripped. | F-5 — Keycloak-internal field; collisions on cross-realm reuse. |
+| R5 | 11 Keycloak built-in client scopes (`acr`, `address`, `email`, `microprofile-jwt`, `offline_access`, `openid`, `phone`, `profile`, `role_list`, `roles`, `web-origins`). | Auto-created by Keycloak per realm; declaring is redundant noise. |
+| R5 | Default realm roles (`uma_authorization`, `offline_access`, `default-roles-<realm>`). | Auto-created. |
+| R5 | Service-account users (`service-account-*`). | Auto-created with their parent client when `serviceAccountsEnabled: true`. |
+| R5 | `components` (KeyProvider, WorkflowProvider, ClientRegistrationPolicy, UserProfileProvider). | Auto-created per realm. |
+| R5 | Top-level `requiredActions`, `defaultRole`, `defaultDefaultClientScopes`, `defaultOptionalClientScopes`. | Auto-managed. |
+| R5 | Empty `smtpServer: {}`, `localizationTexts: {}`, `supportedLocales: []`. | Default empty containers. |
+
+After R5 (the maximally-stripped baseline saved as `realm-uds-baseline.json` — 40 KB / 1234 lines, 43% smaller than R4's output), kcc runs end-to-end on a fresh import in **5 seconds**. Adopts the live `uds` realm Keycloak imported at boot in **3.7 seconds** with zero semantic changes after kcc state is cleared (F-8). Idempotent re-run in **3.6 seconds** with zero diff.
+
+After R4, kcc runs end-to-end on a fresh import in **8 seconds**, producing:
+
+- All 8 clients (6 Keycloak built-ins auto-created + 2 UDS custom).
+- 12 authentication flows (Keycloak built-ins + 5 UDS top-level customs + their sub-flows).
+- 26 client scopes.
+- The Google SAML IdP with `wantAssertionsSigned=true` preserved.
+- All 16 i18n message refs preserved literal (e.g. `${role_uma_authorization}`).
+
+This is the working baseline for subsequent test cases (TC-2 onward).
+
+---

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -76,33 +76,60 @@ RUN if [ "${REALM_FILE##*.}" = "json5" ]; then \
 
 ###################################################################################
 #                                                                                 #
-# Use busybox as the base image to perform the sync                               #
+# Pull the keycloak-config-cli jar from the upstream signed image. Tag pins       #
+# kcc to a Keycloak compatible build (kcc 6.5.0 against Keycloak 26.5.4 line —    #
+# matches our Keycloak 26.5.x within supported window).                           #
 #                                                                                 #
 ###################################################################################
-FROM cgr.dev/chainguard/busybox:latest
+FROM docker.io/adorsys/keycloak-config-cli:6.5.0-26.5.4 AS kcc
 
+###################################################################################
+#                                                                                 #
+# Use a JRE-capable chainguard base so the image can serve two roles:             #
+#   - Default CMD = sync.sh (init container; copies files into Keycloak volumes) #
+#   - Job override = `java -jar /opt/kcc/keycloak-config-cli.jar` (realm sync)   #
+# ENTRYPOINT is cleared because the upstream chainguard JRE image sets it to     #
+# `/usr/bin/java`, which would consume our CMD as a java argument.                #
+#                                                                                 #
+###################################################################################
+FROM cgr.dev/chainguard/jre:latest-dev
+
+USER root
 WORKDIR /home/nonroot
 
 # Copy Jars from the plugin build stage
-COPY --chown=nonroot --from=plugin /home/build/target/*.jar .
+COPY --chown=65532:65532 --from=plugin /home/build/target/*.jar .
 
 # FIPS dependencies
 RUN mkdir -p ./fips/libs
-RUN chown -R nonroot:nonroot ./fips/libs
-COPY --chown=nonroot --from=plugin /home/build/target/fips/libs/*.jar ./fips/libs
+RUN chown -R 65532:65532 ./fips/libs
+COPY --chown=65532:65532 --from=plugin /home/build/target/fips/libs/*.jar ./fips/libs
 
 # Copy the DOD Unclass PEM and truststore for Istio & Keycloak Auth
-COPY --chown=nonroot --from=truststore /home/build/authorized_certs.pem .
-COPY --chown=nonroot --from=truststore /home/build/certs ./certs
+COPY --chown=65532:65532 --from=truststore /home/build/authorized_certs.pem .
+COPY --chown=65532:65532 --from=truststore /home/build/certs ./certs
 
 # The realm.json is loaded into Keycloak on startup only if the realm does not exist
-COPY --chown=nonroot --from=json5-converter /convert/realm.json .
+COPY --chown=65532:65532 --from=json5-converter /convert/realm.json .
 
 # This provides the custom theme for the Keycloak instance
-COPY --chown=nonroot theme theme
+COPY --chown=65532:65532 theme theme
+
+# keycloak-config-cli for realmSync mode. Activated by overriding the Job's
+# command/args; default CMD remains sync.sh for init-container usage.
+COPY --chown=65532:65532 --from=kcc /app/keycloak-config-cli.jar /opt/kcc/keycloak-config-cli.jar
+
+# realm-kcc.json — curated baseline for kcc realmSync mode. Same realm as
+# realm.json but with Keycloak built-ins / auto-managed resources stripped
+# and ${VAR:default} placeholders rewritten to ${env:VAR:-default} so kcc
+# can substitute natively. See docs/dev/keycloak-config-cli-experiment/
+# findings.md (F-1, F-2 through F-9) for derivation.
+COPY --chown=65532:65532 realm-kcc.json .
 
 # This script is used to sync the files from the init container to the Keycloak container
-COPY --chown=nonroot sync.sh .
+COPY --chown=65532:65532 sync.sh .
 RUN chmod +x sync.sh
 
+USER 65532:65532
+ENTRYPOINT []
 CMD ["/home/nonroot/sync.sh"]

--- a/src/realm-kcc.json
+++ b/src/realm-kcc.json
@@ -1,0 +1,1277 @@
+{
+  "realm": "uds",
+  "displayName": "${env:REALM_DISPLAY_NAME:-Unicorn Delivery Service}",
+  "displayNameHtml": "Identity Service",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": "${env:REALM_ACCESS_TOKEN_LIFESPAN:-60}",
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": "${env:REALM_SSO_SESSION_IDLE_TIMEOUT:-600}",
+  "ssoSessionMaxLifespan": "${env:REALM_SSO_SESSION_MAX_LIFESPAN:-36000}",
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": "${env:REGISTER_BUTTON_ENABLED:-true}",
+  "registrationEmailAsUsername": "${env:REALM_EMAIL_AS_USERNAME:-false}",
+  "rememberMe": false,
+  "verifyEmail": "${env:REALM_EMAIL_VERIFICATION_ENABLED:-false}",
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": "${env:USERNAME_PASSWORD_AUTH_ENABLED:-true}",
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": true,
+  "maxTemporaryLockouts": "${env:REALM_MAX_TEMPORARY_LOCKOUTS:-0}",
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 86400,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 900,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 3,
+  "roles": {
+    "realm": [],
+    "client": {
+      "uds-operator": [],
+      "uds-opentofu-client": []
+    }
+  },
+  "groups": [
+    {
+      "name": "UDS Core",
+      "path": "/UDS Core",
+      "subGroups": [
+        {
+          "name": "Admin",
+          "path": "/UDS Core/Admin"
+        },
+        {
+          "name": "Auditor",
+          "path": "/UDS Core/Auditor"
+        }
+      ]
+    }
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
+  "passwordPolicy": "${env:REALM_PASSWORD_POLICY:-hashAlgorithm(pbkdf2-sha256) and forceExpiredPasswordChange(60) and specialChars(2) and digits(1) and lowerCase(1) and upperCase(1) and passwordHistory(5) and length(15) and notUsername(undefined)}",
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 3,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "username": "service-account-uds-operator",
+      "enabled": true,
+      "serviceAccountClientId": "uds-operator",
+      "clientRoles": {
+        "realm-management": [
+          "manage-clients"
+        ]
+      }
+    },
+    {
+      "username": "service-account-opentofu-client",
+      "enabled": true,
+      "serviceAccountClientId": "uds-opentofu-client",
+      "clientRoles": {
+        "realm-management": [
+          "realm-admin"
+        ]
+      }
+    }
+  ],
+  "scopeMappings": [],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "uds-operator",
+      "name": "uds-operator",
+      "description": "A client used by the UDS Operator",
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-kubernetes-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/*"
+      ],
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1741765509",
+        "backchannel.logout.session.required": "true",
+        "frontchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "use.jwks.url": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "fullScopeAllowed": true
+    },
+    {
+      "clientId": "uds-opentofu-client",
+      "name": "uds-opentofu-client",
+      "description": "A client used for managing Keycloak via Tofu",
+      "surrogateAuthRequired": false,
+      "enabled": "${env:REALM_OPENTOFU_CLIENT_ENABLED:-false}",
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "mapper-saml-username-name",
+      "description": "Includes a protocol mapper to map the 'Username' user property to the SAML 'name' attribute.",
+      "protocol": "saml",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "Name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "name"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-saml-username-login",
+      "description": "Includes a protocol mapper to map the 'Username' user property to the SAML 'login' attribute.",
+      "protocol": "saml",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "Name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "login"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-saml-email-email",
+      "description": "Includes a protocol mapper to map the 'Email' user property to the SAML 'email' attribute.",
+      "protocol": "saml",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "Name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "email"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-saml-firstname-first_name",
+      "description": "Includes a protocol mapper to map the 'FirstName' user property to the SAML 'first_name' attribute.",
+      "protocol": "saml",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "mapper-saml-firstname-first_name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "Basic",
+            "user.attribute": "firstName",
+            "friendly.name": "First Name",
+            "attribute.name": "first_name"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-saml-lastname-last_name",
+      "description": "Includes a protocol mapper to map the 'LastName' user property to the SAML 'last_name' attribute.",
+      "protocol": "saml",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "mapper-saml-lastname-last_name",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.nameformat": "Basic",
+            "user.attribute": "lastName",
+            "friendly.name": "Last Name",
+            "attribute.name": "last_name"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-saml-grouplist-groups",
+      "description": "Includes a protocol mapper to map the user's assigned groups to the SAML 'Groups' attribute.",
+      "protocol": "saml",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "mapper-saml-grouplist-groups",
+          "protocol": "saml",
+          "protocolMapper": "saml-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "full.path": "true",
+            "friendly.name": "groups",
+            "attribute.name": "Groups"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-oidc-username-username",
+      "description": "Includes a protocol mapper to map the 'username' user property to the token 'username' claim.",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "false",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "false",
+            "claim.name": "username",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-oidc-mattermostid-id",
+      "description": "Includes a protocol mapper to map the 'mattermostid' user attribute to the token 'id' claim.",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "mattermostid",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "false",
+            "userinfo.token.claim": "true",
+            "user.attribute": "mattermostid",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "false",
+            "claim.name": "id",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    },
+    {
+      "name": "mapper-oidc-email-email",
+      "description": "Includes a protocol mapper to map the 'email' user attribute to the token 'email' claim.",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "false",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "false",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "name": "bare-groups",
+      "description": "A client scope providing groups without leading slash",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "Please use this scope only if you understand the implications of excluding the leading slash from group data."
+      },
+      "protocolMappers": [
+        {
+          "name": "bare groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "bare-group-path-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "multivalued": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bare-groups"
+          }
+        }
+      ]
+    },
+    {
+      "name": "aws-groups",
+      "description": "SAML custom scope for formatting user groups for AWS",
+      "protocol": "saml",
+      "protocolMappers": [
+        {
+          "name": "aws-groups",
+          "protocol": "saml",
+          "protocolMapper": "aws-saml-group-mapper",
+          "consentRequired": false,
+          "config": {
+            "attribute.name": "https://aws.amazon.com/SAML/Attributes/PrincipalTag:groups"
+          }
+        },
+        {
+          "name": "title",
+          "protocol": "saml",
+          "protocolMapper": "aws-saml-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "title",
+            "attribute.name": "https://aws.amazon.com/SAML/Attributes/PrincipalTag:title"
+          }
+        },
+        {
+          "name": "costCenter",
+          "protocol": "saml",
+          "protocolMapper": "aws-saml-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "costCenter",
+            "attribute.name": "https://aws.amazon.com/SAML/Attributes/PrincipalTag:costCenter"
+          }
+        },
+        {
+          "name": "userType",
+          "protocol": "saml",
+          "protocolMapper": "aws-saml-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "userType",
+            "attribute.name": "https://aws.amazon.com/SAML/Attributes/PrincipalTag:userType"
+          }
+        },
+        {
+          "name": "department",
+          "protocol": "saml",
+          "protocolMapper": "aws-saml-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "department",
+            "attribute.name": "https://aws.amazon.com/SAML/Attributes/PrincipalTag:department"
+          }
+        },
+        {
+          "name": "aws-session-name-mapper",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "attribute.name": "https://aws.amazon.com/SAML/Attributes/RoleSessionName"
+          }
+        },
+        {
+          "name": "common-name-mapper",
+          "protocol": "saml",
+          "protocolMapper": "saml-user-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "usercertificateCN",
+            "aggregate.attrs": "false",
+            "attribute.name": "https://aws.amazon.com/SAML/Attributes/PrincipalTag:commonName"
+          }
+        }
+      ]
+    }
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "loginTheme": "theme",
+  "accountTheme": "theme",
+  "eventsEnabled": true,
+  "eventsExpiration": 1800,
+  "eventsListeners": [
+    "jsonlog-event-listener",
+    "registration-event-listener"
+  ],
+  "enabledEventTypes": [
+    "SEND_RESET_PASSWORD",
+    "UPDATE_CONSENT_ERROR",
+    "GRANT_CONSENT",
+    "REMOVE_TOTP",
+    "REVOKE_GRANT",
+    "UPDATE_TOTP",
+    "LOGIN_ERROR",
+    "CLIENT_LOGIN",
+    "RESET_PASSWORD_ERROR",
+    "IMPERSONATE_ERROR",
+    "CODE_TO_TOKEN_ERROR",
+    "CUSTOM_REQUIRED_ACTION",
+    "RESTART_AUTHENTICATION",
+    "IMPERSONATE",
+    "UPDATE_PROFILE_ERROR",
+    "LOGIN",
+    "UPDATE_PASSWORD_ERROR",
+    "CLIENT_INITIATED_ACCOUNT_LINKING",
+    "TOKEN_EXCHANGE",
+    "LOGOUT",
+    "REGISTER",
+    "CLIENT_REGISTER",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT",
+    "UPDATE_PASSWORD",
+    "CLIENT_DELETE",
+    "FEDERATED_IDENTITY_LINK_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN",
+    "CLIENT_DELETE_ERROR",
+    "VERIFY_EMAIL",
+    "CLIENT_LOGIN_ERROR",
+    "RESTART_AUTHENTICATION_ERROR",
+    "EXECUTE_ACTIONS",
+    "REMOVE_FEDERATED_IDENTITY_ERROR",
+    "TOKEN_EXCHANGE_ERROR",
+    "PERMISSION_TOKEN",
+    "SEND_IDENTITY_PROVIDER_LINK_ERROR",
+    "EXECUTE_ACTION_TOKEN_ERROR",
+    "SEND_VERIFY_EMAIL",
+    "EXECUTE_ACTIONS_ERROR",
+    "REMOVE_FEDERATED_IDENTITY",
+    "IDENTITY_PROVIDER_POST_LOGIN",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
+    "UPDATE_EMAIL",
+    "REGISTER_ERROR",
+    "REVOKE_GRANT_ERROR",
+    "EXECUTE_ACTION_TOKEN",
+    "LOGOUT_ERROR",
+    "UPDATE_EMAIL_ERROR",
+    "CLIENT_UPDATE_ERROR",
+    "UPDATE_PROFILE",
+    "CLIENT_REGISTER_ERROR",
+    "FEDERATED_IDENTITY_LINK",
+    "SEND_IDENTITY_PROVIDER_LINK",
+    "SEND_VERIFY_EMAIL_ERROR",
+    "RESET_PASSWORD",
+    "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
+    "UPDATE_CONSENT",
+    "REMOVE_TOTP_ERROR",
+    "VERIFY_EMAIL_ERROR",
+    "SEND_RESET_PASSWORD_ERROR",
+    "CLIENT_UPDATE",
+    "CUSTOM_REQUIRED_ACTION_ERROR",
+    "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
+    "UPDATE_TOTP_ERROR",
+    "CODE_TO_TOKEN",
+    "GRANT_CONSENT_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": true,
+  "identityProviders": [
+    {
+      "alias": "saml",
+      "displayName": "Google SSO",
+      "providerId": "saml",
+      "enabled": "${env:REALM_GOOGLE_IDP_ENABLED:-false}",
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "postBrokerLoginFlowAlias": "Group Protection Authorization",
+      "config": {
+        "postBindingLogout": "false",
+        "postBindingResponse": "true",
+        "backchannelSupported": "false",
+        "idpEntityId": "https://accounts.google.com/o/saml2?idpid=${env:REALM_GOOGLE_IDP_ID}",
+        "loginHint": "false",
+        "allowCreate": "true",
+        "enabledFromMetadata": "true",
+        "singleSignOnServiceUrl": "https://accounts.google.com/o/saml2/idp?idpid=${env:REALM_GOOGLE_IDP_ID}",
+        "wantAuthnRequestsSigned": "false",
+        "allowedClockSkew": "0",
+        "validateSignature": "true",
+        "signingCertificate": "${env:REALM_GOOGLE_IDP_SIGNING_CERT}",
+        "nameIDPolicyFormat": "${env:REALM_GOOGLE_IDP_NAME_ID_FORMAT}",
+        "entityId": "${env:REALM_GOOGLE_IDP_CORE_ENTITY_ID}",
+        "signSpMetadata": "false",
+        "wantAssertionsEncrypted": "false",
+        "sendClientIdOnLogout": "false",
+        "wantAssertionsSigned": "true",
+        "sendIdTokenOnLogout": "true",
+        "postBindingAuthnRequest": "true",
+        "forceAuthn": "false",
+        "attributeConsumingServiceIndex": "0",
+        "addExtensionsElementWithKeyInfo": "false",
+        "principalType": "Subject NameID",
+        "syncMode": "FORCE"
+      },
+      "firstBrokerLoginFlowAlias": "first broker login"
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "name": "Email Mapper",
+      "identityProviderAlias": "saml",
+      "identityProviderMapper": "saml-user-attribute-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "user.attribute": "email",
+        "attribute.friendly.name": "email",
+        "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+        "attribute.name": "email"
+      }
+    },
+    {
+      "name": "Admin Group Mapper",
+      "identityProviderAlias": "saml",
+      "identityProviderMapper": "saml-advanced-group-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "attributes": "[{\"key\":\"groups\",\"value\":\"${env:REALM_GOOGLE_IDP_ADMIN_GROUP}\"}]",
+        "group": "/UDS Core/Admin"
+      }
+    },
+    {
+      "name": "Auditor Group Mapper",
+      "identityProviderAlias": "saml",
+      "identityProviderMapper": "saml-advanced-group-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "attributes": "[{\"key\":\"groups\",\"value\":\"${env:REALM_GOOGLE_IDP_AUDITOR_GROUP}\"}]",
+        "group": "/UDS Core/Auditor"
+      }
+    },
+    {
+      "name": "firstName Mapper",
+      "identityProviderAlias": "saml",
+      "identityProviderMapper": "saml-user-attribute-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "user.attribute": "firstName",
+        "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+        "attribute.name": "firstName"
+      }
+    },
+    {
+      "name": "lastName Mapper",
+      "identityProviderAlias": "saml",
+      "identityProviderMapper": "saml-user-attribute-idp-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "user.attribute": "lastName",
+        "attribute.name.format": "ATTRIBUTE_FORMAT_BASIC",
+        "attribute.name": "lastName"
+      }
+    }
+  ],
+  "components": {
+    "org.keycloak.userprofile.UserProfileProvider": [
+      {
+        "providerId": "declarative-user-profile",
+        "subComponents": {},
+        "config": {
+          "kc.user.profile.config": [
+            "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{},\"length\":{\"min\":\"2\",\"max\":\"255\",\"trim-disabled\":\"true\"}},\"annotations\":{},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"annotations\":{},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"person-name-prohibited-characters\":{},\"length\":{\"min\":\"1\",\"max\":\"255\",\"trim-disabled\":\"true\"}},\"annotations\":{},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"person-name-prohibited-characters\":{},\"length\":{\"min\":\"1\",\"max\":\"255\",\"trim-disabled\":\"true\"}},\"annotations\":{},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"mattermostid\",\"displayName\":\"Mattermost ID\",\"validations\":{},\"annotations\":{},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\"]},\"multivalued\":false},{\"name\":\"rank\",\"displayName\":\"Pay Grade\",\"validations\":{\"options\":{\"options\":[\"E-1\",\"E-2\",\"E-3\",\"E-4\",\"E-5\",\"E-6\",\"E-7\",\"E-8\",\"E-9\",\"W-1\",\"W-2\",\"W-3\",\"W-4\",\"W-5\",\"O-1\",\"O-2\",\"O-3\",\"O-4\",\"O-5\",\"O-6\",\"O-7\",\"O-8\",\"O-9\",\"O-10\",\"GS-1\",\"GS-2\",\"GS-3\",\"GS-4\",\"GS-5\",\"GS-6\",\"GS-7\",\"GS-8\",\"GS-9\",\"GS-10\",\"GS-11\",\"GS-12\",\"GS-13\",\"GS-14\",\"GS-15\",\"SES\",\"N/A\"]}},\"annotations\":{\"inputType\":\"select\"},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"affiliation\",\"displayName\":\"Affiliation\",\"validations\":{\"options\":{\"options\":[\"US Air Force\",\"US Air Force Reserve\",\"US Air National Guard\",\"US Army\",\"US Army Reserve\",\"US Army National Guard\",\"US Coast Guard\",\"US Coast Guard Reserve\",\"US Marine Corps\",\"US Marine Corps Reserve\",\"US Navy\",\"US Navy Reserve\",\"US Space Force\",\"Dept of Defense\",\"Federal Government\",\"A&AS\",\"Contractor\",\"FFRDC\",\"Other\"]}},\"annotations\":{\"inputType\":\"select\"},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"organization\",\"displayName\":\"Unit, Organization or Company Name\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"location\",\"displayName\":\"Anti-bot Location (42)\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"notes\",\"displayName\":\"Access Request Notes\",\"validations\":{},\"annotations\":{\"inputType\":\"textarea\"},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"usercertificateIdentity\",\"displayName\":\"x509 User Identity\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\"]},\"multivalued\":false},{\"name\":\"usercertificateCN\",\"displayName\":\"x509 User CN\",\"validations\":{},\"annotations\":{},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ADMIN_EDIT\"}"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "authenticationFlows": [
+    {
+      "alias": "Authentication",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 1,
+          "autheticatorFlow": true,
+          "flowAlias": "idp redirector",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "${env:X509_LOGIN_FLOW_ENABLED:-ALTERNATIVE}",
+          "priority": 1,
+          "autheticatorFlow": true,
+          "flowAlias": "x509 Authentication",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 3,
+          "autheticatorFlow": true,
+          "flowAlias": "Username-Password Authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "Conditional OTP",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "${env:OTP_FLOW_ENABLED:-REQUIRED}",
+          "priority": 1,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "${env:WEBAUTHN_FLOW_ENABLED:-REQUIRED}",
+          "priority": 2,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "Conditional X509 2FA",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "${env:OTP_FLOW_ENABLED:-REQUIRED}",
+          "priority": 1,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "${env:WEBAUTHN_FLOW_ENABLED:-REQUIRED}",
+          "priority": 2,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "Group Protection Authorization",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "uds-group-restriction",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "Username-Password Authentication",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "deny-access-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "${env:DENY_USERNAME_PASSWORD_ENABLED:-DISABLED}",
+          "priority": 1,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "${env:MFA_FLOW_ENABLED:-DISABLED}",
+          "priority": 2,
+          "autheticatorFlow": true,
+          "flowAlias": "Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "UDS Authentication",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": true,
+          "flowAlias": "Authentication",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "uds-group-restriction",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 2,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorConfig": "uds-user-session-count",
+          "authenticator": "user-session-limits",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 3,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "UDS Authentication Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "UDS Client Credentials",
+      "description": "Client Credentials Authentication flow for UDS",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-kubernetes-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 41,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "UDS Registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "${env:REGISTRATION_FORM_ENABLED:-REQUIRED}",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "UDS registration form",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "uds-group-restriction",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "UDS Reset Credentials",
+      "description": "Reset credentials for a user if they forgot their password",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorConfig": "reset-credentials-email",
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "${env:RESET_CREDENTIAL_FLOW_ENABLED:-REQUIRED}",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "uds-group-restriction",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "UDS registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorConfig": "main",
+          "authenticator": "registration-validation-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-x509-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 51,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "idp redirector",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 1,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "x509 Authentication",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "dod-cac",
+          "authenticator": "auth-x509-client-username-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 1,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "${env:X509_MFA_FLOW_ENABLED:-DISABLED}",
+          "priority": 2,
+          "autheticatorFlow": true,
+          "flowAlias": "Conditional X509 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "alias": "dod-cac",
+      "config": {
+        "x509-cert-auth.canonical-dn-enabled": "false",
+        "x509-cert-auth.mapper-selection.user-attribute-name": "usercertificateIdentity",
+        "x509-cert-auth.serialnumber-hex-enabled": "false",
+        "x509-cert-auth.ocsp-fail-open": "${env:REALM_X509_OCSP_FAIL_OPEN:-false}",
+        "x509-cert-auth.regular-expression": "(.*?)(?:$)",
+        "x509-cert-auth-crl-abort-if-non-updated": "${env:REALM_X509_CRL_ABORT_IF_NON_UPDATED:-false}",
+        "x509-cert-auth.certificate-policy-mode": "All",
+        "x509-cert-auth.timestamp-validation-enabled": "true",
+        "x509-cert-auth.mapper-selection": "Custom Attribute Mapper",
+        "x509-cert-auth.crl-checking-enabled": "${env:REALM_X509_CRL_CHECKING_ENABLED:-false}",
+        "x509-cert-auth.crl-relative-path": "${env:REALM_X509_CRL_RELATIVE_PATH:-crl.pem}",
+        "x509-cert-auth.crldp-checking-enabled": "false",
+        "x509-cert-auth.mapping-source-selection": "Subject's Alternative Name otherName (UPN)",
+        "x509-cert-auth.ocsp-checking-enabled": "${env:REALM_X509_OCSP_CHECKING_ENABLED:-true}"
+      }
+    },
+    {
+      "alias": "main",
+      "config": {}
+    },
+    {
+      "alias": "reset-credentials-email",
+      "config": {
+        "force-login": "true"
+      }
+    },
+    {
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    },
+    {
+      "alias": "uds-user-session-count",
+      "config": {
+        "userClientLimit": "0",
+        "behavior": "Deny new session",
+        "userRealmLimit": "${env:REALM_SSO_SESSION_MAX_PER_USER:-0}"
+      }
+    }
+  ],
+  "browserFlow": "UDS Authentication",
+  "registrationFlow": "UDS Registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "UDS Reset Credentials",
+  "clientAuthenticationFlow": "UDS Client Credentials",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "clientOfflineSessionMaxLifespan": "0",
+    "oauth2DevicePollingInterval": "5",
+    "clientSessionIdleTimeout": "0",
+    "userProfileEnabled": "false",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "acr.loa.map": "{}"
+  },
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": [
+      {
+        "name": "UDS Client Profile",
+        "description": "The UDS Profile restricts what the UDS Operator can do in Keycloak",
+        "executors": [
+          {
+            "executor": "uds-operator-permissions",
+            "configuration": {
+              "allowed-protocol-mappers-as-string": "${env:REALM_SECURITY_HARDENING_ADDITIONAL_PROTOCOL_MAPPERS:-}",
+              "use-default-allowed-protocol-mappers": "true",
+              "use-default-allowed-client-scopes": "true",
+              "allowed-client-scopes-as-string": "${env:REALM_SECURITY_HARDENING_ADDITIONAL_CLIENT_SCOPES:-}"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "clientPolicies": {
+    "policies": [
+      {
+        "name": "UDS Client Policy",
+        "description": "The UDS Profile restricts what the UDS Operator can do in Keycloak",
+        "enabled": true,
+        "conditions": [
+          {
+            "condition": "any-client",
+            "configuration": {
+              "is-negative-logic": false
+            }
+          }
+        ],
+        "profiles": [
+          "UDS Client Profile"
+        ]
+      }
+    ]
+  }
+}

--- a/src/realm.json5
+++ b/src/realm.json5
@@ -2292,7 +2292,7 @@
                     "requirement": "ALTERNATIVE",
                     "priority": 3,
                     "autheticatorFlow": true,
-                    "flowAlias": "Username/Password Authentication",
+                    "flowAlias": "Username-Password Authentication",
                     "userSetupAllowed": false
                 }
             ]
@@ -2523,7 +2523,7 @@
         },
         {
             "id": "cdf1be21-4140-4652-9d68-3b60742cc8ad",
-            "alias": "Username/Password Authentication",
+            "alias": "Username-Password Authentication",
             "description": "",
             "providerId": "basic-flow",
             "topLevel": false,

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -130,25 +130,15 @@ tasks:
     description: "Clone UDS Core for integration testing"
     actions:
       - cmd: rm -rf uds-core
-      - cmd: git clone --branch main https://github.com/defenseunicorns/uds-core.git
+      # Temporarily pinned to the realm-upgrade-kcc-poc branch which carries
+      # the chart edits for realmImport/realmSync. Revert to main once the
+      # branch is merged upstream.
+      - cmd: git clone --branch realm-upgrade-kcc-poc https://github.com/defenseunicorns/uds-core.git
 
   - name: build-deploy-custom-slim
     description: "Build/Deploy custom slim dev bundle for integration testing"
     actions:
-      - description: "Replace dev versions in the dev bundle with the VERSION variable"
-        cmd: |
-          VERSION=$(uds zarf tools yq eval '.metadata.version' uds-core/bundles/k3d-standard/uds-bundle.yaml)
-          for original_file in "bundles/external-loadbalancer/uds-bundle.template.yaml" "bundles/k3d-core-slim-dev/uds-bundle.template.yaml" "bundles/theme-customizations/uds-bundle.template.yaml"
-          do
-            processed_file="${original_file%.template.yaml}.yaml"
-            cp "$original_file" "$processed_file"
-            echo "Processing bundle versions in file $original_file"
-            uds zarf tools yq eval --inplace ".packages[] |= (select(.path == \"../../uds-core/build/\").ref = \"${VERSION}\")" "$processed_file"
-          done
-          echo "Processing complete"
-      - cmd: uds zarf package create . --confirm --set=IDENTITY_CONFIG_IMG=uds-core-config:keycloak --no-progress
-      - cmd: cd uds-core && mkdir -p build && uds run create:single-layer && uds run create:single-layer-callable --set LAYER=identity-authorization && uds run create:single-layer-callable --set LAYER=monitoring
-      - cmd: uds create bundles/k3d-core-slim-dev --confirm --no-progress
+      - task: build-slim-dev-bundle
       - cmd: uds deploy bundles/k3d-core-slim-dev/uds-bundle-k3d-core-slim-dev-*.tar.zst --set=core-identity-authorization.KEYCLOAK_CONFIG_IMAGE=uds-core-config:keycloak --confirm --no-progress
       - task: create-users
 
@@ -272,3 +262,131 @@ tasks:
         cmd: git clone https://github.com/defenseunicorns/uds-docs.git uds-docs
       - description: "UDS Docs Integration Script"
         cmd: cd uds-docs && npm i && DOCS_OVERRIDES="uds-identity-config=$(pwd)/.." npm run build
+
+
+  - name: snapshot-uds-realm
+    description: "Port-forward Keycloak and dump the uds realm via partial-export (the same shape Keycloak --import-realm consumes). No field stripping; the caller filters volatile fields as needed."
+    inputs:
+      output:
+        description: "Path to write the snapshot JSON (relative to repo root)"
+        default: "./tmp/uds-realm-snapshot.json"
+    actions:
+      - cmd: |
+          set -euo pipefail
+          OUT='${{ .inputs.output }}'
+          mkdir -p "$(dirname "$OUT")"
+
+          pkill -f "kubectl.*port-forward.*keycloak-http.*8080:8080" 2>/dev/null || true
+          kubectl -n keycloak port-forward svc/keycloak-http 8080:8080 >./tmp/test-pf.log 2>&1 &
+          PF=$!
+          trap 'kill $PF 2>/dev/null || true' EXIT
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            curl -sf http://localhost:8080/realms/master/.well-known/openid-configuration >/dev/null && break
+            sleep 1
+          done
+
+          KC_USER=$(kubectl get secret -n keycloak keycloak-admin-password -o jsonpath='{.data.username}' | base64 -d)
+          KC_PASS=$(kubectl get secret -n keycloak keycloak-admin-password -o jsonpath='{.data.password}' | base64 -d)
+          TOKEN=$(curl -s -d "client_id=admin-cli" -d "username=$KC_USER" -d "password=$KC_PASS" -d "grant_type=password" http://localhost:8080/realms/master/protocol/openid-connect/token | jq -r .access_token)
+
+          # partial-export = the same realm representation --import-realm consumes.
+          # exportClients + exportGroupsAndRoles flags get clients, scopes, IdPs,
+          # auth flows, groups, and roles included inline.
+          curl -sf -X POST -H "Authorization: Bearer $TOKEN" \
+            'http://localhost:8080/admin/realms/uds/partial-export?exportClients=true&exportGroupsAndRoles=true' \
+            | jq . > "$OUT"
+          echo "snapshot written to: $OUT ($(wc -c <"$OUT") bytes)"
+
+  - name: build-slim-dev-bundle
+    description: "Render templates + build packages + create the slim-dev bundle (no deploy)"
+    actions:
+      - description: "Replace dev versions in the dev bundle with the VERSION variable"
+        cmd: |
+          VERSION=$(uds zarf tools yq eval '.metadata.version' uds-core/bundles/k3d-standard/uds-bundle.yaml)
+          for original_file in "bundles/external-loadbalancer/uds-bundle.template.yaml" "bundles/k3d-core-slim-dev/uds-bundle.template.yaml" "bundles/theme-customizations/uds-bundle.template.yaml"
+          do
+            processed_file="${original_file%.template.yaml}.yaml"
+            cp "$original_file" "$processed_file"
+            uds zarf tools yq eval --inplace ".packages[] |= (select(.path == \"../../uds-core/build/\").ref = \"${VERSION}\")" "$processed_file"
+          done
+      - cmd: uds zarf package create . --confirm --set=IDENTITY_CONFIG_IMG=uds-core-config:keycloak --no-progress
+      - cmd: cd uds-core && mkdir -p build && uds run create:single-layer && uds run create:single-layer-callable --set LAYER=identity-authorization && uds run create:single-layer-callable --set LAYER=monitoring
+      - cmd: uds create bundles/k3d-core-slim-dev --confirm --no-progress
+
+  - name: test-realm-import-then-sync
+    description: "E2E: deploy with realm import only, snapshot, enable realm sync, redeploy without cluster wipe, verify realm is identical"
+    actions:
+      - task: dev-build
+      - task: clone-core
+      - task: uds-core-gateway-cacert
+      - task: build-slim-dev-bundle
+
+      - description: "Phase 1 deploy — realmImport=true (default), realmSync=false"
+        cmd: |
+          uds deploy bundles/k3d-core-slim-dev/uds-bundle-k3d-core-slim-dev-*.tar.zst \
+            --set=core-identity-authorization.KEYCLOAK_CONFIG_IMAGE=uds-core-config:keycloak \
+            --set=core-identity-authorization.REALM_SYNC_ENABLED=false \
+            --confirm --no-progress
+      - task: create-users
+
+      - description: "Snapshot realm BEFORE realm sync"
+        task: snapshot-uds-realm
+        with:
+          output: ./tmp/test-realm-before.json
+
+      - description: "Phase 2 deploy — keep cluster, redeploy core-identity-authorization with realmSync=true"
+        cmd: |
+          uds deploy bundles/k3d-core-slim-dev/uds-bundle-k3d-core-slim-dev-*.tar.zst \
+            -p core-identity-authorization \
+            --set=core-identity-authorization.KEYCLOAK_CONFIG_IMAGE=uds-core-config:keycloak \
+            --set=core-identity-authorization.REALM_SYNC_ENABLED=true \
+            --confirm --no-progress
+
+      - description: "Wait for realm-sync Job to complete"
+        cmd: |
+          kubectl wait -n keycloak --for=condition=complete job -l app.kubernetes.io/component=realm-sync --timeout=180s
+
+      - description: "Snapshot realm AFTER realm sync"
+        task: snapshot-uds-realm
+        with:
+          output: ./tmp/test-realm-after.json
+
+      - description: "Diff before/after — kcc must ADOPT, not recreate"
+        cmd: |
+          # The only legitimate addition between phase 1 and phase 2 is kcc's
+          # own ownership bookkeeping: de.adorsys.keycloak.config.* realm
+          # attributes. Everything else (UUIDs, secrets, timestamps, every
+          # other field) MUST match — if not, kcc destroyed and recreated
+          # something instead of adopting it, and the test should fail.
+          STRIP='if .attributes then .attributes |= with_entries(select(.key | startswith("de.adorsys.keycloak.config") | not)) else . end'
+          jq "$STRIP" ./tmp/test-realm-before.json > ./tmp/test-realm-before.filtered.json
+          jq "$STRIP" ./tmp/test-realm-after.json  > ./tmp/test-realm-after.filtered.json
+          diff ./tmp/test-realm-before.filtered.json ./tmp/test-realm-after.filtered.json > ./tmp/test-realm-diff.out || true
+          echo "filtered snapshots: ./tmp/test-realm-before.filtered.json ./tmp/test-realm-after.filtered.json"
+          echo "diff output:        ./tmp/test-realm-diff.out"
+          if [ -s ./tmp/test-realm-diff.out ]; then
+            echo "FAIL: realm diff contains unexpected changes (kcc may be recreating instead of adopting):"
+            cat ./tmp/test-realm-diff.out
+            exit 1
+          fi
+          echo "PASS: realm bit-identical pre/post realm sync (kcc adopted cleanly)"
+
+      - task: cypress-tests
+
+  - name: test-realm-sync-only
+    description: "E2E: deploy with realm import disabled — kcc creates and reconciles the realm by itself"
+    actions:
+      - task: dev-build
+      - task: clone-core
+      - task: uds-core-gateway-cacert
+      - task: build-slim-dev-bundle
+
+      - description: "Deploy — realmImport=false, realmSync=true"
+        cmd: |
+          uds deploy bundles/k3d-core-slim-dev/uds-bundle-k3d-core-slim-dev-*.tar.zst \
+            --set=core-identity-authorization.KEYCLOAK_CONFIG_IMAGE=uds-core-config:keycloak \
+            --set=core-identity-authorization.REALM_IMPORT_ENABLED=false \
+            --set=core-identity-authorization.REALM_SYNC_ENABLED=true \
+            --confirm --no-progress
+
+      - task: cypress-tests


### PR DESCRIPTION
## POC Summary

### What This Is

This is a working proof-of-concept that deploys `keycloak-config-cli` (kcc) as a Helm post-install/post-upgrade job inside UDS Core. This allows the Keycloak realm baseline to be reconciled with every upgrade, rather than just being imported once during the initial installation. It implements the direction proposed in the Keycloak Baseline/Realm Solution Narrative.

### What's Wired

* **identity-config image**: Now includes both `sync.sh` (the init container, unchanged) and the `kcc` jar located at `/opt/kcc/keycloak-config-cli.jar`. The job overrides the command to run `kcc`.
* **Curated realm baseline** (`src/realm-kcc.json`): Derived from `realm.json5`, this kcc-compatible syntax is stripped down to include only UDS-essential resources. The derivation is documented in `findings.md`.
* **uds-core chart** (sister branch `realm-upgrade-kcc-poc`): Adds two independent Helm values:
  * `realmImport.enabled`: Controls Keycloak's `--import-realm` boot flag (current behavior, default is on).
  * `realmSync.enabled`: Deploys the `kcc` job (off by default, opt-in).
* **Bundle vars**: `REALM_IMPORT_ENABLED` and `REALM_SYNC_ENABLED` are exposed in `slim-dev`, allowing tests to toggle modes via `--set`.

### How to Test It

* **E2E: Import-only deploy** → Enable sync, redeploy → Compare realm pre/post:
  ```
  uds run test-realm-import-then-sync
  ```

* **E2E: Realm import disabled**: `kcc` creates and reconciles the realm itself:
  ```
  uds run test-realm-sync-only
  ```

Both tasks run Cypress at the end. Each task spins up a fresh `slim-dev` cluster, deploys, reconciles, and asserts.

### Known Caveats (TDD Scope)

* Authentication uses `insecureAdminPasswordGeneration` for the proof-of-concept. The production authentication path is to be determined.
* One upstream `kcc` bug has been filed: `adorsys/keycloak-config-cli#1539` (sub-flow priorities reset to 0). This is functionally benign for our realm, resulting in a cosmetic difference in test 1.
* The `clone-core` task is pinned to the `realm-upgrade-kcc-poc` branch of `uds-core`. Revert to main after the chart PR merges.
* `src/realm-kcc.json` is currently a hand-rebuilt artifact. Long-term, we plan to generate it as part of the Docker build to ensure the source of truth remains `realm.json5`.