### PR TITLE
fix(ci): e2e tests breaking because of envoyfilter hanging on grafana

### DIFF
--- a/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
+++ b/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
@@ -40,18 +40,6 @@ packages:
             - name: TENANT_TLS_CACERT
               description: "The CA cert for the tenant gateway (must be base64 encoded)"
               path: tls.cacert
-      istio-controlplane:
-        uds-global-istio-config:
-          values:
-            - path: classificationBanner.text
-              value: "UNCLASSIFIED" # Possible values: UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET, TOP SECRET//SCI, UNKNOWN
-            - path: classificationBanner.addFooter
-              value: true
-            - path: classificationBanner.enabledHosts
-              value:
-                - keycloak.admin.{{ .Values.domain }}
-                - sso.{{ .Values.domain }}
-                - grafana.admin.{{ .Values.domain }}
   - name: core-identity-authorization
     path: ../../uds-core/build/
     # This version will get automatically updated by build-deploy-custom-slim task
@@ -88,8 +76,6 @@ packages:
               value:
                 name: JAVA_OPTS_KC_HEAP
                 value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
-            - path: fips
-              value: true
   - name: core-monitoring
     path: ../../uds-core/build/
     # This version will get automatically updated by build-deploy-custom-slim task


### PR DESCRIPTION
## Description

Our UDS Core envoy filter for classification banner is breaking on Grafana.  We set this feature on for the slim-dev bundle but we don't test it in this repo.  Removing this from here since we should test this UDS Core instead.

Create issue to address this in core and test there instead: https://linear.app/defense-unicorns/issue/CORE-590/classification-banner-envoyfilter-hangs-on-streamedspa-responses-eg

Additionally removed the fips field from the bundle as that no longer is a supported value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed