### PR TITLE
test: use Keycloak PR image

### DIFF
--- a/bundles/external-loadbalancer/uds-bundle.template.yaml
+++ b/bundles/external-loadbalancer/uds-bundle.template.yaml
@@ -42,6 +42,10 @@ packages:
               description: "The keycloak config image to deploy plugin and initial setup configuration"
               path: configImage
           values:
+            - path: image.repository
+              value: quay.io/sebastian_laskawiec/keycloak
+            - path: image.tag
+              value: bcfks-pr-70909865568b
             - path: realmInitEnv
               value:
                 X509_OCSP_FAIL_OPEN: "true"

--- a/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
+++ b/bundles/k3d-core-slim-dev/uds-bundle.template.yaml
@@ -60,6 +60,10 @@ packages:
               description: "The keycloak config image to deploy plugin and initial setup configuration"
               path: configImage
           values:
+            - path: image.repository
+              value: quay.io/sebastian_laskawiec/keycloak
+            - path: image.tag
+              value: bcfks-pr-70909865568b
             - path: realmInitEnv
               value:
                 GOOGLE_IDP_ENABLED: true

--- a/bundles/theme-customizations/uds-bundle.template.yaml
+++ b/bundles/theme-customizations/uds-bundle.template.yaml
@@ -19,6 +19,10 @@ packages:
               description: "The keycloak config image to deploy plugin and initial setup configuration"
               path: configImage
           values:
+            - path: image.repository
+              value: quay.io/sebastian_laskawiec/keycloak
+            - path: image.tag
+              value: bcfks-pr-70909865568b
             - path: themeCustomizations
               value:
                 enableAccessRequestNotes: true

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -17,6 +17,10 @@ variables:
     description: "The repository + name for the published image"
     default: "ghcr.io/defenseunicorns/uds/identity-config"
 
+  - name: KEYCLOAK_PR_IMAGE
+    description: "Temporary Keycloak PR image used by the BCFKS proof bundles"
+    default: "quay.io/sebastian_laskawiec/keycloak:bcfks-pr-70909865568b"
+
 tasks:
   - name: build-and-publish
     description: "Build and publish the multi-arch image"
@@ -138,6 +142,9 @@ tasks:
       - description: "Replace dev versions in the dev bundle with the VERSION variable"
         cmd: |
           VERSION=$(uds zarf tools yq eval '.metadata.version' uds-core/bundles/k3d-standard/uds-bundle.yaml)
+          uds zarf tools yq eval --inplace \
+            '(.components[] | select(.name == "keycloak") | .images) += ["'"${KEYCLOAK_PR_IMAGE}"'"]' \
+            uds-core/src/keycloak/zarf.yaml
           for original_file in "bundles/external-loadbalancer/uds-bundle.template.yaml" "bundles/k3d-core-slim-dev/uds-bundle.template.yaml" "bundles/theme-customizations/uds-bundle.template.yaml"
           do
             processed_file="${original_file%.template.yaml}.yaml"


### PR DESCRIPTION
## Summary

Image-only proof PR to run UDS Identity Config CI against a Keycloak build from the BCFKS PR.

See https://github.com/keycloak/keycloak/pull/50149